### PR TITLE
Add database state metrics

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -148,7 +148,7 @@ By default, database metrics include:
 [options="header",cols="<3m,<4"]
 |===
 |Name |Description
-|<prefix>.db.state.count.hosted|Databases hosted on this server. Databases in states started, store copying, or draining are considered hosted. (gauge)
+|<prefix>.db.state.count.hosted|Databases hosted on this server. Databases in states `started`, `store copying`, or `draining` are considered hosted. (gauge)
 |<prefix>.db.state.count.failed|Databases in a failed state on this server. (gauge)
 |<prefix>.db.state.count.desired_started|Databases that desire to be started on this server. (gauge)
 |===

--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -145,6 +145,14 @@ By default, database metrics include:
 |<prefix>.db.operation.count.recovered|Count of database operations that failed previously but have recovered. (counter)
 |===
 
+[options="header",cols="<3m,<4"]
+|===
+|Name |Description
+|<prefix>.db.state.count.hosted|Databases hosted on this server. Databases in states started, store copying, or draining are considered hosted. (gauge)
+|<prefix>.db.state.count.failed|Databases in a failed state on this server. (gauge)
+|<prefix>.db.state.count.desired_started|Databases that desire to be started on this server. (gauge)
+|===
+
 .Database data metrics
 
 [options="header",cols="<3m,<4"]


### PR DESCRIPTION
We have recently introduced metrics that track the states databases are in on a server. This PR updates the docs to reflect this.