### PR TITLE
updated section about if java 19 is accidentally installed

### DIFF
--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -73,41 +73,6 @@ sudo update-java-alternatives --jre --set <java17name>
 
 . Confirm which version of Java is the default using `java -version` again.
 
-[[debian-install-newer-java]]
-=== If `apt` installed OpenJDK 19
-
-On newer Debian or Ubuntu operating systems, Java 19 is available by default, and `apt` may have installed OpenJDK 19, *even if Java 17 was already installed*.
-
-If this happens, you will see this warning on Neo4j start:
-[output]
-----
-WARNING! You are using an unsupported Java runtime.
-* Please use Oracle(R) Java(TM) 17, OpenJDK(TM) 17 to run Neo4j.
-* Please see https://neo4j.com/docs/ for Neo4j installation instructions.
-----
-
-To fix this, you can install Java 17 manually, uninstall OpenJDK 19, or set Java 17 as the default.
-
-* Install OpenJDK 17 manually:
-+
-[source, shell, subs="attributes"]
-----
-sudo apt install openjdk-17-jre
-----
-+
-For other distributions of Java 17, see
-xref:installation/linux/debian.adoc#debian-prerequisites-notopenjdk[instructions for setting up java pre-requisites].
-
-* Uninstall OpenJDK 19:
-+
-[source, shell, subs="attributes"]
-----
-sudo apt remove openjdk-19-jre-headless
-----
-
-* Alternatively, if you want to keep OpenJDK 19 installed, follow the instructions in the section for
-xref:installation/linux/debian.adoc#multiple-java-versions[Dealing with multiple installed Java versions] to set Java 17 as the default java version.
-
 [[debian-installation]]
 == Installation
 
@@ -208,6 +173,44 @@ echo "neo4j-enterprise neo4j/accept-license select Accept commercial license" | 
 echo "neo4j-enterprise neo4j/question select I ACCEPT" | sudo debconf-set-selections
 echo "neo4j-enterprise neo4j/license note" | sudo debconf-set-selections
 ----
+
+[[debian-install-newer-java]]
+=== Verify Correct Java is Installed
+
+On newer Debian or Ubuntu operating systems, Java 19 is available by default, and `apt` may have installed OpenJDK 19, *even if Java 17 was already installed*.
+
+If this happens, you will see this warning on Neo4j start:
+[output]
+----
+WARNING! You are using an unsupported Java runtime.
+* Please use Oracle(R) Java(TM) 17, OpenJDK(TM) 17 to run Neo4j.
+* Please see https://neo4j.com/docs/ for Neo4j installation instructions.
+----
+
+To fix this, you can install Java 17 manually, then either uninstall OpenJDK 19, or set Java 17 as the default.
+
+To install OpenJDK 17 manually:
++
+[source, shell, subs="attributes"]
+----
+sudo apt install openjdk-17-jre
+----
++
+For other distributions of Java 17, see
+xref:installation/linux/debian.adoc#debian-prerequisites-notopenjdk[instructions for setting up java pre-requisites].
+
+* Uninstall OpenJDK 19:
++
+[source, shell, subs="attributes"]
+----
+sudo apt remove openjdk-19-jre-headless
+----
+
+* Set Java 17 as default:
++
+If you want to keep OpenJDK 19 installed, follow the instructions in the section for
+xref:installation/linux/debian.adoc#multiple-java-versions[Dealing with multiple installed Java versions] to set Java 17 as the default java version.
+
 
 [[debian-offline-installation]]
 == Offline installation


### PR DESCRIPTION
I moved the section to AFTER installation instead of the java pre-requisites because it's something that will only happen *after* neo4j is installed.