### PR TITLE
Rename 'Bulk import tool' in line with the rest of the manual

### DIFF
--- a/modules/ROOT/pages/introduction.adoc
+++ b/modules/ROOT/pages/introduction.adoc
@@ -278,11 +278,11 @@ See the link:{download-center-drivers}[Neo4j Download Center - Drivers] for more
 | 34 billion nodes, 34 billion relationships, and 68 billion properties
 | No limit
 
-| Bulk import tool
+| Import command-line tool (`neo4j-admin import` command)
 | {check-mark}
 | {check-mark}
 
-| Bulk import tool, resumable
+| Import command-line tool (`neo4j-admin import` command), resumable
 | {cross-mark}
 | {check-mark}
 


### PR DESCRIPTION
We don't use the name _Bulk import tool_ for the command `neo4j-admin import`.
Notice! In v4.4 it's `neo4j-admin import`, not `neo4j-admin database import`.