### PR TITLE
Updating the table with missing cluster-related procedures

### DIFF
--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -217,7 +217,7 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :
 // dbms.clientConfig()
 
 | xref:reference/procedures.adoc#procedure_dbms_cluster_checkConnectivity[`dbms.cluster.checkConnectivity()`]
-| label:yes[]
+| label:no[]
 | label:yes[]
 | label:admin-only[]
 
@@ -353,17 +353,17 @@ Replaced by: `SHOW DATABASES`.
 | 
 
 | xref:reference/procedures.adoc#procedure_dbms_setDatabaseAllocator[`dbms.setDatabaseAllocator()`]
-| label:yes[]
+| label:no[]
 | label:yes[]
 | label:admin-only[]
 
 | xref:reference/procedures.adoc#procedure_dbms_setDefaultAllocationNumbers[`dbms.setDefaultAllocationNumbers()`]
-| label:yes[]
+| label:no[]
 | label:yes[]
 | label:admin-only[]
 
 | xref:reference/procedures.adoc#procedure_dbms_setDefaultDatabase[`dbms.setDefaultDatabase()`]
-| label:yes[]
+| label:no[]
 | label:yes[]
 | label:admin-only[]
 
@@ -513,7 +513,7 @@ Replaced by: `ALTER USER`.
 |
 
 | xref:reference/procedures.adoc#procedure_dbms_showTopologyGraphConfig[`dbms.showTopologyGraphConfig()`]
-| label:yes[]
+| label:no[]
 | label:yes[]
 | label:admin-only[]
 
@@ -1097,7 +1097,7 @@ m|DBMS
 |===
 
 [[procedure_dbms_cluster_checkConnectivity]]
-.dbms.cluster.checkConnectivity() label:admin-only[]
+.dbms.cluster.checkConnectivity() label:enterprise-edition[] label:admin-only[]
 [cols="<15s,<85"]
 |===
 | Description
@@ -1456,7 +1456,7 @@ m|DBMS
 |===
 
 [[procedure_dbms_quarantineDatabase]]
-.dbms.quarantineDatabase() label:admin-only[]
+.dbms.quarantineDatabase() label:enterprise-edition[] label:admin-only[]
 [cols="<15s,<85"]
 |===
 | Description
@@ -1506,7 +1506,7 @@ m|DBMS
 |===
 
 [[procedure_dbms_setDatabaseAllocator]]
-.dbms.setDatabaseAllocator() label:admin-only[]
+.dbms.setDatabaseAllocator() label:enterprise-edition[] label:admin-only[]
 [cols="<15s,<85"]
 |===
 | Description
@@ -1518,7 +1518,7 @@ a|WRITE
 |===
 
 [[procedure_dbms_setDefaultAllocationNumbers]]
-.dbms.setDefaultAllocationNumbers() label:admin-only[]
+.dbms.setDefaultAllocationNumbers() label:enterprise-edition[] label:admin-only[]
 [cols="<15s,<85"]
 |===
 | Description
@@ -1530,7 +1530,7 @@ a|WRITE
 |===
 
 [[procedure_dbms_setDefaultDatabase]]
-.dbms.setDefaultDatabase() label:admin-only[]
+.dbms.setDefaultDatabase() label:enterprise-edition[] label:admin-only[]
 [cols="<15s,<85"]
 |===
 | Description
@@ -1866,7 +1866,7 @@ m|DBMS
 |===
 
 [[procedure_dbms_showTopologyGraphConfig]]
-.dbms.showTopologyGraphConfig() label:admin-only[]
+.dbms.showTopologyGraphConfig() label:enterprise-only[] label:admin-only[]
 [cols="<15s,<85"]
 |===
 | Description


### PR DESCRIPTION
Please review if new procedures are enterprise-only or not, what are their signature, and if labels for admin-only are correct.