### PR TITLE
removed references to deprecated NEO4JLABS_PLUGINS feature name

### DIFF
--- a/modules/ROOT/pages/docker/operations.adoc
+++ b/modules/ROOT/pages/docker/operations.adoc
@@ -262,26 +262,26 @@ docker run \
    neo4j:{neo4j-version-exact}
 ----
 
-[[docker-neo4jlabs-plugins]]
-== Configure Neo4j Labs plugins
+[[docker-neo4j-plugins]]
+== Configure Neo4j plugins
 
 The Neo4j Docker image includes a startup script that can automatically download and configure certain Neo4j plugins at runtime.
 
 [NOTE]
 ====
-This feature is intended to facilitate using Neo4j Labs plugins in development environments, but it is not recommended for use in production environments.
+This feature is intended to facilitate using Neo4j plugins in development environments, but it is not recommended for use in production environments.
 
 To use plugins in production with Neo4j Docker containers, see xref:docker/operations.adoc#docker-procedures[Install user-defined procedures].
 ====
 
-The `NEO4JLABS_PLUGINS` environment variable can be used to specify the plugins to install using this method.
+The `NEO4J_PLUGINS` environment variable can be used to specify the plugins to install using this method.
 This should be set to a JSON-formatted list of supported plugins.
 
 For example, to install the APOC plugin (`apoc`), you can use the Docker argument;
 
 [source, argument, role=noheader]
 ----
---env NEO4JLABS_PLUGINS='["apoc"]'
+--env NEO4J_PLUGINS='["apoc"]'
 ----
 
 and run the following command:
@@ -292,7 +292,7 @@ docker run -it --rm \
   --publish=7474:7474 --publish=7687:7687 \
   --user="$(id -u):$(id -g)" \
   -e NEO4J_AUTH=none \
-  --env NEO4JLABS_PLUGINS='["apoc"]' \
+  --env NEO4J_PLUGINS='["apoc"]' \
   neo4j:{neo4j-version-exact}
 ----
 
@@ -300,10 +300,10 @@ For example, to install the APOC plugin (`apoc`) and the Neo Semantics plugin (`
 
 [source, argument, role=noheader]
 ----
---env NEO4JLABS_PLUGINS='["apoc", "n10s"]'
+--env NEO4J_PLUGINS='["apoc", "n10s"]'
 ----
 
-.Supported Neo4j Labs plugins
+.Supported Neo4j plugins
 [options="header",cols="d,m,a"]
 |===
 |Name |Key  |Further information


### PR DESCRIPTION
The docker image reports that the environment `NEO4JLABS_PLUGINS` is deprecated since 5.0.0 and renamed to `NEO4J_PLUGINS` now, but I forgot to update the documentation about it. 
Here is the documentation update.