### PR TITLE
Updating the name of `dbms.databases.writable`

### DIFF
--- a/modules/ROOT/pages/configuration/dynamic-settings.adoc
+++ b/modules/ROOT/pages/configuration/dynamic-settings.adoc
@@ -563,7 +563,7 @@ m|++++++
 [cols="<1s,<4"]
 |===
 |Description
-a|Formerly `dbms.databases.writable`. List of databases for which to allow write queries. Databases not included in this list will allow write queries anyway, unless xref:reference/configuration-settings.adoc#config_server.databases.default_to_read_only[server.databases.default_to_read_only] is set to true. +
+a|Formerly `dbms.databases.writable`. List of databases for which to allow write queries. Databases not included in this list will allow write queries anyway, unless xref:reference/configuration-settings.adoc#config_server.databases.default_to_read_only[server.databases.default_to_read_only] is set to true.
 |Valid values
 a|server.databases.writable, a ',' separated set with elements of type 'A valid database name containing only alphabetic characters, numbers, dots and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name 'system''.
 |Dynamic a|true


### PR DESCRIPTION
As of 5.x, this has been changed to `server.databases.writable`.
On Manual Modeling: https://github.com/neo-technology/neo4j-manual-modeling/pull/3361