### PR TITLE
Adding more context to the `sub` information on the SSO tutorial

### DIFF
--- a/modules/ROOT/pages/tutorial/tutorial-sso-configuration.adoc
+++ b/modules/ROOT/pages/tutorial/tutorial-sso-configuration.adoc
@@ -26,9 +26,9 @@ SSO works in the following way:
 +
 [IMPORTANT]
 ====
-JWT must *always* contain a value for `sub`.
+JWTs must *always* contain a value for `sub` even when using a different claim for `username`.
 It is the only claim guaranteed to be unique and stable. 
-Other claims, such as `email` or `preferred_username` may change over time and should *not* be used for authentication.
+Other claims, such as `email` or `preferred_username` are less secure and may change over time. They should *not* be used for authentication.
 Neo4j may assign permissions to a user based on this username value in a hybrid authorization configuration. 
 Thus, changing the username claim from `sub` is not recommended.
 ====

--- a/modules/ROOT/pages/tutorial/tutorial-sso-configuration.adoc
+++ b/modules/ROOT/pages/tutorial/tutorial-sso-configuration.adoc
@@ -23,6 +23,15 @@ SSO works in the following way:
 . The client (e.g., Bloom, Neo4j Browser, etc.) asks the user for credentials and contacts the identity provider.
 . The identity provider responds with a JSON Web Token (JWT), a JSON file containing fields (claims) relative to the user (email, audience, groups, etc.).
 . The client provides the server with the JWT, and the server verifies its signature with the JWKs.
++
+[IMPORTANT]
+====
+JWT must *always* contain a value for `sub`.
+It is the only claim guaranteed to be unique and stable. 
+Other claims, such as `email` or `preferred_username` may change over time and should *not* be used for authentication.
+Neo4j may assign permissions to a user based on this username value in a hybrid authorization configuration. 
+Thus, changing the username claim from `sub` is not recommended.
+====
 
 == Okta
 
@@ -165,9 +174,6 @@ dbms.security.oidc.azure.config=token_type_principal=id_token;token_type_authent
 [IMPORTANT]
 ====
 `sub` is the only claim guaranteed to be unique and stable. 
-Other claims, such as `email` or `preferred_username`, may change over time and should *not* be used for authentication. 
-Neo4j may assign permissions to a user based on this username value in a hybrid authorization configuration. 
-Thus, changing the username claim from `sub` is not recommended. 
 For details, see https://learn.microsoft.com/en-us/azure/active-directory/develop/id-tokens#using-claims-to-reliably-identify-a-user-subject-and-object-id[Microsoft documentation] as well as the https://openid.net/specs/openid-connect-core-1_0.html#ClaimStability[OpenId spec].
 ====
 +

--- a/modules/ROOT/pages/tutorial/tutorial-sso-configuration.adoc
+++ b/modules/ROOT/pages/tutorial/tutorial-sso-configuration.adoc
@@ -28,7 +28,8 @@ SSO works in the following way:
 ====
 JWTs must *always* contain a value for `sub` even when using a different claim for `username`.
 It is the only claim guaranteed to be unique and stable. 
-Other claims, such as `email` or `preferred_username` are less secure and may change over time. They should *not* be used for authentication.
+Other claims, such as `email` or `preferred_username` are less secure and may change over time.
+They should *not* be used for authentication.
 Neo4j may assign permissions to a user based on this username value in a hybrid authorization configuration. 
 Thus, changing the username claim from `sub` is not recommended.
 ====


### PR DESCRIPTION
This PR is an updated version of this one https://github.com/neo4j/docs-operations/pull/608 after the detachment of forks. 