### PR TITLE
Rename server.memory.off_heap.max_size to server.memory.off_heap.transaction_max_size

### DIFF
--- a/modules/ROOT/pages/reference/configuration-settings.adoc
+++ b/modules/ROOT/pages/reference/configuration-settings.adoc
@@ -288,7 +288,7 @@ This setting will be deprecated in favour of <<config_dbms.max_databases,`dbms.m
 |<<config_server.memory.heap.max_size,server.memory.heap.max_size>>|Maximum heap size.
 |<<config_server.memory.off_heap.block_cache_size,server.memory.off_heap.block_cache_size>>|Defines the size of the off-heap memory blocks cache.
 |<<config_server.memory.off_heap.max_cacheable_block_size,server.memory.off_heap.max_cacheable_block_size>>|Defines the maximum size of an off-heap memory block that can be cached to speed up allocations.
-|<<config_server.memory.off_heap.max_size,server.memory.off_heap.max_size>>|The maximum amount of off-heap memory that can be used to store transaction state data; it's a total amount of memory shared across all active transactions.
+|<<config_server.memory.off_heap.transaction_max_size,server.memory.off_heap.transaction_max_size>>|The maximum amount of off-heap memory that can be used to store transaction state data; it's a total amount of memory shared across all active transactions.
 |<<config_server.memory.pagecache.directio,server.memory.pagecache.directio>>|Use direct I/O for page cache.
 |<<config_server.memory.pagecache.flush.buffer.enabled,server.memory.pagecache.flush.buffer.enabled>>|Page cache can be configured to use a temporal buffer for flushing purposes.
 |<<config_server.memory.pagecache.flush.buffer.size_in_pages,server.memory.pagecache.flush.buffer.size_in_pages>>|Page cache can be configured to use a temporal buffer for flushing purposes.
@@ -594,7 +594,7 @@ This setting will be deprecated in favour of <<config_dbms.max_databases,`dbms.m
 * <<config_server.memory.heap.max_size,server.memory.heap.max_size>>: Maximum heap size.
 * <<config_server.memory.off_heap.block_cache_size,server.memory.off_heap.block_cache_size>>: Defines the size of the off-heap memory blocks cache.
 * <<config_server.memory.off_heap.max_cacheable_block_size,server.memory.off_heap.max_cacheable_block_size>>: Defines the maximum size of an off-heap memory block that can be cached to speed up allocations.
-* <<config_server.memory.off_heap.max_size,server.memory.off_heap.max_size>>: The maximum amount of off-heap memory that can be used to store transaction state data; it's a total amount of memory shared across all active transactions.
+* <<config_server.memory.off_heap.transaction_max_size,server.memory.off_heap.transaction_max_size>>: The maximum amount of off-heap memory that can be used to store transaction state data; it's a total amount of memory shared across all active transactions.
 * <<config_server.memory.pagecache.directio,server.memory.pagecache.directio>>: Use direct I/O for page cache.
 * <<config_server.memory.pagecache.flush.buffer.enabled,server.memory.pagecache.flush.buffer.enabled>>: Page cache can be configured to use a temporal buffer for flushing purposes.
 * <<config_server.memory.pagecache.flush.buffer.size_in_pages,server.memory.pagecache.flush.buffer.size_in_pages>>: Page cache can be configured to use a temporal buffer for flushing purposes.
@@ -3792,14 +3792,14 @@ a|server.memory.off_heap.max_cacheable_block_size, a byte size (valid multiplier
 m|+++512.00KiB+++
 |===
 
-[[config_server.memory.off_heap.max_size]]
-.server.memory.off_heap.max_size
+[[config_server.memory.off_heap.transaction_max_size]]
+.server.memory.off_heap.transaction_max_size
 [cols="<1s,<4"]
 |===
 |Description
 a|The maximum amount of off-heap memory that can be used to store transaction state data; it's a total amount of memory shared across all active transactions. Zero means 'unlimited'. Used when <<config_db.tx_state.memory_allocation,db.tx_state.memory_allocation>> is set to 'OFF_HEAP'.
 |Valid values
-a|server.memory.off_heap.max_size, a byte size (valid multipliers are `B`, `KiB`, `KB`, `K`, `kB`, `kb`, `k`, `MiB`, `MB`, `M`, `mB`, `mb`, `m`, `GiB`, `GB`, `G`, `gB`, `gb`, `g`, `TiB`, `TB`, `PiB`, `PB`, `EiB`, `EB`) which is minimum `0B`
+a|server.memory.off_heap.transaction_max_size, a byte size (valid multipliers are `B`, `KiB`, `KB`, `K`, `kB`, `kb`, `k`, `MiB`, `MB`, `M`, `mB`, `mb`, `m`, `GiB`, `GB`, `G`, `gB`, `gb`, `g`, `TiB`, `TB`, `PiB`, `PB`, `EiB`, `EB`) which is minimum `0B`
 |Default value
 m|+++2.00GiB+++
 |===


### PR DESCRIPTION
The off-heap memory block contains a lot more than transaction state (netty, lucene etc.) so the config setting 'server.memory.off_heap.max_size' has been renamed to 'server.memory.off_heap.transaction_max_size' to make it clearer that it only applies to transaction state.