### PR TITLE
server.db.query_cache_size has been deprecated in 5.7 (#726)

### DIFF
--- a/modules/ROOT/pages/reference/configuration-settings.adoc
+++ b/modules/ROOT/pages/reference/configuration-settings.adoc
@@ -246,7 +246,8 @@ If this is set to `false` (default), the search for group membership will be per
 |<<config_server.databases.default_to_read_only,server.databases.default_to_read_only>>|Whether or not any database on this instance are read_only by default.
 |<<config_server.databases.read_only,server.databases.read_only>>|List of databases for which to prevent write queries.
 |<<config_server.databases.writable,server.databases.writable>>|List of databases for which to allow write queries.
-|<<config_server.db.query_cache_size,server.db.query_cache_size>>|The number of cached Cypher query execution plans per database.
+|<<config_server.db.query_cache_size,server.db.query_cache_size>>|label:deprecated[Deprecated in 5.7]The number of cached Cypher query execution plans per database.
+Replaced by <<config_server.memory.query_cache.per_db_cache_num_entries,`server.memory.query_cache.per_db_cache_num_entries`>>.
 |<<config_server.default_advertised_address,server.default_advertised_address>>|Default hostname or IP address the server uses to advertise itself.
 |<<config_server.default_listen_address,server.default_listen_address>>|Default network interface to listen for incoming connections.
 |<<config_server.directories.cluster_state,server.directories.cluster_state>>|label:enterprise-edition[Enterprise only]Directory to hold cluster state including Raft log.
@@ -3328,6 +3329,8 @@ a|The number of cached Cypher query execution plans per database. The max number
 a|server.db.query_cache_size, an integer which is minimum `0`
 |Default value
 m|+++1000+++
+|Deprecated
+a|The `server.db.query_cache_size` configuration setting has been deprecated in favour of <<config_server.memory.query_cache.per_db_cache_num_entries,`server.memory.query_cache.per_db_cache_num_entries`>>.
 |===
 
 [[config_server.default_advertised_address]]
@@ -3890,7 +3893,7 @@ a|server.memory.query_cache.sharing_enabled, a boolean
 m|+++false+++
 |===
 
-[[config_server.memory.query_cache.shared_cache_num_entried]]
+[[config_server.memory.query_cache.shared_cache_num_entries]]
 .server.memory.query_cache.shared_cache_num_entries
 [cols="<1s,<4"]
 |===


### PR DESCRIPTION
Cherry-picked from #726 