### PR TITLE
Adding context on why to create a temporary user

### DIFF
--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -59,7 +59,6 @@ The server may have to be considered indefinitely lost.)
 .. Run `SHOW DATABASE system`.
 If the response doesn't contain a writer, the `system` database is unavailable and needs to be recovered, continue to step 3.
 .. Optionally, you can create a temporary user to validate the `system` database's writability by running `CREATE USER 'temporaryUser' SET PASSWORD 'temporaryPassword'`.
-Make sure you have the correct access rights to do this.
 ... Confirm that the query was executed successfully and the temporary user was created as expected, by running `SHOW USERS`, then continue to xref:clustering/disaster-recovery.adoc#recover-servers[Recover servers].
 If not, continue to step 3.
 . *Restore the `system` database.*


### PR DESCRIPTION
This is an optional step and requires specific rights to be performed. Some lines about that are added now.