### PR TITLE
Note about Let's Encrypt (#164)

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -81,6 +81,11 @@ Using OpenSSL can significantly improve performance, especially for AES-GCM-cryp
 The SSL configuration requires SSL xref:security/ssl-framework.adoc#term-ssl-certificate[certificates] to be issued by a Certificate Authority (CA).
 All certificates must follow the xref:security/ssl-framework.adoc#term-ssl-x509[X.509] standard and be saved in a `PEM-encoded` file.
 
+[TIP]
+====
+Open tools such as Let's Encrypt allow the automatic generation of browser-trusted certificates.
+====
+
 .Example public.crt file
 [source, text]
 ----


### PR DESCRIPTION
The request was to incorporate a Medium post about getting certificates with Let's Encrypt, but since we do not document third party tools in product documentation, one way to solve this was to actually leave a note mentioning the open tool (Let's Encrypt) as a suggestion.

Original PR: https://github.com/neo4j/docs-operations/pull/164