### PR TITLE
Removing some elements that were breaking the overall formatting

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/access-control.adoc
@@ -752,7 +752,7 @@ GRANT DELETE ON GRAPH healthcare RELATIONSHIPS HAS, DIAGNOSIS TO receptionist;
 Privileges that were granted or denied earlier can be revoked using link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/access-control/manage-privileges/#access-control-revoke-privileges[the `REVOKE` command].
 ====
 
-=== Privileges of nurses
+=== Privileges of `nurse`
 
 Nurses should have the capabilities of both doctors and receptionists, but assigning them both the `doctor` and `receptionist` roles might not have the expected effect.
 If those two roles were created with `GRANT` privileges only, combining them would be simply cumulative.
@@ -901,7 +901,7 @@ Performing this action, otherwise reserved for the `doctor` role, involves more 
 There might be nurses that should not be entrusted with this option, which is why you can divide the `nurse` role into _senior_ and _junior_ nurses, for example.
 Currently, Daniel is a senior nurse.
 
-=== Privileges of junior nurses
+=== Privileges of _junior_ `nurse`
 
 Previously, creating the `nurse` role by combining the `doctor` and `receptionist` roles led to an undesired scenario as the `DENIED` privileges of the `doctor` role overrode the `GRANTED` privileges of the `receptionist`.
 In that case, the objective was to enhance the permissions of the _senior_ nurse, but when it comes to the _junior_ nurse, they should be able to perform the same actions as the _senior_, except adding diagnoses to the database.


### PR DESCRIPTION
Inserting code inside boxes was generating conflicts with the formatting of sections' titles. I removed them as they are not crucial and thus we can similar conflicts in the future.