### PR TITLE
Removing a duplicate "for" in settings description (#214)

### DIFF
--- a/modules/ROOT/pages/clustering/settings.adoc
+++ b/modules/ROOT/pages/clustering/settings.adoc
@@ -104,7 +104,7 @@ If this instance is included in the `initial_discovery_members` of other cluster
 | Core
 | The address/port setting that specifies where the Neo4j instance advertises to other members of the cluster that it listens for Raft messages within the Core cluster.
 
-**Example:** `causal_clustering.raft_advertised_address=192.168.33.20:7000` listens for for cluster communication in the network interface bound to `192.168.33.20` on port `7000`.
+**Example:** `causal_clustering.raft_advertised_address=192.168.33.20:7000` listens for cluster communication in the network interface bound to `192.168.33.20` on port `7000`.
 
 | xref:reference/configuration-settings.adoc#config_causal_clustering.transaction_advertised_address[`causal_clustering.transaction_advertised_address`]
 | All


### PR DESCRIPTION
Original PR https://github.com/neo4j/docs-operations/pull/214