### PR TITLE
Add page monitoring cluster endpoints to the index

### DIFF
--- a/modules/ROOT/pages/clustering/index.adoc
+++ b/modules/ROOT/pages/clustering/index.adoc
@@ -16,6 +16,7 @@ This chapter describes the following:
 * Monitoring -- Monitoring of a cluster.
 ** xref:clustering/monitoring/show-servers-monitoring.adoc[Monitoring servers] -- The tools available for monitoring the servers in a cluster.
 ** xref:clustering/monitoring/show-databases-monitoring.adoc[Monitoring databases] -- The tools available for monitoring the databases in a cluster.
+** xref:clustering/monitoring/endpoints.adoc[Monitor cluster endpoints for status information] -- The endpoints and semantics of endpoints used to monitor the health of the cluster.
 * xref:clustering/disaster-recovery.adoc[Disaster recovery] -- How to recover a cluster in the event of a disaster.
 * xref:clustering/settings.adoc[Settings reference] -- A summary of the most important cluster settings.
 // * xref:clustering/clustering-advanced/index.adoc[Advanced clustering] -- Some more advanced features of Neo4j clusters.


### PR DESCRIPTION
It wasn't listed in the table of contents there though the page is in the left-side menu 