### PR TITLE
Remove unsupported immutable privileges management option

### DIFF
--- a/modules/ROOT/pages/tutorial/tutorial-immutable-privileges.adoc
+++ b/modules/ROOT/pages/tutorial/tutorial-immutable-privileges.adoc
@@ -19,7 +19,8 @@ To do so, follow these steps:
 
 . Change the config setting xref:reference/configuration-settings.adoc#config_dbms.security.auth_enabled[`dbms.security.auth_enabled`] to `false`.
 . Restart the Neo4j DBMS.
-. Create or remove immutable privileges in the same way as regular privileges, using the keyword `IMMUTABLE`. For example:
+. Create or remove immutable privileges in the same way as regular privileges using the keyword `IMMUTABLE`.
+For example:
 [source, cypher, role=noplay]
 ----
 DENY IMMUTABLE DATABASE MANAGEMENT ON DBMS TO PUBLIC


### PR DESCRIPTION
Security init file is not a supported option and should not be mentioned in the docs

Deleted documentation has moved to this internal doc: https://sites.google.com/neotechnology.com/dbms-internal-documentation/administering-immutable-privileges