### PR TITLE
Change the value from 2 days back to 7 in v4.4 (#297)

### DIFF
--- a/modules/ROOT/pages/configuration/transaction-logs.adoc
+++ b/modules/ROOT/pages/configuration/transaction-logs.adoc
@@ -47,7 +47,7 @@ An overview of configuration settings for transaction logging:
 | Specify if Neo4j should try to preallocate logical log file in advance.
 
 | xref:reference/configuration-settings.adoc#config_dbms.tx_log.rotation.retention_policy[`dbms.tx_log.rotation.retention_policy`]
-| `2 days`
+| `7 days`
 a|
 Make Neo4j keep the logical transaction logs for being able to backup the database.
 Can be used for specifying the threshold to prune logical logs after.
@@ -90,7 +90,7 @@ Manually deleting transaction log files is not supported.
 ====
 
 You can control the number of transaction logs that Neo4j keeps using the parameter xref:reference/configuration-settings.adoc#config_dbms.tx_log.rotation.retention_policy[`dbms.tx_log.rotation.retention_policy`].
-It is set to `2 days` by default, which means Neo4j keeps logical logs that contain any transaction committed within 2 days.
+It is set to `7 days` by default, which means Neo4j keeps logical logs that contain any transaction committed within 7 days.
 The configuration is dynamic, so if you need to update it, you do not have to restart Neo4j for the change to take effect.
 
 Other possible values are:


### PR DESCRIPTION
The default value for `dbms.tx_log.rotation.retention_policy` is 7 days in v4.4, isn't it?
Should we cherry-pick it back to v4.3, 4.2, 4.1, 4.0? see the PR https://github.com/neo-technology/neo4j-manual-modeling/pull/3324