### PR TITLE
Removing sentence as requested

### DIFF
--- a/modules/ROOT/pages/clustering/internals.adoc
+++ b/modules/ROOT/pages/clustering/internals.adoc
@@ -229,7 +229,6 @@ The biggest difference is the existence of an additional cluster state.
 Most of the files there are relatively small, but the Raft logs can become quite large depending on the configuration and workload.
 
 It is important to understand that once a database has been extracted from a cluster and used in a standalone deployment, it must not be put back into an operational cluster.
-This is because the cluster and the standalone deployment now have separate databases, with different and irreconcilable writes applied to them.
 
 [WARNING]
 ====


### PR DESCRIPTION
It alone does not communicate much meaning, so removing this for now as more context is provided.