### PR TITLE
Add antora-page-roles extension

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -35,6 +35,7 @@ asciidoc:
   - "@neo4j-documentation/remote-include"
   - "@neo4j-documentation/macros"
   - "@neo4j-antora/antora-add-notes"
+  - "@neo4j-antora/antora-page-roles"
   - "@neo4j-antora/antora-table-footnotes"
   attributes:
     page-theme: docs


### PR DESCRIPTION
Labels are missing from pages because the add-page-roles extension was missing from the publish playbook.

This PR restores the extension to the playbook.