### PR TITLE
Removing some elements that were breaking the overall formatting (#465)

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/access-control.adoc
@@ -97,9 +97,6 @@ In this example, consider five users of the _healthcare_ database:
 
 These users can be created using the `CREATE USER` command (from the `system` database):
 
-.Creating users
-====
-
 [source, cypher]
 ----
 CREATE USER charlie SET PASSWORD $secret1 CHANGE NOT REQUIRED;
@@ -108,9 +105,6 @@ CREATE USER daniel SET PASSWORD $secret3 CHANGE NOT REQUIRED;
 CREATE USER bob SET PASSWORD $secret4 CHANGE NOT REQUIRED;
 CREATE USER tina SET PASSWORD $secret5 CHANGE NOT REQUIRED;
 ----
-
-====
-
 
 At this point the users have no ability to interact with the database, so these capabilities need to be granted by using roles.
 There are two different ways of doing this, either by using the built-in roles, or through more fine-grained access control using privileges and custom roles.
@@ -138,9 +132,6 @@ Tina, the IT administrator who installs and manages the database, needs to be as
 
 Here is how to grant roles to the users:
 
-.Granting roles
-====
-
 [source, cypher]
 ----
 GRANT ROLE reader TO charlie;
@@ -150,10 +141,8 @@ GRANT ROLE editor TO bob;
 GRANT ROLE admin TO tina;
 ----
 
-====
-
 [[auth-access-control-using-privileges]]
-== Sub-graph access control using privileges]
+== Sub-graph access control using privileges
 
 A limitation of the previously described approach is that it does allow all users to see all the data on the database.
 In many real-world scenarios though, it would be preferable to establish some access restrictions.
@@ -171,7 +160,6 @@ REVOKE ROLE editor FROM daniel;
 REVOKE ROLE editor FROM bob;
 REVOKE ROLE admin FROM tina;
 ----
-====
 
 Now you can create custom roles based on the concept of _privileges_, which allows more control over what each user is capable of doing.
 To properly assign those privileges, start by identifying each type of user:
@@ -217,40 +205,33 @@ To achieve that, a new role can be created from scratch and only specific admini
 Before creating the new roles and assigning them to Alice, Bob, Daniel, Charlie, and Tina, it is important to define the privileges each role should have.
 Since all users need `ACCESS` privilege to the `healthcare` database, this can be set through the `PUBLIC` role instead of all the individual roles:
 
-====
 [source, cypher]
 ----
 GRANT ACCESS ON DATABASE healthcare TO PUBLIC;
 ----
-====
 
 === Privileges of `itadmin`
 
 This role can be created as a copy of the built-in `admin` role:
 
-====
 [source, cypher, role=systemcmd]
 ----
 CREATE ROLE itadmin AS COPY OF admin;
 ----
-====
 
 Then you need to *deny* the two specific actions this role is not supposed to perform:
 
 * Read any patients' social security number (`SSN`).
 * Submit medical diagnoses.
 
-====
 [source, cypher, role=systemcmd]
 ----
 DENY READ {ssn} ON GRAPH healthcare NODES Patient TO itadmin;
 DENY CREATE ON GRAPH healthcare RELATIONSHIPS DIAGNOSIS TO itadmin;
 ----
-====
 
 The complete set of privileges available to users assigned the `itadmin` role can be viewed using the following command:
 
-====
 [source, cypher, role=systemcmd]
 ----
 SHOW ROLE itadmin PRIVILEGES AS COMMANDS;
@@ -274,7 +255,6 @@ SHOW ROLE itadmin PRIVILEGES AS COMMANDS;
 | "DENY CREATE ON GRAPH `healthcare` RELATIONSHIP DIAGNOSIS TO `itadmin`" |
 +-------------------------------------------------------------------------+
 ----
-====
 
 [NOTE]
 ====
