### PR TITLE
adding information about runtime max number

### DIFF
--- a/modules/ROOT/partials/neo4j-config/all-settings.adoc
+++ b/modules/ROOT/partials/neo4j-config/all-settings.adoc
@@ -2882,7 +2882,8 @@ m|+++neo4j+++
 |Description
 a|label:enterprise-edition[Enterprise only]Initial default number of primary instances of user databases. If the user does not specify the number of primaries in 'CREATE DATABASE', this value will be used, unless it is overwritten with the 'dbms.setDefaultAllocationNumbers' procedure.
 |Valid values
-a|initial.dbms.default_primaries_count, an integer which is minimum `1` and is maximum `11`
+a|initial.dbms.default_primaries_count, an integer which is minimum `1` and is maximum `11`.
+The same value applies to runtime max number.
 |Default value
 m|+++1+++
 |===
@@ -2894,7 +2895,8 @@ m|+++1+++
 |Description
 a|label:enterprise-edition[Enterprise only]Initial default number of secondary instances of user databases. If the user does not specify the number of secondaries in 'CREATE DATABASE', this value will be used, unless it is overwritten with the 'dbms.setDefaultAllocationNumbers' procedure.
 |Valid values
-a|initial.dbms.default_secondaries_count, an integer which is minimum `0` and is maximum `20`
+a|initial.dbms.default_secondaries_count, an integer which is minimum `0` and is maximum `20`.
+The same value applies to runtime max number.
 |Default value
 m|+++0+++
 |===


### PR DESCRIPTION
Is this also valid for previous versions (i.e. 4.4, 4.3 etc)? 