### PR TITLE
Updated unbind command to reflect 5

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/unbind.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/unbind.adoc
@@ -41,31 +41,11 @@ The Neo4j server process must be shut down before running the `neo4j-admin unbin
 
 You can use the `neo4j-admin unbind` command to:
 
-* Turn a cluster member into a standalone server:
-+
-To start the Neo4j server in single (standalone) mode after unbinding it from the cluster, first set <<config_server.cluster.initial_mode_constraint, `server.cluster.initial_mode_constraint=SINGLE`>> in _xref:configuration/file-locations.adoc[neo4j.conf]_.
+* Remove the cluster state of a server. This means that once restarted this server will rejoin the cluster as a new server and will have to be enabled using ENABLE SERVER command.
 
-* Seed a Neo4j cluster with existing store files:
-+
-To seed a new cluster using the store files of another cluster, you must first run `neo4j-admin unbind` on each server.
-For more information about seeding a Neo4j cluster, see xref:clustering/databases.adoc#cluster-seed[Seed a cluster].
-+
 [WARNING]
 ====
-If a cluster holds a previous version of any of the databases being seeded, you must `DROP` those databases before seeding.
-Alternatively, you can stop every instance, unbind them from the cluster using xref:tools/neo4j-admin/unbind.adoc[neo4j-admin unbind] and then forcefully restore the correct seeds (backups) for the databases in question.
-If you do not `DROP` or `unbind` before seeding, either with `neo4j-admin database restore` or `neo4j-admin database load`, the database's store files and cluster state will be out of sync, potentially leading to logical corruptions.
-====
-
-* Recover a Neo4j Cluster:
-+
-In the event of serious failures you may need to recover an entire cluster from backups.
-Before restoring those backups, you must first run `neo4j-admin unbind` on each server.
-For more information about recovering databases from online backups, see xref:backup-restore/restore-backup.adoc[Restore a database backup].
-+
-[NOTE]
-====
-You *must* run the `neo4j-admin unbind` command on both primary and secondary servers.
+If you unbind a server, then all of the database stores on that server will be preserved. Once this server is restated and enabled it will be seen as an entirely new server and therefore there is no guarantee that the allocator will pick this server to host the same databases. This may lead to having orphaned database stores on this server.
 ====
 
 [[unbind-command-archive]]


### PR DESCRIPTION
Unbind command can't be used for the same purpose in autonomous clusters. Logically the command works the same but I have changed the examples because they do not work anymore