### PR TITLE
Adding link for logging reference in memory configuration docs (#244)

### DIFF
--- a/modules/ROOT/pages/performance/memory-configuration.adoc
+++ b/modules/ROOT/pages/performance/memory-configuration.adoc
@@ -243,4 +243,4 @@ CALL dbms.listPools()
 SHOW TRANSACTIONS
 ----
 
-Or alternatively, you can monitor the memory usage of each query in the _query.log_.
+Or alternatively, you can monitor the memory usage of each query in the xref:monitoring/logging.adoc#query-logging[_query.log_].


### PR DESCRIPTION
As per request.

Cherry-pick of https://github.com/neo4j/docs-operations/pull/244