### PR TITLE
Docker additional configuration settings via an environment variable for JVM no longer override the default JVM configurations

### DIFF
--- a/modules/ROOT/pages/docker/configuration.adoc
+++ b/modules/ROOT/pages/docker/configuration.adoc
@@ -52,6 +52,11 @@ For example:
 --env NEO4J_server_jvm_additional="-Dcom.sun.management.jmxremote.authenticate=true -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.password.file=$HOME/conf/jmx.password -Dcom.sun.management.jmxremote.access.file=$HOME/conf/jmx.access -Dcom.sun.management.jmxremote.port=3637"
 ----
 
+[NOTE]
+====
+From Neo4j 5.6 onwards, Docker additional configuration settings via an environment variable for JVM no longer override the default JVM configurations but are appended to them.
+====
+
 [[docker-conf-volume]]
 == Mounting the _/conf_ volume
 


### PR DESCRIPTION
Cherry-picked from #669 