### PR TITLE
Add note about server commands and composite databases

### DIFF
--- a/modules/ROOT/pages/clustering/servers.adoc
+++ b/modules/ROOT/pages/clustering/servers.adoc
@@ -127,7 +127,12 @@ neo4j@neo4j> ENABLE SERVER '25a7efc7-d063-44b8-bdee-f23357f89f01' OPTIONS
 
 `modeConstraint` is used to control whether a server can be used to host a database in only primary or secondary mode.
 `allowedDatabases` and `deniedDatabases` are collections of database names that filter which databases may be hosted on a server.
-These are mutually exclusive and if both are specified, an error is returned.
+The `allowedDatabases` and `deniedDatabases` are mutually exclusive and if both are specified, an error is returned.
+
+[NOTE]
+====
+`allowedDatabases` and `deniedDatabases` do not affect composite databases, they are always available everywhere.
+====
 
 If no options are set, a server can host any database in any mode.
 Servers can also provide default values for these options via their _neo4j.conf_ files on first startup.
@@ -243,6 +248,11 @@ neo4j@neo4j> ALTER SERVER '25a7efc7-d063-44b8-bdee-f23357f89f01' SET OPTIONS {mo
 Altering servers may cause databases to be moved, and should be performed with care.
 For example, if the server `25a7efc7-d063-44b8-bdee-f23357f89f01` hosts database `foo` in primary mode when the above command is executed, then another server must begin hosting `foo` in primary mode.
 Likewise, if `ALTER SERVER '25a7efc7-d063-44b8-bdee-f23357f89f01' SET OPTIONS {allowedDatabases:['bar','baz']};` is executed, then `foo` is forced to move.
+
+[NOTE]
+====
+`allowedDatabases` and `deniedDatabases` do not affect composite databases, they are always available everywhere.
+====
 
 As with the `DEALLOCATE DATABASES FROM SERVER ...` command, if the alteration of a server's options renders it impossible for the cluster to satisfy one or more of the databases' topologies, then the command fails and no changes are made.
 


### PR DESCRIPTION
The `allowedDatabases` and `deniedDatabases` doesn't apply to composite databases.

Companion PR to https://github.com/neo4j/docs-cypher/pull/333