### PR TITLE
Minor fixes to SSL page (#118)

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -232,7 +232,7 @@ The SSL policies are configured by assigning values to parameters of the followi
 | Setting suffix         | Description                                                                            | Default value
 3+^.^| *Basic*
 | `enabled`              | Setting this to `true` enables this policy.                                        | `false`
-| `base_directory`       | The base directory under which <term-ssl-cryptographic-objects, cryptographic objects>> are searched for by default.      | `certificates/<scope>`
+| `base_directory`       | The base directory under which <<term-ssl-cryptographic-objects, cryptographic objects>> are searched for by default.      | `certificates/<scope>`
 | `private_key`          | The private key used for authenticating and securing this instance.                    | `private.key`
 | `private_key_password` | The passphrase to decode the private key.
                            Only applicable for encrypted private keys.                                            |
@@ -245,7 +245,7 @@ The SSL policies are configured by assigning values to parameters of the followi
                            address it uses against the certificate Common Name (CN) and Subject Alternative
                            Names (SAN) fields.
                            If the address does not match those fields, the client disconnects.            | `false`
-| `ciphers`              | A comma-separated list of ciphers suits allowed during cipher negotiation.
+| `ciphers`              | A comma-separated list of ciphers suites allowed during cipher negotiation.
                            Valid values depend on the current JRE and SSL provider.
                            For Ciphers supported by the Oracle JRE, see the link:https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#jsse-cipher-suite-names[Oracle official documentation].
 | Java platform default allowed cipher suites.
@@ -1004,7 +1004,7 @@ For more information, see xref:configuration/neo4j-conf.adoc#neo4j-conf-expand-c
 ==== Using specific cipher
 
 There are cases where Neo4j Enterprise requires the use of specific ciphers for encryptions.
-One can set up a Neo4j configuration by specifying the list of cipher suits that will be allowed during cipher negotiation.
+One can set up a Neo4j configuration by specifying the list of cipher suites that will be allowed during cipher negotiation.
 Valid values depend on the current JRE and SSL provider.
 For Oracle JRE here is the list of supported ones - https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#jsse-cipher-suite-names.
 


### PR DESCRIPTION
* The section in the `base_directory` has a link that doesn't render.
* Typo of 'suites'.