### PR TITLE
Adding note to communicate that Fabric was deprecated in Neo4j 5

### DIFF
--- a/modules/ROOT/pages/fabric/introduction.adoc
+++ b/modules/ROOT/pages/fabric/introduction.adoc
@@ -9,8 +9,8 @@
 
 [NOTE]
 ====
-_Composite databases_ is introduced in Neo4j 5 as an implementation of the Fabric technology.
-As such, in Neo4j 5, Composite databases replaces what is known as Fabric in Neo4j 4.x.
+_Composite databases_ are introduced in Neo4j 5 as an implementation of the Fabric technology.
+As such, in Neo4j 5, Composite databases replace what is known as Fabric in Neo4j 4.x.
 For more information, see link:/docs/operations-manual/5/composite-databases/[Composite databases] in version 5 of the Neo4j Operations Manual.
 ====
 


### PR DESCRIPTION
And it is now replaced by composite databases.

Related PR https://github.com/neo4j/docs-operations/pull/235