### PR TITLE
Remove use of 'servers' when describing initial database counts (#150)

### DIFF
--- a/modules/ROOT/pages/clustering/setup/deploy.adoc
+++ b/modules/ROOT/pages/clustering/setup/deploy.adoc
@@ -3,7 +3,7 @@
 [[clustering-deploy]]
 = Deploy a basic cluster
 
-The first step in setting up a cluster infrastructure is configuring a number of servers to form a cluster that you can run your databases on.
+The first step in setting up a cluster infrastructure is configuring a number of servers to form a cluster that you can host your databases on.
 The following configuration settings are important to consider when deploying a new cluster.
 //Remember to update the settings and link below.
 See also xref:clustering/settings.adoc[Settings reference] for more detailed descriptions and examples.
@@ -25,11 +25,11 @@ Setting this value to `0.0.0.0` makes Neo4j bind to all available network interf
 The behavior of this setting can be modified by configuring the setting `dbms.cluster.discovery.type`.
 This is described in detail in <<clustering-discovery>>
 | <<config_initial.dbms.default_primaries_count, `initial.dbms.default_primaries_count`>>
-| The number of initial servers in primary mode.
-If not specified, it defaults to one server in primary mode.
+| The number of initial database hostings in primary mode.
+If not specified, it defaults to one hosting in primary mode.
 | <<config_initial.dbms.default_secondaries_count, `initial.dbms.default_secondaries_count`>>
-| The number of initial servers in secondary mode.
-If not specified, it defaults to zero servers in secondary mode.
+| The number of initial database hostings in secondary mode.
+If not specified, it defaults to zero hostings in secondary mode.
 |===
 
 The following example shows how to set up a basic cluster with three servers with primary hosting capabilities.


### PR DESCRIPTION
The configuration page uses 'instances', and 'servers' is misleading

---------

Co-authored-by: AlexicaWright <49636617+AlexicaWright@users.noreply.github.com>