### PR TITLE
Reverting the changes

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/expose.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/expose.adoc
@@ -95,10 +95,10 @@ When Neo4j is fully started, a Prometheus endpoint will be available at the conf
 [WARNING]
 ====
 You should never expose the Prometheus endpoint directly to the Internet. 
-If security is of paramount importance, you should set `server.metrics.prometheus.endpoint=localhost:2004` and configure a reverse HTTP proxy on the same machine that handles the authentication, SSL, caching, etc. 
+If security is of paramount importance, you should set `metrics.prometheus.endpoint=localhost:2004` and configure a reverse HTTP proxy on the same machine that handles the authentication, SSL, caching, etc. 
 ====
-If you can afford to send unencrypted metrics within the internal network, such as `server.metrics.prometheus.endpoint=10.0.0.123:2004`, all servers within the same netmask will be able to access it.
+If you can afford to send unencrypted metrics within the internal network, such as `metrics.prometheus.endpoint=10.0.0.123:2004`, all servers within the same netmask will be able to access it.
 
-If you specify anything more permissible, such as `server.metrics.prometheus.endpoint=0.0.0.0:2004`, you should have a firewall rule to prevent any unauthorized access. 
+If you specify anything more permissible, such as `metrics.prometheus.endpoint=0.0.0.0:2004`, you should have a firewall rule to prevent any unauthorized access. 
 Data in transit will still not be encrypted, so it should never go other any insecure networks.
 

--- a/modules/ROOT/partials/neo4j-config/all-settings.adoc
+++ b/modules/ROOT/partials/neo4j-config/all-settings.adoc
@@ -5825,7 +5825,7 @@ m|+++false+++
 |Description
 a|The hostname and port to use as Prometheus endpoint.
 |Valid values
-a|metrics.prometheus.endpoint, a socket address in the format `hostname:port`, `hostname`, or `:port`. If missing, port and hostname are acquired from `server.default_listen_address`.
+a|metrics.prometheus.endpoint, a socket address in the format `hostname:port`, `hostname`, or `:port`. If missing, port and hostname are acquired from `dbms.default_listen_address`.
 |Default value
 m|+++localhost:2004+++
 |===


### PR DESCRIPTION
Reverting changes from the cherry-pick https://github.com/neo4j/docs-operations/pull/610 which was using new nomenclature to the settings. This is correcting them to the way they used to be called before 5.