### PR TITLE
Update documentation to reflect changes to server groups  (#305)

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -98,6 +98,8 @@
 ** xref:clustering/disaster-recovery.adoc[]
 //** xref:clustering/internals.adoc[]
 ** xref:clustering/settings.adoc[]
+** xref:clustering/clustering-advanced/index.adoc[]
+*** xref:clustering/clustering-advanced/multi-data-center-routing.adoc[]
 ** xref:clustering/glossary.adoc[]
 
 * xref:backup-restore/index.adoc[]

--- a/modules/ROOT/images/pipeline-of-strategies.svg
+++ b/modules/ROOT/images/pipeline-of-strategies.svg
@@ -13,14 +13,14 @@
             <rect id="Rectangle-14" stroke="#DFDFDF" x="533.5" y="48.5" width="255" height="122"></rect>
             <text id="connect-randomly-to" font-family="CourierNewPSMT, Courier New" font-size="12" font-weight="normal" fill="#C9244E">
                 <tspan x="53.0859375" y="109">connect-randomly-to-</tspan>
-                <tspan x="96.2929688" y="123">server-group</tspan>
+                <tspan x="96.2929688" y="123">server-tags</tspan>
             </text>
             <text id="typically-connect-to" font-family="CourierNewPSMT, Courier New" font-size="12" font-weight="normal" fill="#C9244E">
                 <tspan x="298.933594" y="109">typically-connect-to-random-</tspan>
-                <tspan x="356.542969" y="123">read-replica</tspan>
+                <tspan x="356.542969" y="123">secondary</tspan>
             </text>
             <text id="connect-to-random-co" font-family="CourierNewPSMT, Courier New" font-size="12" font-weight="normal" fill="#C9244E">
-                <tspan x="556.583008" y="113">connect-to-random-core-server</tspan>
+                <tspan x="556.583008" y="113">connect-to-random-primary-server</tspan>
             </text>
             <path d="M76.5,219.5 L723.5,219.5" id="Line-13" stroke="#979797" stroke-width="3" stroke-linecap="square"></path>
             <polygon id="Triangle-6" fill="#979797" points="730.182408 219.435292 711.182408 228.435292 711.182408 210.435292"></polygon>

--- a/modules/ROOT/pages/clustering/clustering-advanced/index.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/index.adoc
@@ -1,0 +1,12 @@
+[role=enterprise-edition]
+[[clustering-advanced]]
+= Advanced Clustering
+:description: This appendix describes advanced features of a Neo4j Cluster. 
+
+This section includes information about advanced deployments of a Neo4j Cluster.
+
+* xref:clustering/clustering-advanced/multi-data-center-routing.adoc[Multi-data center routing] -- Information about routing in multi-data center deployments.
+
+For details on the configuration and operation of a Neo4j cluster, see xref:clustering/index.adoc[Clustering].
+
+For descriptions of settings related to running a Neo4j cluster, see xref:clustering/settings.adoc[Settings reference].

--- a/modules/ROOT/pages/clustering/clustering-advanced/multi-data-center-routing.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/multi-data-center-routing.adoc
@@ -1,0 +1,436 @@
+[role=enterprise-edition]
+[[multi-data-center-routing]]
+= Multi-data center routing
+:description: This section shows how to configure Neo4j servers so that they are topology/data center-aware. It describes the precise configuration needed to achieve a scalable multi-data center deployment. 
+
+This section describes the following:
+
+* <<mdc-introduction, Introduction>>
+* <<mdc-prerequisite-configuration, Prerequisite configuration>>
+** <<mdc-server-tags, Server tags>>
+** <<mdc-primaries-for-reading, Primaries for reading>>
+* <<mdc-load-balancing-framework, Load balancing>>
+** <<mdc-policy-definitions, Policy definitions>>
+** <<mdc-policy-names, Policy names>>
+** <<mdc-filters, Filters>>
+** <<mdc-dsl-example, Load balancing examples>>
+* <<mdc-strategy-plugins, Strategy plugins>>
+** <<mdc-programmatically-specify-rules, Configuring upstream selection using pre-defined catchup strategies>>
+** <<mdc-configuration-user-defined-strategy, Configuring user-defined catchup strategies>>
+// ** <<mdc-build-your-own-strategy-plugin, Building upstream strategy plugins using Java>>
+** <<#mdc-favoring-data-centers, Favoring data centers>>
+
+[[mdc-introduction]]
+== Introduction
+
+When deploying a multi-data center cluster it is often desirable to take advantage of locality to reduce latency and improve performance.
+For example, it is preferrable that graph-intensive workloads are executed in the local data center at LAN latencies rather than in a faraway data center at WAN latencies. Neo4j's _load balancing_ and _catchup strategy plugins_ for multi-data center scenarios facilitates precisely this.
+
+Neo4j's load balancing is a cooperative system where the driver asks the cluster on a recurring basis where it should direct the different classes of its workload (e.g., writes and reads).
+This allows the driver to work independently for long stretches of time, yet check back from time to time to adapt to changes such as a new server having been added for increased capacity.
+There are also failure situations where the driver asks again immediately, when it cannot use any of its allocated servers for example.
+
+This is mostly transparent from the perspective of a client.
+On the server side, the load balancing behaviors are configured using a simple <<mdc-policy-definitions, Design Specific Language>>, _DSL_, and exposed under a named _load balancing policy_ which the driver can bind to.
+All server-side configuration is performed on the Primary servers.
+
+Catchup strategy plugins are sets of rules that define how secondary servers contact upstream servers in the cluster in order to synchronize transaction logs.
+Neo4j comes with a set of pre-defined strategies, and also user-defined strategies can be created using the same DSL.
+Finally, Neo4j supports an API which advanced users may use to enhance upstream recommendations.
+
+Once a catchup strategy plugin resolves a satisfactory upstream server, it is used for pulling transactions to update the local secondary for a single synchronization.
+For subsequent updates, the procedure is repeated so that the most preferred available upstream server is always resolved.
+
+[[mdc-prerequisite-configuration]]
+== Prerequisite configuration
+
+[[mdc-server-tags]]
+=== Server tags
+
+Both load balancing across multiple data centers and user-defined catchup strategies are predicated on the _Server Tag_ concept.
+
+In order to optimize the use of the cluster's servers according to the specific requirements, they are sorted using _Server Tags_.
+Server tags can map to data centers, availability zones, or any other significant topological elements from the operator's domain, e.g., `us`, `us-east`. 
+Applying the same tag to multiple servers logically groups them together.
+Note that servers can have mulitple tags.
+
+Server tags are defined as a key that maps onto a set of servers in a cluster.
+Server tags are defined on each server using the  `xref:reference/configuration-settings.adoc#config_initial.server.tags[initial.server.tags]` parameter in _neo4j.conf_. 
+Each server in a cluster can be tagged with to zero or more server tags.
+
+.Definition of grouping servers using server tags
+====
+
+Grouping servers using server tags is achieved in `neo4j.conf` as in the following examples:
+
+.Tag the current instance with `us` and `us-east`
+[source, properties]
+----
+initial.server.tags=us,us-east
+----
+
+.Tag the current instance with `london`
+[source, properties]
+----
+initial.server.tags=london
+----
+.Tag the current instance with `eu`
+[source, properties]
+----
+initial.server.tags=eu
+----
+
+Note that membership of a group implied by a server tag is explicit.
+For example, a server tagged with `gb-london` is not automatically part of the same tag group as a server that is tagged with `gb` or `eu` unless that server is also explicitly tagged with those tags.
+====
+
+[[mdc-primaries-for-reading]]
+=== Primaries for reading
+
+Depending on the deployment and the available number of servers in the cluster, different strategies make sense for whether or not the reading workload should be routed to the primary servers.
+The following configuration allows the routing of read workload to primary servers.
+Valid values are `true` and `false`.
+
+[source, properties]
+----
+dbms.routing.reads_on_primaries_enabled=true
+----
+
+
+[[mdc-load-balancing-framework]]
+== The load balancing framework
+
+There are different topology-aware load balancing options available for client applications in a multi-data center Neo4j deployment. 
+There are different ways to configure the load balancing for the cluster so that client applications can direct its workload at the most appropriate cluster members, such as those nearby. 
+
+The load balancing system is based on a plugin architecture for future extensibility and for allowing user customizations.
+The current version ships with exactly one such canned plugin called the _server policies_ plugin.
+
+The server policies plugin is selected by setting the following property:
+
+[source, properties]
+----
+dbms.routing.load_balancing.plugin=server_policies
+----
+
+Under the server policies plugin, a number of load balancing policies can be configured server-side and be exposed to drivers under unique names.
+The drivers, in turn, must on instantiation select an appropriate policy by specifying its name.
+Common patterns for naming policies are after geographical regions or intended application groups.
+
+[IMPORTANT]
+====
+It is crucial to define the exact same policies on all servers since this is to be regarded as cluster-wide configuration and failure to do so leads to unpredictable behavior.
+Similarly, policies in active use should not be removed or renamed since it breaks applications trying to use these policies.
+It is perfectly acceptable and expected however, that policies be modified under the same name.
+====
+
+If a driver asks for a policy name that is not available, then the driver is not able to use the cluster.
+A driver that does not specify any name at all gets the behavior of the default policy as configured.
+The default policy, if left unchanged, distributes the load across all servers.
+It is possible to change the default policy to any behavior that a named policy can have.
+
+A misconfigured driver or load balancing policy results in suboptimal routing choices and can even prevent successful interactions with the cluster entirely.
+
+[NOTE]
+====
+The details of how to write a custom plugin is not documented here.
+Please contact Neo4j Professional Services if you think that you need a custom plugin.
+====
+
+[NOTE]
+.Use load balancing from Neo4j drivers
+====
+Once enabled and configured, the custom load balancing feature is used by drivers to route traffic as intended.
+See the link:{neo4j-docs-base-uri}[Neo4j Driver manuals] for instructions on how to configure drivers to use custom load balancing.
+====
+
+
+[[mdc-policy-definitions]]
+=== Policy definitions
+
+The configuration of load balancing policies is transparent to client applications and expressed via a simple DSL.
+The syntax consists of a set of rules which are considered in order.
+The first rule to produce a non-empty result is the final result.
+
+[source, properties]
+----
+rule1; rule2; rule3
+----
+
+Each rule in turn consists of a set of filters which limit the considered servers, starting with the complete set.
+Note that the evaluation of each rule starts fresh with the complete set of available servers.
+
+There is a fixed set of filters which composes a rule and they are chained together using arrows.
+
+[source, properties]
+----
+filter1 -> filter2 -> filter3
+----
+
+If there are any servers still left after the last filter then the rule evaluation has produced a result and this is returned to the driver.
+However, if there are no servers left then the next rule is considered.
+If no rule is able to produce a usable result then the driver is signalled a failure.
+
+
+[[mdc-policy-names]]
+=== Policy names
+
+The policies are configured under the namespace of the `server_policies` plugin and named as desired.
+Policy names can contain alphanumeric characters and underscores, and they are case sensitive.
+Below is the property key for a policy with the name `mypolicy`.
+
+`dbms.routing.load_balancing.config.server_policies.mypolicy=`
+
+The actual policy is defined in the value part using the DSL.
+
+The `default` policy name is reserved for the default policy.
+It is possible to configure this policy like any other and it is used by driver clients that do not specify a policy.
+
+Additionally, any number of policies can be created using unique policy names.
+The policy name can suggest a particular region or an application for which it is intended to be used.
+
+
+[[mdc-filters]]
+=== Filters
+
+There are four filters available for specifying rules, detailed below.
+The syntax is similar to a method call with parameters.
+
+* `tags(name1, name2, ...)`
+** Only servers that are tagged with any of the specified tags pass the filter.
+** The defined names must match those of the _server tags_.
+** Prior to 5.4 `tags()` were referred to as `groups()`, which continue to work but are now deprecated.
+* `min(count)`
+** Only the minimum amount of servers are allowed to pass (or none).
+** Allows overload conditions to be managed.
+* `all()`
+** No need to specify since it is implicit at the beginning of each rule.
+** Implicitly the last rule (override this behavior using halt).
+* `halt()`
+** Only makes sense as the last filter in the last rule.
+** Stops the processing of any more rules.
+
+The tags filter is essentially an OR-filter, e.g. `tags(A,B)` which passes any server in with either tag A, B or both (the union of the server tags).
+An AND-filter can also be created by chaining two filters as in `tags(A) \-> tags(B)`, which only passes servers with both tags (the intersect of the server tags).
+
+
+[[mdc-dsl-example]]
+== Load balancing examples
+
+The discussion on multi-data center clusters introduced a four region, multi-data center setup.
+The cardinal compass points for regions and numbered data centers within those regions were used there and the same hypothetical setup is used here as well.
+
+image::nesw-regions-and-dcs.svg[title="Mapping regions and data centers onto server tags", role="middle"]
+
+The behavior of the load balancer is configured in the property `dbms.routing.load_balancing.config.server_policies.<policy-name>`.
+The specified rules allows for fine-tuning how the cluster routes requests under load.
+
+The examples make use of the line continuation character `\` for better readability.
+It is valid syntax in xref:configuration/file-locations.adoc[_neo4j.conf_] as well and it is recommended to break up complicated rule definitions using this and a new rule on every line.
+
+The most restrictive strategy is to insist on a particular data center to the exclusion of all others:
+
+.Specific data center only
+====
+[source, properties]
+----
+dbms.routing.load_balancing.config.server_policies.north1_only=\
+tags(north1)->min(2); halt();
+----
+
+This case states that the intention is to send queries to servers tagged with `north1`, which maps onto a specific physical data center, provided there are two of them available.
+If at least two servers tagged with `north1` cannot be provided, then the operation should `halt()`, i.e. not try any other data center.
+====
+
+While the previous example demonstrates the basic form of load balancing rules, it is possible to be a little more expansive:
+
+.Specific data center preferably
+====
+[source, properties]
+----
+dbms.routing.load_balancing.config.server_policies.north1=\
+tags(north1)->min(2);
+----
+
+In this case if at least two servers are tagged with `north1` then the load is balanced across them.
+Otherwise, any server in the whole cluster is used, falling back to the implicit, final `all()` rule.
+====
+
+The previous example considered only a single data center before resorting to the whole cluster.
+If there is a hierarchy or region concept exposed through the server groups, the fall back can be more graceful:
+
+.Gracefully falling back to neighbors
+====
+[source, properties]
+----
+dbms.routing.load_balancing.config.server_policies.north_app1=\
+tags(north1,north2)->min(2);\
+tags(north);\
+all();
+----
+
+This example says that the cluster should load balance across servers with the `north1` and `north2` tags provided there are at least two machines available across them.
+Failing that, any server in the `north` region can be used, and if the whole of the north is offline, any server in the cluster can be used.
+====
+
+[[mdc-strategy-plugins]]
+== Catchup strategy plugins
+
+_Catchup strategy plugins_ are sets of rules that define how secondaries contact upstream servers in the cluster in order to synchronize transaction logs.
+Neo4j comes with a set of pre-defined strategies, and also leverages the <<mdc-policy-definitions, DSL>> to flexibly create user-defined strategies.
+Finally, Neo4j supports an API which advanced users may use to enhance upstream server recommendations.
+
+Once a catchup strategy plugin resolves a satisfactory upstream server, it is used for pulling transactions to update the local secondary for a single synchronization.
+For subsequent updates, the procedure is repeated so that the most preferred available upstream server is always resolved.
+
+[[mdc-programmatically-specify-rules]]
+=== Configuring upstream selection strategy using pre-defined catchup strategies
+
+Neo4j ships with the following pre-defined catchup strategy plugins.
+These provide coarse-grained algorithms for selecting an upstream server:
+
+[options="header",width="100%",cols="1,1"]
+|===
+| Plugin name                                          | Resulting behavior
+| `connect-to-random-primary-server`                   | Connect to any *primary server* selecting at random from those currently available.
+| `typically-connect-to-random-secondary`           | Connect to any available *secondary server*, but around 10% of the time connect to any random primary server.
+| `connect-randomly-to-server-tags`                   | Connect at random to any available *secondary server* tagged with any of the server tags specified in the comma-separated list `server.cluster.catchup.connect_randomly_to_server_tags`.
+| `leader-only`                                        | Connect only to the current Raft leader of the *primary servers*.
+| [deprecated]#`connect-randomly-to-server-group`# | [deprecated]#Connect at random to any available *secondary server* in the server groups specified in the comma-separated list `server.cluster.catchup.connect_randomly_to_server_group`.
+                                                         Deprecated, please use `connect-randomly-to-server-tags`.#
+| [deprecated]#`connect-randomly-within-server-group`# | [deprecated]#Connect at random to any available *secondary server* in any of the server groups to which this server belongs.
+                                                         Deprecated, please use `connect-randomly-to-server-tags`.#
+|===
+
+Pre-defined strategies are used by configuring the xref:reference/configuration-settings.adoc#config_server.cluster.catchup.upstream_strategy[`server.cluster.catchup.upstream_strategy`] option.
+Doing so allows for specification of an ordered preference of strategies to resolve an upstream provider of transaction data.
+A comma-separated list of strategy plugin names with preferred strategies is provided earlier in that list.
+The catchup strategy is selected by asking each of the strategies in list-order whether they can provide an upstream server from which transactions can be pulled.
+
+.Define an upstream server selection strategy
+====
+Consider the following configuration example:
+
+[source, properties]
+----
+server.cluster.catchup.upstream_strategy=connect-randomly-to-server-tags,typically-connect-to-random-secondary
+----
+
+With this configuration the secondary server first tries to connect to any other server with tag(s) specified in `server.cluster.catchup.connect_randomly_to_server_tags`.
+Should it fail to find any live servers with those tags, then it connects to a random secondary server.
+
+[[img-pipeline-of-strategies]]
+image::pipeline-of-strategies.svg[title="The first satisfactory response from a strategy will be used.", role="middle"]
+
+To ensure that downstream servers can still access live data in the event of upstream failures, the last resort of any server is always to contact a random primary server.
+This is equivalent to ending the `server.cluster.catchup.upstream_strategy` configuration with `connect-to-random-primary-server`.
+====
+
+
+[[mdc-configuration-user-defined-strategy]]
+=== Configuring user-defined catchup strategies
+
+Neo4j clusters support a small DSL for the configuration of client-cluster load balancing.
+This is described in detail in <<mdc-policy-definitions, Design Specific Language>> and <<mdc-filters, Filters>>.
+The same DSL is used to describe preferences for how a server binds to another server to request transaction updates.
+
+The DSL is made available by selecting the `user-defined` catchup strategy as follows:
+
+[source, properties]
+----
+server.cluster.catchup.upstream_strategy=user-defined
+----
+
+Once the user-defined strategy has been specified, we can add configuration to the xref:reference/configuration-settings.adoc#config_server.cluster.catchup.user_defined_upstream_strategy[`server.cluster.catchup.user_defined_upstream_strategy`] setting based on the server tags that have been set for the cluster.
+
+This functionality is described with two examples:
+
+.Defining a user-defined strategy
+====
+
+For illustrative purposes four regions are proposed: `north`, `south`, `east`, and `west` and within each region there is a number of data centers such as `north1` or `west2`.
+The server tags are configured so that each data center maps to its own server tag.
+Additionally it is assumed that each data center fails independently from the others and that a region can act as a supergroup of its constituent data centers.
+So a server in the `north` region might have configuration like `initial.server.tags=north2,north` which puts it in two groups that match to our physical topology as shown in the diagram below.
+
+[[img-nesw-regions-and-dcs]]
+image::nesw-regions-and-dcs.svg[title="Mapping regions and data centers onto server tags", role="middle"]
+
+Once the servers are tagged, the next task is to define some upstream selection rules based on them.
+For design purposes, assume that any server in one of the `north` region data centers prefers to catchup within the data center if it can, but resorts to any northern instance otherwise.
+To configure that behavior, add:
+
+[source, properties]
+----
+server.cluster.catchup.user_defined_upstream_strategy=tags(north2); tags(north); halt()
+----
+
+The configuration is in precedence order from left to right.
+The `tags()` operator yields a server tag from which to catchup.
+In this case, only if there are no servers tagged with `north2` does the operation proceed to the `tags(north)` rule which yields any server tagged with `north`.
+Finally, if no servers can be resolved with any of the previous tags, then the rule chain is stopped via `halt()`.
+
+Note that the use of `halt()` ends the rule chain explicitly.
+If a `halt()` is not used at the end of the rule chain, then the `all()` rule is implicitly added.
+`all()` is expansive: it offers up all servers and so increases the likelihood of finding an available upstream server.
+However `all()` is indiscriminate and the servers it offers are not guaranteed to be topologically or geographically local, potentially increasing the latency of synchronization.
+
+====
+
+The example above shows a simple hierarchy of preferences expressed through the use of server tags.
+But the hierarchy can be more sophisticated.
+For example, conditions can be placed on the tagged catchup servers.
+
+.User-defined strategy with conditions
+====
+
+In this example it is desired to roughly qualify cluster health before selecting from where to catchup.
+For this, the `min()` filter is used as follows:
+
+[source, properties]
+----
+server.cluster.catchup.user_defined_upstream_strategy=tags(north2)->min(3), tags(north)->min(3); all();
+----
+
+`tags(north2)\->min(3)` states that catchup from servers tagged with `north2` should be performed only if there are three available servers, which here is interpreted as an indicator of good health.
+If `north2` can't meet that requirement then catchup should be attempted from any server tagged with `north` provided there are at least three of them available as per `tags(north)\->min(3)`.
+Finally, if catchup cannot be performed from a sufficiently healthy `north` region, then the operation (explicitly) falls back to the whole cluster with `all()`.
+
+The `min()` filter is a simple but reasonable health indicator of a set of servers with the same tag.
+====
+
+// [[mdc-build-your-own-strategy-plugin]]
+// === Building upstream strategy plugins using Java
+
+// Neo4j supports an API which advanced users may use to enhance upstream recommendations in arbitrary ways: load, subnet, machine size, or anything else accessible from the JVM.
+// In such cases we are invited to build our own implementations of `org.neo4j.causalclustering.upstream.UpstreamDatabaseSelectionStrategy` to suit our own needs, and register them with the catchup strategy selection pipeline just like the pre-packaged plugins.
+
+// We have to override the `org.neo4j.causalclustering.upstream.UpstreamDatabaseSelectionStrategy#upstreamDatabase()` method in our code.
+// Overriding that class gives us access to the following items:
+
+// [options="header"]
+// |===
+// | Resource                                               | Description
+// | `org.neo4j.causalclustering.discovery.TopologyService` | This is a directory service which provides access to the addresses of all servers and server groups in the cluster.
+// | `org.neo4j.kernel.configuration.Config`                | This provides the configuration from _neo4j.conf_ for the local instance.
+// Configuration for our own plugin can reside here.
+// | `org.neo4j.causalclustering.identity.MemberId`         | This provides the unique cluster `MemberId` of the current instance.
+// |===
+
+// Once our code is written and tested, we have to prepare it for deployment.
+// `UpstreamDatabaseSelectionStrategy` plugins are loaded via the Java Service Loader.
+// This means when we package our code into a jar file, we'll have to create a file _META-INF.services/org.neo4j.upstream.readreplica.UpstreamDatabaseSelectionStrategy_ in which we write the fully qualified class name(s) of the plugins, e.g. `org.example.myplugins.PreferServersWithHighIOPS`.
+
+// To deploy this jar into the Neo4j server we copy it into the xref:configuration/file-locations.adoc[_plugins_] directory and restart the instance.
+
+[[mdc-favoring-data-centers]]
+=== Favoring data centers
+
+In a multi-data center scenario, while it remains a rare occurrence, it is possible to bias where writes for the specified database should be directed.
+`db.cluster.raft.leader_transfer.priority_tag` can be applied to specify a set of servers with a given tag which should have priority when selecting the leader for a given database.
+The priority tag can be set on one or multiple databases and it means that the cluster attempts to keep the leadership for the configured database on a server tagged with the configured server tag.
+
+A database for which `db.cluster.raft.leader_transfer.priority_tag` has been configured is excluded from the automatic balancing of leaderships across a cluster.
+It is therefore recommended to not use this configuration unless it is necessary.
+
+

--- a/modules/ROOT/pages/clustering/index.adoc
+++ b/modules/ROOT/pages/clustering/index.adoc
@@ -17,6 +17,8 @@ This chapter describes the following:
 ** xref:clustering/monitoring/show-servers-monitoring.adoc[Monitoring servers] -- The tools available for monitoring the servers in a cluster.
 ** xref:clustering/monitoring/show-databases-monitoring.adoc[Monitoring databases] -- The tools available for monitoring the databases in a cluster.
 * xref:clustering/settings.adoc[Settings reference] -- A summary of the most important cluster settings.
+* xref:clustering/clustering-advanced/index.adoc[]
+** xref:clustering/clustering-advanced/multi-data-center-routing.adoc[]
 * xref:clustering/glossary.adoc[Clustering glossary] -- A glossary of terms used in the clustering documentation.
 //* <<clustering-internals, Internals>> -- A few internals regarding the operation of the cluster.
 Further information:


### PR DESCRIPTION
In 5.3 we introduced the concept of server tags which replaced the existing server groups. This PR updates the docs to reflect this change, this resulted in a few config settings changing. This PR also revives the hidden clustering advanced section.

Co-authored-by: AlexicaWright <49636617+AlexicaWright@users.noreply.github.com>