### PR TITLE
Remove the asterisks in the Cypher Shell example

### DIFF
--- a/modules/ROOT/pages/tools/cypher-shell.adoc
+++ b/modules/ROOT/pages/tools/cypher-shell.adoc
@@ -261,22 +261,22 @@ The output is the following:
 [queryresult]
 ----
 Available commands:
-  *:begin*       Open a transaction
-  *:commit*      Commit the currently open transaction
-  *:connect*     Connects to a database
-  *:disconnect*  Disconnects from database
-  *:exit*        Exit the logger
-  *:help*        Show this help message
-  *:history*     Statement history
-  *:impersonate* Impersonate user
-  *:param*       Set the value of a query parameter
-  *:params*      Print all query parameter values
-  *:rollback*    Rollback the currently open transaction
-  *:source*      Executes Cypher statements from a file
-  *:use*         Set the active database
+  :begin        Open a transaction
+  :commit       Commit the currently open transaction
+  :connect      Connects to a database
+  :disconnect   Disconnects from database
+  :exit         Exit the logger
+  :help         Show this help message
+  :history      Statement history
+  :impersonate  Impersonate user
+  :param        Set the value of a query parameter
+  :params       Print all query parameter values
+  :rollback     Rollback the currently open transaction
+  :source       Executes Cypher statements from a file
+  :use          Set the active database
 
 For help on a specific command type:
-    :help *command*
+    :help command
 
 Keyboard shortcuts:
     Up and down arrows to access statement history.


### PR DESCRIPTION
It looks like this syntax was introduced when we created the first 5.0 branch, and it's not included in v4.4 docs.

The output looks quite misleading, so this PR removed the syntax. It needs to be merged into `dev`, and cherry-picked to `5.x`.