### PR TITLE
Note about Let's Encrypt

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -83,7 +83,7 @@ All certificates must follow the xref:security/ssl-framework.adoc#term-ssl-x509[
 
 [TIP]
 ====
-Open tools such as Let's Encrypt allows the generation of valid signed certificates without the need to issue them from a CA.
+Open tools such as Let's Encrypt allow the automatic generation of browser-trusted certificates.
 ====
 
 .Example public.crt file


### PR DESCRIPTION
The request was to incorporate a Medium post about getting certificates with Let's Encrypt, but since we do not document third party tools in product documentation, one way to solve this was to actually leave a note mentioning the open tool (Let's Encrypt) as a suggestion.