### PR TITLE
Remove the mention of a metric that doesn't exist

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/essential.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/essential.adoc
@@ -54,7 +54,7 @@ They can help with capacity planning.
 | Description
 
 | Heap usage
-| `vm.heap.used` and `vm.heap.total`
+| `vm.heap.used`
 | If Neo4j consistently uses 100% of the heap, increase the initial and max heap size.
 For more information, see xref:performance/memory-configuration.adoc[].
 


### PR DESCRIPTION
The docs were mentioning a metric that hasn't existed for a long time. We only have `vm.heap.committed`, `vm.heap.used` and `vm.heap.max`