### PR TITLE
Update disaster recovery guide to reflect error message change

### DIFF
--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -117,7 +117,7 @@ If *all* servers show health `AVAILABLE` and status `ENABLED` continue to xref:c
 . On each `UNAVAILABLE` server, run `CALL dbms.cluster.cordonServer("unavailable-server-id")`.
 . On each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id`.
 . On each server that failed to deallocate with one of the following messages:
-.. `Could not deallocate server [server]. Can't move databases in single mode [database]`
+.. `Could not deallocate server [server]. Can't move databases with only one primary [database]`
 +
 or
 +

--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -117,7 +117,7 @@ If *all* servers show health `AVAILABLE` and status `ENABLED` continue to xref:c
 . On each `UNAVAILABLE` server, run `CALL dbms.cluster.cordonServer("unavailable-server-id")`.
 . On each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id`.
 . On each server that failed to deallocate with one of the following messages:
-.. `Could not deallocate server [server]. Can't move databases with only one primary [database]`
+.. `Could not deallocate server [server]. Can't move databases with only one primary [database].`
 +
 or
 +


### PR DESCRIPTION
Recently in 5.7 we updated the error message when attempting to deallocate a server hosting a database with only 1 primary. This PR updates the disaster recovery guide to reflect this. 