### PR TITLE
Updating the name of `dbms.databases.writable` (#163)

### DIFF
--- a/modules/ROOT/pages/configuration/dynamic-settings.adoc
+++ b/modules/ROOT/pages/configuration/dynamic-settings.adoc
@@ -143,7 +143,7 @@ CALL dbms.setConfigValue('db.logs.query.enabled', '')
 |xref:reference/configuration-settings.adoc#config_dbms.cypher.render_plan_description[dbms.cypher.render_plan_description]|If set to `true` a textual representation of the plan description will be rendered on the server for all queries running with `EXPLAIN` or `PROFILE`.
 |xref:reference/configuration-settings.adoc#config_server.databases.default_to_read_only[server.databases.default_to_read_only]|Whether or not any database on this instance are read_only by default.
 |xref:reference/configuration-settings.adoc#config_server.databases.read_only[server.databases.read_only]|List of databases for which to prevent write queries.
-|xref:configuration/dynamic-settings.adoc#config_dbms.databases.writable[dbms.databases.writable]|List of databases for which to allow write queries.
+|xref:configuration/dynamic-settings.adoc#config_server.databases.writable[server.databases.writable]|List of databases for which to allow write queries.
 |xref:reference/configuration-settings.adoc#config_dbms.memory.transaction.total.max[dbms.memory.transaction.total.max]|Limit the amount of memory that all of the running transactions can consume, in bytes (or kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').
 |xref:reference/configuration-settings.adoc#config_dbms.routing.client_side.enforce_for_domains[dbms.routing.client_side.enforce_for_domains]|Always use client side routing (regardless of the default router) for neo4j:// protocol connections to these domains.
 |xref:reference/configuration-settings.adoc#config_dbms.routing.reads_on_writers_enabled[dbms.routing.reads_on_writers_enabled]|Configure if the `dbms.routing.getRoutingTable()` procedure should include the leader as read endpoint or return only read replicas/followers.
@@ -537,7 +537,7 @@ m|+++false+++
 [cols="<1s,<4"]
 |===
 |Description
-a|Whether or not any database on this instance are read_only by default. If false, individual databases may be marked as read_only using dbms.database.read_only. If true, individual databases may be marked as writable using xref:configuration/dynamic-settings.adoc#config_dbms.databases.writable[dbms.databases.writable].
+a|Whether or not any database on this instance are read_only by default. If false, individual databases may be marked as read_only using dbms.database.read_only. If true, individual databases may be marked as writable using xref:configuration/dynamic-settings.adoc#config_server.databases.writable[server.databases.writable].
 |Valid values
 a|server.databases.default_to_read_only, a boolean
 |Dynamic a|true
@@ -558,14 +558,14 @@ a|server.databases.read_only, a ',' separated set with elements of type 'A valid
 m|++++++
 |===
 
-[[config_dbms.databases.writable]]
-.dbms.databases.writable
+[[config_server.databases.writable]]
+.server.databases.writable
 [cols="<1s,<4"]
 |===
 |Description
-a|List of databases for which to allow write queries. Databases not included in this list will allow write queries anyway, unless xref:reference/configuration-settings.adoc#config_server.databases.default_to_read_only[server.databases.default_to_read_only] is set to true.
+a|Formerly `dbms.databases.writable`. List of databases for which to allow write queries. Databases not included in this list will allow write queries anyway, unless xref:reference/configuration-settings.adoc#config_server.databases.default_to_read_only[server.databases.default_to_read_only] is set to true.
 |Valid values
-a|dbms.databases.writable, a ',' separated set with elements of type 'A valid database name containing only alphabetic characters, numbers, dots and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name 'system''.
+a|server.databases.writable, a ',' separated set with elements of type 'A valid database name containing only alphabetic characters, numbers, dots and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name 'system''.
 |Dynamic a|true
 |Default value
 m|++++++


### PR DESCRIPTION
As of 5.x, this has been changed to `server.databases.writable`.

https://github.com/neo4j/docs-operations/pull/163 