### PR TITLE
Removing a duplicate "for" in settings description (#214)

### DIFF
--- a/modules/ROOT/pages/clustering/settings.adoc
+++ b/modules/ROOT/pages/clustering/settings.adoc
@@ -79,7 +79,7 @@ If this server is included in the `discovery.endpoints` of other cluster members
 | xref:reference/configuration-settings.adoc#config_server.cluster.raft.advertised_address[`server.cluster.raft.advertised_address`]
 | The address/port setting that specifies where the Neo4j server advertises to other members of the cluster that it listens for Raft messages within the cluster.
 
-**Example:** `server.cluster.raft.advertised_address=192.168.33.20:7000` listens for for cluster communication in the network interface bound to `192.168.33.20` on port `7000`.
+**Example:** `server.cluster.raft.advertised_address=192.168.33.20:7000` listens for cluster communication in the network interface bound to `192.168.33.20` on port `7000`.
 
 | xref:reference/configuration-settings.adoc#config_server.cluster.advertised_address[`server.cluster.advertised_address`]
 | The address/port setting that specifies where the instance advertises it listens for requests for transactions in the transaction-shipping catchup protocol.


### PR DESCRIPTION
Original PR https://github.com/neo4j/docs-operations/pull/214