### PR TITLE
fixing link for the neo4j-download-center-uri  (#356)

### DIFF
--- a/modules/ROOT/pages/installation/neo4j-desktop.adoc
+++ b/modules/ROOT/pages/installation/neo4j-desktop.adoc
@@ -9,7 +9,7 @@ Neo4j Desktop is a convenient way for developers to work with local Neo4j databa
 Neo4j Desktop is not suited for production environments.
 ====
 
-To install Neo4j Desktop, go to {neo4j-download-center-uri}[Neo4j Download Center] and follow the instructions.
+To install Neo4j Desktop, go to link:{neo4j-download-center-uri}[Neo4j Download Center] and follow the instructions.
 
 [TIP]
 ====

--- a/publish.yml
+++ b/publish.yml
@@ -57,4 +57,4 @@ asciidoc:
     '0': "\\{0}"
     neo4j-base-uri: ''
     neo4j-docs-base-uri: /docs
-    neo4j-download-center-uri: /download-center
+    neo4j-download-center-uri: https://neo4j.com/download-center


### PR DESCRIPTION
It was broken in neo4j desktop installation page. Should be cherry picked to all branches.

Co-authored-by: Neil Dewhurst <ndewhurst@gmail.com>

Cherry-pick of https://github.com/neo4j/docs-operations/pull/356