### PR TITLE
Note about Let's Encrypt (#164)

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -86,6 +86,11 @@ If the same certificates are used across all instances of the cluster, make sure
 Multi-host and wildcard certificates are also supported.
 ====
 
+[TIP]
+====
+Open tools such as Let's Encrypt allow the automatic generation of browser-trusted certificates.
+====
+
 The instructions on this page assume that you have already obtained the required certificates from the CA.
 
 === Validate the key and the certificate


### PR DESCRIPTION
The request was to incorporate a Medium post about getting certificates with Let's Encrypt, but since we do not document third party tools in product documentation, one way to solve this was to actually leave a note mentioning the open tool (Let's Encrypt) as a suggestion.

Original PR: https://github.com/neo4j/docs-operations/pull/164