### PR TITLE
Fix typo in docker introduction

### DIFF
--- a/modules/ROOT/pages/docker/introduction.adoc
+++ b/modules/ROOT/pages/docker/introduction.adoc
@@ -72,7 +72,7 @@ docker run \
 
 [NOTE]
 ====
-With no persistent storage for the databases, `NEO4J_ATUH` takes effect each time the container is recreated, even if you have changed the password.
+With no persistent storage for the databases, `NEO4J_AUTH` takes effect each time the container is recreated, even if you have changed the password.
 
 However, with persistent storage for the databases, `NEO4J_AUTH` only takes effect on the initial startup.
 It is ignored when the container is recreated and cannot override a changed password.


### PR DESCRIPTION
The environment variable `NEO4J_AUTH` was spelled as `NEO4J_ATUH`
Cherry-picked from #651 