### PR TITLE
Adding note to differentiate this setting from a previous one

### DIFF
--- a/modules/ROOT/pages/reference/configuration-settings.adoc
+++ b/modules/ROOT/pages/reference/configuration-settings.adoc
@@ -2894,7 +2894,7 @@ m|+++EQUAL_NUMBERS+++
 a|Name of the default database (aliases are not supported). +
 [NOTE]
 ====
-This setting is not the same as `dbms.default_database`, which was used to set the default database on Neo4j 4 and earlier versions. 
+This setting is not the same as `dbms.default_database`, which was used to set the default database in Neo4j 4.x and earlier versions. 
 
 The `initial.dbms.default_database` setting is meant to set the default database *before* the creation of the DBMS. 
 Once it is created, the setting is not valid anymore. 


### PR DESCRIPTION
And linking to the correct procedure in case users want to set a default database, as per request.