### PR TITLE
To change the default value back to 7 days

### DIFF
--- a/modules/ROOT/pages/configuration/transaction-logs.adoc
+++ b/modules/ROOT/pages/configuration/transaction-logs.adoc
@@ -48,15 +48,10 @@ An overview of configuration settings for transaction logging:
 | Specify if Neo4j should try to preallocate logical log file in advance.
 
 | xref:reference/configuration-settings.adoc#config_dbms.tx_log.rotation.retention_policy[`dbms.tx_log.rotation.retention_policy`]
-<<<<<<< HEAD
-| `2 days`
-| Make Neo4j keep the logical transaction logs for being able to backup the database. Can be used for specifying the threshold to prune logical logs after.
-=======
 | `7 days`
 a|
 Make Neo4j keep the logical transaction logs for being able to backup the database.
 Can be used for specifying the threshold to prune logical logs after.
->>>>>>> 77ae1c0 (Change the value from 2 days back to 7 in v4.4 (#297))
 
 | xref:reference/configuration-settings.adoc#config_dbms.tx_log.rotation.size[`dbms.tx_log.rotation.size`]
 | `250M`


### PR DESCRIPTION
The default value for `dbms.tx_log.rotation.retention_policy` is 7 days in series 4.x
Should be cherry-picked to v4.3, 4.2, 4.1.
See the PR #297 