### PR TITLE
Better document the username and groups config items (#674)

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
@@ -114,12 +114,12 @@ The default is `false`, to read the claim from the token.
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.claims.username[dbms.security.oidc.<provider>.claims.username]
 | sub
 | true
-| The claim to use for the database username.
+| The claim to use for the database username. Neo4j expects to find a string claim in the JWT or user_info response with this name.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.claims.groups[dbms.security.oidc.<provider>.claims.groups]
 |
 | true
-| The claim to use for the database roles.
+| The claim to use for the database roles. Neo4j expects to find a claim in the JWT or user_info response with this name. The claim may be a string claim representing a single role or a string array claim representing multiple roles.
 
 | xref:reference/configuration-settings.adoc#config_dbms.security.oidc.-provider-.authorization.group_to_role_mapping[dbms.security.oidc.<provider>.authorization.group_to_role_mapping]
 |
@@ -247,7 +247,7 @@ dbms.security.oidc.mysso.claims.client_id=myclientid
 . Configure Claims:
 +
 Provide the name of the claims that map to the database username and roles.
-`username` is expected to be a string claim and `roles` is expected to be a list of strings.
+`username` is expected to be a string claim, and `roles` is expected to be a list of strings representing a set of roles or a single string representing a single role.
 +
 [source, properties]
 ----


### PR DESCRIPTION
The groups config item gained support for a single string in 5.4.0 so we should reflect that. Also explain in more detail what is supported.

Cherry-picked from #674 