### PR TITLE
Removing information no longer correct (#577)

### DIFF
--- a/modules/ROOT/pages/reference/configuration-settings.adoc
+++ b/modules/ROOT/pages/reference/configuration-settings.adoc
@@ -3646,7 +3646,7 @@ m|+++:7473+++
 [cols="<1s,<4"]
 |===
 |Description
-a|Additional JVM arguments. Argument order can be significant. To use a Java commercial feature, the argument to unlock commercial features must precede the argument to enable the specific feature in the config value string. For example, to use Flight Recorder, `-XX:+UnlockCommercialFeatures` must come before `-XX:+FlightRecorder`.
+a|Additional JVM arguments. Argument order can be significant. To use a Java commercial feature, the argument to unlock commercial features must precede the argument to enable the specific feature in the config value string.
 |Valid values
 a|server.jvm.additional, one or more jvm arguments
 |===


### PR DESCRIPTION
This was valid until Java 8, 11 or higher no longer align to this.

Cherry-picked from https://github.com/neo4j/docs-operations/pull/577#pullrequestreview-1343807015