### PR TITLE
Fixing broken link to fabric documentation

### DIFF
--- a/modules/ROOT/pages/manage-databases/remote-alias.adoc
+++ b/modules/ROOT/pages/manage-databases/remote-alias.adoc
@@ -41,7 +41,7 @@ If the administrators decide this should not be the case, then _Bob_ must define
 
 == Fabric vs remote alias database
 
-Here is a comparison between a link:https://neo4j.com/docs/operations-manual/4.4/fabric/[Fabric database] and a remote alias database, so you can make a more informed decision about which one to use:
+Here is a comparison between a xref:/composite-databases/index.adoc[Fabric database] and a remote alias database, so you can make a more informed decision about which one to use:
 
 [options="header",cols="<,<,<"]
 |===


### PR DESCRIPTION
Fabric documentation was deprecated in 5, so the link shouldn't point to current but to 4.4. 