### PR TITLE
Adding note to communicate that Fabric was deprecated in Neo4j 5 (#236)

### DIFF
--- a/modules/ROOT/pages/fabric/introduction.adoc
+++ b/modules/ROOT/pages/fabric/introduction.adoc
@@ -7,6 +7,13 @@
 [[fabric-overview]]
 == Overview
 
+[NOTE]
+====
+_Composite databases_ are introduced in Neo4j 5 as an implementation of the Fabric technology.
+As such, in Neo4j 5, Composite databases replace what is known as Fabric in Neo4j 4.x.
+For more information, see link:/docs/operations-manual/5/composite-databases/[Composite databases] in version 5 of the Neo4j Operations Manual.
+====
+
 Fabric, introduced in Neo4j 4.0, is a way to store and retrieve data in multiple databases, whether they are on the same Neo4j DBMS or in multiple DBMSs, using a single Cypher query.
 Fabric achieves a number of desirable objectives:
 


### PR DESCRIPTION
And it is now replaced by composite databases.

Related PR https://github.com/neo4j/docs-operations/pull/235

Co-authored-by: AlexicaWright <49636617+AlexicaWright@users.noreply.github.com>