### PR TITLE
Adding recommendation about password length anticipating new feature

### DIFF
--- a/modules/ROOT/pages/configuration/set-initial-password.adoc
+++ b/modules/ROOT/pages/configuration/set-initial-password.adoc
@@ -7,8 +7,7 @@ This must be performed before starting up the database for the first time.
 
 [NOTE]
 ====
-The default minimum password length is 8 characters.
-Use the `dbms.security.auth_minimum_password_length` configuration to change it.
+It is recommended that passwords have at least 8 characters.
 ====
 
 *Syntax:*


### PR DESCRIPTION
The new feature for changing minimum length of the password is coming up only in 5.3, but we can already prepare users for that now.
Related to https://github.com/neo-technology/neo4j/pull/17116