### PR TITLE
Removing extra "calling" in syntax as result of a typo (#381)

### DIFF
--- a/modules/ROOT/pages/monitoring/background-jobs.adoc
+++ b/modules/ROOT/pages/monitoring/background-jobs.adoc
@@ -112,7 +112,7 @@ An xref:authentication-authorization/terminology.adoc#term-administrator[adminis
 
 *Syntax:*
 
-`CALL calling dbms.scheduler.failedJobs()`
+`CALL dbms.scheduler.failedJobs()`
 
 *Returns:*
 


### PR DESCRIPTION
Cherry-picked from https://github.com/neo4j/docs-operations/pull/381