### PR TITLE
Remove use of 'servers' when describing initial database counts

### DIFF
--- a/modules/ROOT/pages/clustering/setup/deploy.adoc
+++ b/modules/ROOT/pages/clustering/setup/deploy.adoc
@@ -3,7 +3,7 @@
 [[clustering-deploy]]
 = Deploy a basic cluster
 
-The first step in setting up a cluster infrastructure is configuring a number of servers to form a cluster that you can run your databases on.
+The first step in setting up a cluster infrastructure is configuring a number of servers to form a cluster that you can host your databases on.
 The following configuration settings are important to consider when deploying a new cluster.
 //Remember to update the settings and link below.
 See also xref:clustering/settings.adoc[Settings reference] for more detailed descriptions and examples.


### PR DESCRIPTION
The configuration page uses 'instances', and 'servers' is misleading