### PR TITLE
Note about Let's Encrypt (#164)

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -20,6 +20,11 @@ All certificates must be in the `PEM` format, and they can be combined into one 
 The private key is also required to be in the `PEM` format.
 Multi-host and wildcard certificates are supported.
 
+[TIP]
+====
+Open tools such as Let's Encrypt allow the automatic generation of browser-trusted certificates.
+====
+
 [[ssl-connectors]]
 == Connectors
 


### PR DESCRIPTION
The request was to incorporate a Medium post about getting certificates with Let's Encrypt, but since we do not document third party tools in product documentation, one way to solve this was to actually leave a note mentioning the open tool (Let's Encrypt) as a suggestion.

Original PR: https://github.com/neo4j/docs-operations/pull/164