### PR TITLE
Removing information no longer correct (#577) (#580)

### DIFF
--- a/modules/ROOT/pages/clustering/servers.adoc
+++ b/modules/ROOT/pages/clustering/servers.adoc
@@ -268,8 +268,8 @@ For instance if `SET OPTIONS {modeConstraint:'SECONDARY'}` is executed followed 
 
 === Renaming a server
 
-When first discovered and enabled, a server's name defaults to the value of its generated server ID.
-However, this can be changed later using the following command:
+When first discovered, a server's name defaults to the value of its generated server ID.
+However, as long as the server is enabled, this can be changed later using the following command:
 
 [source,cypher]
 ----


### PR DESCRIPTION
This was valid until Java 8, 11 or higher no longer align to this.

Cherry-picked from
https://github.com/neo4j/docs-operations/pull/577#pullrequestreview-1343807015