@@ -283,12 +263,10 @@ Privileges that were granted or denied earlier can be revoked using link:{neo4j-
 
 To provide the IT administrator `tina` these privileges, they must be assigned the new role `itadmin`:
 
-====
 [source, cypher, role=systemcmd]
 ----
 neo4j@system> GRANT ROLE itadmin TO tina;
 ----
-====
 
 To demonstrate that Tina is not able to see the patients' `SSN`, you can login to `healthcare` as `tina` and run the following query:
 
@@ -369,7 +347,6 @@ DENY TRAVERSE
     RELATIONSHIPS DIAGNOSIS
     TO researcherB;
 ----
-====
 
 * *Granting privileges*:
 +
@@ -407,20 +384,16 @@ GRANT READ {dateOfBirth}
     NODES Patient
     TO researcherW;
 ----
-====
 
 In order to test that the researcher Charlie now has the specified privileges, assign them the `researcherB` role (with specifically denied privileges):
 
-====
 [source, cypher, role=systemcmd]
 ----
 GRANT ROLE researcherB TO charlie;
 ----
-====
 
 You can also use a version of the `SHOW PRIVILEGES` command to see Charlie's access rights, which are a combination of those assigned to the `researcherB` and `PUBLIC` roles:
 
-====
 [source, cypher, role=systemcmd]
 ----
 neo4j@system> SHOW USER charlie PRIVILEGES AS COMMANDS;
@@ -441,7 +414,6 @@ neo4j@system> SHOW USER charlie PRIVILEGES AS COMMANDS;
 | "DENY READ {ssn} ON GRAPH `healthcare` NODE Patient TO $role"         |
 +-----------------------------------------------------------------------+
 ----
-====
 
 Now when Charlie logs into the `healthcare` database and tries to run a command similar to the one previously used by the `itadmin`, they will see different results:
 
@@ -508,7 +480,6 @@ Privileges that were granted or denied earlier can be revoked using link:{neo4j-
 Doctors should be given the ability to read and write almost everything, except the patients' `address` property, for instance.
 This role can be built from scratch by assigning full read and write access, and then specifically denying access to the `address` property:
 
-====
 [source, cypher]
 ----
 CREATE ROLE doctor;
@@ -518,16 +489,13 @@ GRANT WRITE ON GRAPH healthcare TO doctor;
 DENY READ {address} ON GRAPH healthcare NODES Patient TO doctor;
 DENY SET PROPERTY {address} ON GRAPH healthcare NODES Patient TO doctor;
 ----
-====
 
 To allow the doctor Alice to have these privileges, grant them this new role:
 
-====
 [source, cypher]
 ----
 neo4j@system> GRANT ROLE doctor TO alice;
 ----
-====
 
 To demonstrate that Alice is not able to see patient addresses, log in as `alice` to `healthcare` and run the following query:
 
@@ -642,7 +610,6 @@ Receptionists should only be able to manage patient information.
 They are not allowed to find or read any other parts of the graph.
 In addition, they should be able to create and delete patients, but not any other nodes:
 
-====
 [source, cypher, role=systemdb]
 ----
 CREATE ROLE receptionist;
@@ -651,7 +618,6 @@ GRANT CREATE ON GRAPH healthcare NODES Patient TO receptionist;
 GRANT DELETE ON GRAPH healthcare NODES Patient TO receptionist;
 GRANT SET PROPERTY {*} ON GRAPH healthcare NODES Patient TO receptionist;
 ----
-====
 
 It would have been simpler to grant global `WRITE` privileges to the receptionist Bob.
 However, this would have the unfortunate side effect of allowing them the ability to create other nodes, like new `Symptom` nodes, even though they would subsequently be unable to find or read those same nodes.
@@ -659,12 +625,10 @@ While there are use cases in which it is desirable to have roles able to create 
 
 With that in mind, grant the receptionist Bob their new `receptionist` role:
 
-====
 [source, cypher]
 ----
 neo4j@system> GRANT ROLE receptionist TO bob;
 ----
-====
 
 With these privileges, if Bob tries to read the entire database, they will still only see the patients:
 
@@ -776,21 +740,19 @@ org.neo4j.graphdb.ConstraintViolationException: Cannot delete node<42>, because 
 The reason why this query fails is that, while Bob can find the `(:Patient)` node, they do not have sufficient traverse rights to find nor delete the outgoing relationships from it.
 Either they need to ask Tina the `itadmin` for help for this task, or more privileges can be added to the `receptionist` role:
 
-====
 [source, cypher, role=systemcmd]
 ----
 GRANT TRAVERSE ON GRAPH healthcare NODES Symptom, Disease TO receptionist;
 GRANT TRAVERSE ON GRAPH healthcare RELATIONSHIPS HAS, DIAGNOSIS TO receptionist;
 GRANT DELETE ON GRAPH healthcare RELATIONSHIPS HAS, DIAGNOSIS TO receptionist;
 ----
-====
 
 [NOTE]
 ====
 Privileges that were granted or denied earlier can be revoked using link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/access-control/manage-privileges/#access-control-revoke-privileges[the `REVOKE` command].
 ====
 
-=== Privileges of nurses
+=== Privileges of `nurse`
 
 Nurses should have the capabilities of both doctors and receptionists, but assigning them both the `doctor` and `receptionist` roles might not have the expected effect.
 If those two roles were created with `GRANT` privileges only, combining them would be simply cumulative.
@@ -799,16 +761,13 @@ This means that the nurse will still have the same restrictions as a doctor, whi
 
 To demonstrate this, you can assign the `doctor` role to the nurse Daniel:
 
-====
 [source, cypher]
 ----
 neo4j@system> GRANT ROLE doctor, receptionist TO daniel;
 ----
-====
 
 Daniel should now have a combined set of privileges:
 
-====
 [source, cypher, role=systemdb]
 ----
 SHOW USER daniel PRIVILEGES AS COMMANDS;
@@ -834,7 +793,6 @@ SHOW USER daniel PRIVILEGES AS COMMANDS;
 | "DENY SET PROPERTY {address} ON GRAPH `healthcare` NODE Patient TO $role" |
 +---------------------------------------------------------------------------+
 ----
-====
 
 [NOTE]
 ====
@@ -879,7 +837,6 @@ To correct that, you can:
 The second option is simpler if you consider that the nurse is essentially the doctor without the `address` restrictions.
 In this case, you need to create a `nurse` role from scratch:
 
-====
 [source, cypher, role=systemdb]
 ----
 CREATE ROLE nurse
@@ -887,18 +844,15 @@ GRANT TRAVERSE ON GRAPH healthcare TO nurse;
 GRANT READ {*} ON GRAPH healthcare TO nurse;
 GRANT WRITE ON GRAPH healthcare TO nurse;
 ----
-====
 
 Now you assign the `nurse` role to the nurse Daniel, but remember to revoke the `doctor` and the `receptionist` roles so there are no privileges being overridden:
 
-====
 [source, cypher, role=systemdb]
 ----
 REVOKE ROLE doctor FROM daniel;
 REVOKE ROLE receptionist FROM daniel;
 GRANT ROLE nurse TO daniel;
 ----
-====
 
 This time, when the nurse Daniel takes another look at the patient records, they will see the `address` fields:
 
@@ -947,33 +901,28 @@ Performing this action, otherwise reserved for the `doctor` role, involves more 
 There might be nurses that should not be entrusted with this option, which is why you can divide the `nurse` role into _senior_ and _junior_ nurses, for example.
 Currently, Daniel is a senior nurse.
 
-=== Privileges of junior nurses
+=== Privileges of _junior_ `nurse`
 
 Previously, creating the `nurse` role by combining the `doctor` and `receptionist` roles led to an undesired scenario as the `DENIED` privileges of the `doctor` role overrode the `GRANTED` privileges of the `receptionist`.
 In that case, the objective was to enhance the permissions of the _senior_ nurse, but when it comes to the _junior_ nurse, they should be able to perform the same actions as the _senior_, except adding diagnoses to the database.
 
 To achieve this, you can create a special role that contains specifically only the additional restrictions:
 
-====
 [source, cypher, role=systemdb]
 ----
 CREATE ROLE disableDiagnoses;
 DENY CREATE ON GRAPH healthcare RELATIONSHIPS DIAGNOSIS TO disableDiagnoses;
 ----
-====
 
 And then assign this new role to the nurse Daniel, so you can test the behavior:
 
-====
 [source, cypher, role=systemdb]
 ----
 GRANT ROLE disableDiagnoses TO daniel;
 ----
-====
 
 If you check what privileges Daniel has now, it is the combination of the two roles `nurse` and `disableDiagnoses`:
 
-====
 [source, cypher, role=systemdb]
 ----
 neo4j@system> SHOW USER daniel PRIVILEGES AS COMMANDS;
@@ -994,7 +943,6 @@ neo4j@system> SHOW USER daniel PRIVILEGES AS COMMANDS;
 | "DENY CREATE ON GRAPH `healthcare` RELATIONSHIP DIAGNOSIS TO $role" |
 +---------------------------------------------------------------------+
 ----
-====
 
 Daniel can still see the address fields, and can even perform the diagnosis investigation that the `doctor` can perform:
 
@@ -1043,12 +991,10 @@ Create relationship with type 'DIAGNOSIS' is not allowed for user 'daniel' with 
 
 To promote Daniel back to senior nurse, revoke the role that introduced the restriction:
 
-====
 [source, cypher, role=systemdb]
 ----
 REVOKE ROLE disableDiagnoses FROM daniel;
 ----
-====
 
 === Building a custom administrator role
 
@@ -1058,7 +1004,6 @@ Instead, you can build the administrator role from the ground up.
 
 The IT administrator Tina is able to create new users and assign them to the product roles as an `itadmin`, but you can create a more restricted role called `userManager` and grant it only the appropriate privileges:
 
-====
 [source, cypher, role=systemdb]
 ----
 CREATE ROLE userManager;
@@ -1066,17 +1011,14 @@ GRANT USER MANAGEMENT ON DBMS TO userManager;
 GRANT ROLE MANAGEMENT ON DBMS TO userManager;
 GRANT SHOW PRIVILEGE ON DBMS TO userManager;
 ----
-====
 
 Test the new behavior by revoking the `itadmin` role from Tina and grant them the `userManager` role instead:
 
-====
 [source, cypher, role=systemdb]
 ----
 REVOKE ROLE itadmin FROM tina
 GRANT ROLE userManager TO tina
 ----
-====
 
 These are the privileges granted to `userManager`:
 
@@ -1086,7 +1028,6 @@ These are the privileges granted to `userManager`:
 
 Listing Tina's new privileges should now show a much shorter list than when they were a more powerful administrator with the `itadmin` role:
 
-====
 [source, cypher, role=systemdb]
 ----
 neo4j@system> SHOW USER tina PRIVILEGES AS COMMANDS;
@@ -1105,7 +1046,6 @@ neo4j@system> SHOW USER tina PRIVILEGES AS COMMANDS;
 | "GRANT SHOW PRIVILEGE ON DBMS TO $role"          |
 +--------------------------------------------------+
 ----
-====
 
 [NOTE]
 ====
@@ -1116,16 +1056,13 @@ Refer to the section link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/acc
 
 Now Tina should be able to create new users and assign them to roles:
 
-====
 [source, cypher, role=systemdb]
 ----
 CREATE USER sally SET PASSWORD 'secret' CHANGE REQUIRED;
 GRANT ROLE receptionist TO sally;
 SHOW USER sally PRIVILEGES AS COMMANDS;
 ----
-====
 
-====
 ----
 +----------------------------------------------------------------------+
 | command                                                              |
@@ -1140,5 +1077,3 @@ SHOW USER sally PRIVILEGES AS COMMANDS;
 | "GRANT DELETE ON GRAPH `healthcare` NODE Patient TO $role"           |
 +----------------------------------------------------------------------+
 ----
-====
-====


### PR DESCRIPTION
Inserting code inside boxes was generating conflicts with the formatting of sections' titles. I removed them as they are not crucial and thus we can similar conflicts in the future.

Cherry-picked from https://github.com/neo4j/docs-operations/pull/465