### PR TITLE
Remove comparison between Remote aliases and Fabric (#298)

### DIFF
--- a/modules/ROOT/pages/manage-databases/remote-alias.adoc
+++ b/modules/ROOT/pages/manage-databases/remote-alias.adoc
@@ -39,34 +39,6 @@ _Carol_ can use her own regular credentials to access the remote database `Db1` 
 This configuration will also allow _Carol_ to access `Db2` in **DBMS B**.
 If the administrators decide this should not be the case, then _Bob_ must define the appropriate privileges (see link:https://neo4j.com/docs/cypher-manual/current/access-control/[Cypher manual -> Access control] for further information).
 
-== Fabric vs remote alias database
-
-Here is a comparison between a link:https://neo4j.com/docs/operations-manual/current/fabric/[Fabric database] and a remote alias database, so you can take a more informed decision about which one to use:
-
-[options="header",cols="<,<,<"]
-|===
-|
-| Fabric
-| Remote alias database
-
-| *Authentication*
-| Identical user credentials in both DBMSs.
-| Authenticates with defined user on remote DBMS for anyone using the alias.
-
-| *Credentials*
-| In memory.
-| Stored encrypted.
-
-| *Configuration*
-| Manually set per instance.
-| Secret key for encryption set per instance. +
-Created aliases are synchronized across cluster instances.
-
-| *Restarting when creating or altering endpoints*
-| Yes
-| No
-|===
-
 == Configuration of a remote DBMS (_Bob_)
 
 In the suggested example, there are two administrators: _Alice_ and _Bob_.


### PR DESCRIPTION
There is no longer a feature called Fabric so it shouldn't be mentioned in this way. The replacement, composite databases, is based on local and remote aliases, and so, a comparison is not needed.