### PR TITLE
Add information on the column ValidValues

### DIFF
--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -1451,7 +1451,7 @@ Results include:
 * `defaultValue`: the default value of the setting.
 * `startupValue`: the value when the server was started, after _neo4j.conf_ and command line arguments have been applied.
 * `explicitlySet`: true if the value was set explicitly, or false if it was set by default.
-* `validValues`: data types of the settings.
+* `validValues`: contains information on data types and possible values for the settings.
 
 | Signature
 m|dbms.listConfig(searchString =  :: STRING?) :: (name :: STRING?, description :: STRING?, value :: STRING?, dynamic :: BOOLEAN?, defaultValue :: STRING?, startupValue :: STRING?, explicitlySet :: BOOLEAN?, validValues :: STRING?)


### PR DESCRIPTION
Results of the procedure `dbms.listConfig` lack information on the column 'validValues`. The description was added.