### PR TITLE
Adding link for logging reference in memory configuration docs (#244)

### DIFF
--- a/modules/ROOT/pages/performance/memory-configuration.adoc
+++ b/modules/ROOT/pages/performance/memory-configuration.adoc
@@ -244,7 +244,7 @@ CALL dbms.listTransactions()
 CALL dbms.listQueries()
 ----
 
-Or alternatively, you can enable `dbms.logs.query.allocation_logging_enabled` and monitor the memory usage of each query in the _query.log_.
+Or alternatively, you can enable `dbms.logs.query.allocation_logging_enabled` and monitor the memory usage of each query in the xref:monitoring/logging.adoc#query-logging[_query.log_].
 
 [NOTE]
 ====


### PR DESCRIPTION
As per request.

Cherry-pick of https://github.com/neo4j/docs-operations/pull/244