### PR TITLE
4.4 - adding info on how to log JWT claims

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
@@ -21,95 +21,120 @@ For example, if you are using Okta as your identity provider you might use `okta
 
 The following configuration settings are important to consider when configuring single sign-on.
 For a more detailed overview of the single sign-on configuration options, see xref:reference/configuration-settings.adoc[Configuration settings].
-These settings can also be updated while the database is running, see xref:configuration/dynamic-settings.adoc[Dynamic settings] for more information on how to do this.
+Some of these settings can also be updated while the database is running, see xref:configuration/dynamic-settings.adoc[Dynamic settings] for more information on how to do this.
 Altering any of these settings causes users to re-authenticate as their permissions may have changed as a result.
 
-[options="header",cols="<3,<1,<3"]
+[options="header",cols="<3,<1,<1,<3"]
 |===
 | Parameter name
 | Default value
+| Dynamic
 | Description
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.display_name[dbms.security.oidc.<provider>.display_name]
 |
+| false
 | The display name for the provider.
 This is displayed in clients such as Neo4j Browser and Bloom.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.auth_flow[dbms.security.oidc.<provider>.auth_flow]
 | pkce
+| true
 | The OIDC auth_flow for clients such as Neo4j Browser and Bloom to use.
 Supported values are `pkce` and `implicit`.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.well_known_discovery_uri[dbms.security.oidc.<provider>.well_known_discovery_uri]
 |
+| true
 | The OpenID Connect Discovery URL for the provider.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.auth_endpoint[dbms.security.oidc.<provider>.auth_endpoint]
 |
+| true
 | URL of the provider's Authorization Endpoint.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.auth_params[dbms.security.oidc.<provider>.auth_params]
 |
+| true
 | Optional parameters that clients may require with the Authorization Endpoint. The map is a semicolon-separated list of key-value pairs. For example: k1=v1;k2=v2.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.token_endpoint[dbms.security.oidc.<provider>.token_endpoint]
 |
+| true
 | URL of the provider's OAuth 2.0 Token Endpoint.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.token_params[dbms.security.oidc.<provider>.token_params]
 |
+| true
 | Option parameters that clients may require with the Token Endpoint. The map is a semicolon-separated list of key-value pairs. For example: k1=v1;k2=v2.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.jwks_uri[dbms.security.oidc.<provider>.jwks_uri]
 |
+| true
 | URL of the provider's JSON Web Key Set.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.user_info_uri[dbms.security.oidc.<provider>.user_info_uri]
 |
+| true
 | URL of the provider's UserInfo Endpoint.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.issuer[dbms.security.oidc.<provider>.issuer]
 |
+| true
 | URL that the provider asserts as its issuer identifier.
 This will be checked against the `iss` claim in the token.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.audience[dbms.security.oidc.<provider>.audience]
 |
+| true
 | The expected value for the `aud` claim.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.client_id[dbms.security.oidc.<provider>.client_id]
 |
+| true
 |  The `client_id` of this client as issued by the provider.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.params[dbms.security.oidc.<provider>.params]
 |
+| true
 |  Option parameters that clients may require. The map is a semicolon-separated list of key-value pairs. For example: k1=v1;k2=v2.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.config[dbms.security.oidc.<provider>.config]
 |
+| true
 |  Option additional configuration that clients may require. The map is a semicolon-separated list of key-value pairs. For example: k1=v1;k2=v2.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.get_groups_from_user_info[dbms.security.oidc.<provider>.get_groups_from_user_info]
 | false
+| true
 | Whether to fetch the groups claim from the user info endpoint on the identity provider.
 The default is `false`, to read the claim from the token.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.get_username_from_user_info[dbms.security.oidc.<provider>.get_username_from_user_info]
 | false
+| true
 | Whether to fetch the username claim from the user info endpoint on the identity provider.
 The default is `false`, to read the claim from the token.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.claims.username[dbms.security.oidc.<provider>.claims.username]
 | sub
+| true
 | The claim to use for the database username.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.claims.groups[dbms.security.oidc.<provider>.claims.groups]
 |
+| true
 | The claim to use for the database roles.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.authorization.group_to_role_mapping[dbms.security.oidc.<provider>.authorization.group_to_role_mapping]
 |
+| true
 | List an authorization mapping from groups to the pre-defined built-in roles `admin`, `architect`, `publisher`, `editor`, and `reader`, or to any custom-defined roles.
+
+| xref:reference/configuration-settings.adoc#config_dbms.security.logs.oidc.jwt_claims_at_debug_level_enabled[dbms.security.logs.oidc.jwt_claims_at_debug_level_enabled]
+| false
+| false
+| When set to `true`, will log the claims from the JWT into the security log (provided the security log level is also set to `DEBUG`).
 |===
 
 [[auth-sso-configure-sso]]
@@ -272,3 +297,13 @@ dbms.jvm.additional=-Djavax.net.ssl.keyStorePassword=mypasword
 dbms.jvm.additional=-Djavax.net.ssl.trustStore=/path/to/MyCert.jks
 dbms.jvm.additional=-Djavax.net.ssl.trustStorePassword=mypasword
 ----
+
+[[auth-sso-debug-jwt-claims]]
+== Debug logging of JWT claims
+
+Whilst setting up an OIDC integration, it is sometimes necessary to perform troubleshooting. In these cases it can be useful to view the claims contained in the JWT supplied by the identity provider. In order to enable the logging of these claims at `DEBUG` level in the security log, set <<config_dbms.security.logs.oidc.jwt_claims_at_debug_level_enabled, dbms.security.logs.oidc.jwt_claims_at_debug_level_enabled>> to be `true` and set the security log level to `DEBUG`.
+
+[WARNING]
+====
+* Make sure to set <<config_dbms.security.logs.oidc.jwt_claims_at_debug_level_enabled, dbms.security.logs.oidc.jwt_claims_at_debug_level_enabled>> back to `false` for production environments in order to avoid unwanted logging of potentially sensitive information. Also, it is important to bear in mind that the set of claims provided by an identity provider in the JWT can change over time.
+====

--- a/modules/ROOT/pages/tutorial/tutorial-sso-configuration.adoc
+++ b/modules/ROOT/pages/tutorial/tutorial-sso-configuration.adoc
@@ -290,9 +290,18 @@ It is generally safer to use access tokens when possible due to being shorter-li
 If authorization permissions change on the identity provider, Neo4j will fail authorization.
 Neo4j Browser will try to reconnect and reflect the changed permissions faster than if ID tokens were used.
 
+=== Debug logging of JWT claims
+
+Whilst setting up an OIDC integration, it is sometimes necessary to perform troubleshooting. In these cases it can be useful to view the claims contained in the JWT supplied by the identity provider. In order to enable the logging of these claims at `DEBUG` level in the security log, set <<config_dbms.security.logs.oidc.jwt_claims_at_debug_level_enabled, dbms.security.logs.oidc.jwt_claims_at_debug_level_enabled>> to be `true` and set the security log level to `DEBUG`.
+
+[WARNING]
+====
+* Make sure to set <<config_dbms.security.logs.oidc.jwt_claims_at_debug_level_enabled, dbms.security.logs.oidc.jwt_claims_at_debug_level_enabled>> back to `false` for production environments in order to avoid unwanted logging of potentially sensitive information. Also, it is important to bear in mind that the set of claims provided by an identity provider in the JWT can change over time.
+====
+
 === How to debug further problems with the configuration
 Apart from the logs available in _logs/debug.log_ and _logs/security.log_ in the Neo4j path, you can also use the web-development console in your web browser when doing the SSO authentication flow with Bloom or Neo4j Browser.
-However, this could reveal potential problems as the one presented below with an example identity provider and the Cross-Origin Request policy:
+This could reveal potential problems such as the one presented below with an example identity provider and the Cross-Origin Request policy:
 
 image::sso-configuration-tutorials/oidc-cors-error.png[title="CORS error"]
 


### PR DESCRIPTION
adding info on how to log JWT claims to the SSO tutorial, the SSO configuration descriptions, and the sso guide.