### PR TITLE
added rhel 9.0 to the supported OS list

### DIFF
--- a/modules/ROOT/pages/installation/requirements.adoc
+++ b/modules/ROOT/pages/installation/requirements.adoc
@@ -101,7 +101,7 @@ For cloud environments, and server-based, on-premise environments:
 | *Amazon Linux 2022 AMI*                          | Amazon Corretto 17, and OracleJDK 17
 | *CentOS Stream 8, 9*                             | OpenJDK 17, OracleJDK 17, and ZuluJDK 17
 | *Debian 11*                                      | OpenJDK 17, OracleJDK 17, and ZuluJDK 17
-| *Red Hat Enterprise Linux Server 8.4, 8.6*       | Red Hat OpenJDK 17,  Oracle JDK 17, and ZuluJDK 17
+| *Red Hat Enterprise Linux Server 8.4, 8.6, 9.0*  | Red Hat OpenJDK 17,  Oracle JDK 17, and ZuluJDK 17
 | *Ubuntu Server 16.04, 18.04, 20.04, 22.04*       | OpenJDK 17, OracleJDK 17, and ZuluJDK 17
 | *Windows Server 2016, 2019, 2022*                | OracleJDK 17, ZuluJDK 17
 |===


### PR DESCRIPTION
RHEL 9.0 has actually been supported for a while. I just forgot to update the documentation.