### PR TITLE
Remove reference to 'user and role management procedures'

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/ldap-integration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/ldap-integration.adoc
@@ -100,7 +100,7 @@ This way, the LDAP connector is used as a security provider for both authenticat
 [[auth-ldap-map-ldap-roles]]
 == Map the LDAP groups to the Neo4j roles
 
-To access the user and role management procedures, you have to map the LDAP groups to the xref:authentication-authorization/built-in-roles.adoc[Neo4j built-in] and custom-defined roles.
+To assign privileges to users based on their LDAP groups, you have to map the LDAP groups to the xref:authentication-authorization/built-in-roles.adoc[Neo4j built-in] and custom-defined roles.
 To do that, you need to know what privileges the Neo4j roles have, and based on these privileges, to create the mapping to the groups defined in the LDAP server.
 The map must be formatted as a semicolon separated list of key-value pairs, where the key is a comma-separated list of the LDAP group names and the value is a comma-separated list of the corresponding role names.
 For example, `group1=role1;group2=role2;group3=role3,role4,role5;group4,group5=role6`.


### PR DESCRIPTION
Replace the reference to the removed user and role management procedures with something more helpful.