### PR TITLE
External link was broken  (#349)

### DIFF
--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -64,7 +64,7 @@ The configured server uses all the addresses from the SRV record to join or form
 == Discovery in Kubernetes
 
 A special case is when a cluster is running in https://kubernetes.io/[Kubernetes^] and each server is running as a Kubernetes service.
-Then, the addresses of the other servers can be obtained using the List Service API, as described in the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#list-service-v1-core[Kubernetes API documentation^].
+Then, the addresses of the other servers can be obtained using the List Service API, as described in the https://kubernetes.io/docs/reference/kubernetes-api/[Kubernetes API documentation^].
 
 The following settings are used to configure for this scenario:
 


### PR DESCRIPTION
because the kubernetes docs version was updated from 1.18 to 1.19


Cherry-pick from https://github.com/neo4j/docs-operations/pull/349