### PR TITLE
Rename procedure

### DIFF
--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -236,7 +236,7 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :
 | label:admin-only[]
 
 // New in 5.6
-// | xref:reference/procedures.adoc#procedure_dbms_cluster_secondaryreplicationtoggle[`dbms.cluster.secondaryReplicationToggle()`]
+// | xref:reference/procedures.adoc#procedure_dbms_cluster_secondaryreplicationdisable[`dbms.cluster.secondaryReplicationDisable()`]
 // | label:no[]
 // | label:yes[]
 // | label:admin-only[]
@@ -1343,8 +1343,8 @@ m|READ
 |===
 
 // New in 5.6
-// [[procedure_dbms_cluster_secondaryreplicationtoggle]]
-// .dbms.cluster.secondaryReplicationToggle() label:enterprise-edition[] label:admin-only[]
+// [[procedure_dbms_cluster_secondaryreplicationdisable]]
+// .dbms.cluster.secondaryReplicationDisable() label:enterprise-edition[] label:admin-only[]
 // [cols="<15s,<85"]
 // |===
 // | Description
@@ -1375,17 +1375,17 @@ m|READ
 // .Pause transaction pulling for database `neo4j`
 // [source, cypher, role="noheader"]
 // ----
-// CALL dbms.cluster.secondaryReplicationToggle("neo4j", true)
+// CALL dbms.cluster.secondaryReplicationDisable("neo4j", true)
 // ----
 
 // .Resume transaction pulling for database `neo4j`
 // [source, cypher, role="noheader"]
 // ----
-// CALL dbms.cluster.secondaryReplicationToggle("neo4j", false)
+// CALL dbms.cluster.secondaryReplicationDisable("neo4j", false)
 // ----
 
 // | Signature
-// m|dbms.cluster.secondaryReplicationToggle(databaseName :: STRING?, pause :: BOOLEAN?) :: (state :: STRING?)
+// m|dbms.cluster.secondaryReplicationDisable(databaseName :: STRING?, pause :: BOOLEAN?) :: (state :: STRING?)
 // | Mode
 // m|READ
 // // | Default roles


### PR DESCRIPTION
Rename secondaryReplicationToggle -> secondaryReplicationDisable. PM decided it was a better name

https://trello.com/c/Y6fEeZZ0/128-fix-the-naming-of-dbmsclusterreadreplicatoggle