### PR TITLE
Add neo4j service configuration for tarball installations (#331)

### DIFF
--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -1,6 +1,6 @@
 :description: How to install Neo4j on Debian, and Debian-based distributions like Ubuntu, using the Neo4j Debian package.
 [[debian]]
-= Debian
+= Debian-based distributions (.deb)
 
 You can install Neo4j on Debian, and Debian-based distributions like Ubuntu, using the Neo4j Debian package.
 
@@ -230,3 +230,10 @@ For operating systems that are not using `systemd`, some package-specific option
 | _NEO4J_SHUTDOWN_TIMEOUT_ | _120_           | Timeout in seconds when waiting for Neo4j to stop. If it takes longer than this then the shutdown is considered to have failed. This may need to be increased if the system serves long-running transactions.
 | _NEO4J_ULIMIT_NOFILE_    | _60000_         | Maximum number of file handles that can be opened by the Neo4j process.
 |===
+
+[[debian-service-start-automatically]]
+== Starting the service automatically on system start
+
+On Debian-based distributions, Neo4j is enabled to start automatically on system boot by default.
+
+For more information on operating the Neo4j system service, see xref:installation/linux/systemd.adoc[Neo4j system service].

--- a/modules/ROOT/pages/installation/linux/rpm.adoc
+++ b/modules/ROOT/pages/installation/linux/rpm.adoc
@@ -1,6 +1,6 @@
 :description: How to deploy Neo4j using the Neo4j RPM package on Red Hat, CentOS, Fedora, or Amazon Linux distributions.
 [[linux-rpm]]
-= Deploy Neo4j using the Neo4j RPM package
+= Red Hat, CentOS, Fedora, and Amazon Linux distributions (.rpm)
 
 You can deploy Neo4j on Red Hat, CentOS, Fedora, or Amazon Linux distributions using the Neo4j RPM package.
 
@@ -180,7 +180,6 @@ rpm --install <Cypher Shell RPM file name>
 rpm --install <Neo4j RPM file name>
 ----
 
-
 [[linux-rpm-install-offline-install-upgrade]]
 ==== Offline upgrade from 4.4.0 or later
 
@@ -196,3 +195,15 @@ rpm -U <Cypher Shell RPM file name> <Neo4j RPM file name>
 ----
 
 This must be one single command, and Neo4j Cypher Shell must be the first package in the command.
+
+[[rpm-service-start-automatically]]
+== Starting the service automatically on system start
+
+To enable Neo4j to start automatically on system boot, run the following command:
+
+[source, shell]
+----
+systemctl enable neo4j
+----
+
+For more information on operating the Neo4j system service, see xref:installation/linux/systemd.adoc[Neo4j system service].

--- a/modules/ROOT/pages/installation/linux/systemd.adoc
+++ b/modules/ROOT/pages/installation/linux/systemd.adoc
@@ -18,19 +18,6 @@ For instructions on how to set the number of concurrent files that a user can ha
 Configuration is stored in _/etc/neo4j/neo4j.conf_.
 See xref:configuration/file-locations.adoc[Default file locations] for a complete catalog of where files are found for the various packages.
 
-
-[[linux-service-start-automatically]]
-== Starting the service automatically on system start
-
-If you installed the RPM package and want Neo4j to start automatically on system boot then you need to enable the service.
-On Debian-based distributions this is done for you at installation time.
-
-[source, shell]
-----
-systemctl enable neo4j
-----
-
-
 [[linux-service-control]]
 == Controlling the service
 
@@ -51,7 +38,7 @@ systemctl edit neo4j
 ----
 
 Then place any customizations under a `[Service]` section.
-The following example lists default values which may be interesting to change for some users:
+The following example lists default values that may be interesting to change for some users:
 
 [source]
 ----

--- a/modules/ROOT/pages/installation/linux/tarball.adoc
+++ b/modules/ROOT/pages/installation/linux/tarball.adoc
@@ -1,38 +1,116 @@
 :description: How to install Neo4j on Linux from a tarball, and run it as a console application or service.
 [[installation-linux-tarball]]
-= Linux tarball installation
+= Linux executable (.tar)
 
-Before you install Neo4j on Linux from a tarball and run it as a console application or service, check xref:installation/requirements.adoc[System Requirements] to see if your setup is suitable.
+Before you install Neo4j on Linux from a tarball and run it as a console application or a service, check xref:installation/requirements.adoc[System Requirements] to see if your setup is suitable.
 
 [[unix-console]]
-== Unix console application
+== Install Neo4j from a tarball
 
 . If it is not already installed, get link:http://openjdk.java.net/[OpenJDK 17] or link:http://www.oracle.com/technetwork/java/javase/downloads/index.html[Oracle Java 17].
-. Download the latest release from {neo4j-download-center-uri}[Neo4j Download Center].
+. Download the latest Neo4j tarball from https://neo4j.com/download-center/[Neo4j Download Center] and unpack it:
 +
-Select the appropriate tar.gz distribution for your platform.
-. Make sure to download Neo4j from {neo4j-download-center-uri}[Neo4j Download Center] and always check that the SHA hash of the downloaded file is correct:
-.. To find the correct SHA hash, go to Neo4j Download Center and click on `SHA-256` which will be located below your downloaded file.
-.. Using the appropriate commands for your platform, display the `SHA-256` hash for the file that you downloaded.
-.. Ensure that the two are identical.
-. Extract the contents of the archive, using `tar -xf` <filename>.
-For example, `tar -xf neo4j-community-{neo4j-version-exact}-unix.tar.gz`.
-. Place the extracted files in a permanent home on your server.
-The top level directory is referred to as NEO4J_HOME.
+[source, shell, subs="attributes"]
+----
+tar zxf neo4j-enterprise-{neo4j-version-exact}-unix.tar.gz
+----
+. Move the extracted files to your server's _/opt_ directory and create a symlink to it:
++
+[source, shell, subs="attributes"]
+----
+mv neo4j-enterprise-{neo4j-version-exact} /opt/
+ln -s /opt/neo4j-enterprise-{neo4j-version-exact}/opt/neo4j
+----
+. Create a `neo4j` user and group:
++
+[source, shell]
+----
+groupadd neo4j
+useradd -g neo4j neo4j -s /bin/bash
+----
+. Give the directory the correct ownership using one of the options:
+
+* *Ubuntu*
++
+[source, shell, subs="attributes"]
+----
+chown -R neo4j:adm /opt/neo4j-enterprise-{neo4j-version-exact}
+----
+* *RedHat*
++
+[source, shell, subs="attributes"]
+----
+chown -R neo4j /opt/neo4j-enterprise-{neo4j-version-exact}
+----
+. label:enterprise[Enterprise Edition] Accept the license agreement by either using the environment variable `NEO4J_ACCEPT_LICENSE_AGREEMENT=yes` or by running `<NEO4J_HOME>/bin/neo4j-admin license --accept-commercial`.
++
+[NOTE]
+====
+From Neo4j v5.4 onwards, you are required to accept the license _before_ running the Neo4j Enterprise Edition from the tarball.
+====
+. Start Neo4j:
 .. To run Neo4j as a console application, use: `<NEO4J_HOME>/bin/neo4j console`.
 .. To run Neo4j in a background process, use: `<NEO4J_HOME>/bin/neo4j start`.
-. Visit http://localhost:7474 in your web browser.
-. Connect using the username 'neo4j' with default password 'neo4j'.
-You'll then be prompted to change the password.
+. Open  http://localhost:7474 in your web browser.
+. Connect using the username `neo4j` with the default password `neo4j`.
+You will then be prompted to change the password.
 . Stop the server by typing `Ctrl-C` in the console.
 
 
-[[installation-linux-tarball-service]]
-== Linux service
+[[linux-tarball-start-automatically]]
+== Configure Neo4j to start automatically on system boot
 
-If you want to run Neo4j as a system service, you can install either the xref:installation/linux/debian.adoc[Debian] or xref:installation/linux/rpm.adoc[RPM] package.
+You can create a Neo4j service and configure it to start automatically on system boot.
 
-For more information on configuring and operating the Neo4j system service, see xref:installation/linux/systemd.adoc[Neo4j system service].
+. Create the file _/lib/systemd/system/neo4j.service_ with the following contents:
++
+[source, shell]
+----
+[Unit]
+Description=Neo4j Graph Database
+After=network-online.target
+Wants=network-online.target
 
+[Service]
+ExecStart=/opt/neo4j/bin/neo4j console
+Restart=on-abnormal
+User=neo4j
+Group=neo4j
+Environment="NEO4J_CONF=/opt/neo4j/conf" "NEO4J_HOME=/opt/neo4j"
+LimitNOFILE=60000
+TimeoutSec=120
+
+[Install]
+WantedBy=multi-user.target
+Reload systemctl to pick up the new service file
+systemctl daemon-reload
+----
+
+. Configure Neo4j to start at boot time:
++
+[source, shell]
+----
+systemctl enable neo4j
+----
+. Start Neo4j:
++
+[source, shell]
+----
+systemctl start neo4j
+----
+. Check the status of the newly created service:
++
+[source, shell]
+----
+systemctl status neo4j
+----
+. Reboot the system (if desired) to verify that Neo4j restarts on boot:
++
+[source, shell]
+----
+reboot
+----
+
+For more information on operating the Neo4j system service, see xref:installation/linux/systemd.adoc[Neo4j system service].
 
 include::partial$/installation/linux/linux-open-files.adoc[leveloffset=+1]


### PR DESCRIPTION
Cherry-picked from #331 
This PR includes:

- A new section on neo4j service configuration for tarball installations
- Update the titles to be coherent
- Update the Linux tarball installation to include neo4j user and group creation