### PR TITLE
Changing the order of the paragraphs for clarity (#519)

### DIFF
--- a/modules/ROOT/pages/configuration/set-initial-password.adoc
+++ b/modules/ROOT/pages/configuration/set-initial-password.adoc
@@ -5,6 +5,9 @@
 Use the `set-initial-password` command of `neo4j-admin` to define the password for the native user `neo4j`.
 This must be performed before starting up the database for the first time.
 
+If the password is not set explicitly using this method, it will be set to the default password `neo4j`.
+In that case, you will be prompted to change the default password at first login.
+
 [NOTE]
 ====
 label:Neo4j-5.3[]
@@ -36,6 +39,3 @@ You will be prompted to change this password to one of your own choice at first 
 $neo4j-home> bin/neo4j-admin set-initial-password secretpassword --require-password-change
 ----
 ====
-
-If the password is not set explicitly using this method, it will be set to the default password `neo4j`.
-In that case, you will be prompted to change the default password at first login.

--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -242,4 +242,14 @@ For operating systems that are not using `systemd`, some package-specific option
 
 On Debian-based distributions, Neo4j is enabled to start automatically on system boot by default.
 
+[NOTE]
+====
+Before starting up the database for the first time, it is recommended to use the `set-initial-password` command of `neo4j-admin` to define the password for the native user `neo4j`.
+
+If the password is not set explicitly using this method, it will be set to the default password `neo4j`.
+In that case, you will be prompted to change the default password at first login. 
+
+For more information, see xref:configuration/set-initial-password.adoc[].
+====
+
 For more information on operating the Neo4j system service, see xref:installation/linux/systemd.adoc[Neo4j system service].

--- a/modules/ROOT/pages/installation/linux/rpm.adoc
+++ b/modules/ROOT/pages/installation/linux/rpm.adoc
@@ -238,4 +238,14 @@ To enable Neo4j to start automatically on system boot, run the following command
 systemctl enable neo4j
 ----
 
-For more information on operating the Neo4j system service, see xref:installation/linux/systemd.adoc[Neo4j system service].
+[NOTE]
+====
+Before starting up the database for the first time, it is recommended to use the `set-initial-password` command of `neo4j-admin` to define the password for the native user `neo4j`.
+
+If the password is not set explicitly using this method, it will be set to the default password `neo4j`.
+In that case, you will be prompted to change the default password at first login. 
+
+For more information, see xref:configuration/set-initial-password.adoc[].
+====
+
+For more information on operating the Neo4j system service, see xref:installation/linux/systemd.adoc[Neo4j system service]. 


### PR DESCRIPTION
Customer couldn't find information about the default password when installing Neo4j, so this PR changes the order of paragraphs to make it easier for readers to find that information.

---------

Cherry-picked from https://github.com/neo4j/docs-operations/pull/519