### PR TITLE
Removing link to backports as it is broken (#762)

### DIFF
--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -12,12 +12,11 @@ To install Neo4j on Debian you need to make sure of the following:
 
 
 [[debian-ubuntu-prerequisites]]
-=== Java Prerequisites (Oracle Java, Debian 9+ and Ubuntu 16.04+ only)
+=== Java Prerequisites (Oracle Java and Ubuntu 16.04+ only)
 
 Neo4j {neo4j-version} requires the Java 11 runtime.
-Java 11 is not included in Ubuntu 16.04 LTS or Debian 9 (stretch) and will have to be set up manually prior to installing or upgrading to Neo4j {neo4j-version}, as described below.
-Debian 9 users can find OpenJDK 11 in https://packages.debian.org/stretch-backports/openjdk-11-jdk[backports].
-Debian 10 and Ubuntu 18.04 onwards already have the Openjdk Java 11 package available through `apt`.
+Java 11 is not included in Ubuntu 16.04 LTS and will have to be set up manually prior to installing or upgrading to Neo4j {neo4j-version}, as described below.
+Ubuntu 18.04 onwards already has the Openjdk Java 11 package available through `apt`.
 
 
 [[debian-oraclejava]]
@@ -27,13 +26,6 @@ Neo4j is compatible with Oracle Java on Debian/Ubuntu Linux, but should be insta
 The Debian installer may still be used, but it will install OpenJDK Java 11 in addition to any existing Java installations.
 
 This is due to changes in Oracle's Debian package manifest between Java versions 8 and 11.
-
-
-[[debian-java]]
-==== Java 11 on Debian 9
-
-Java 11 must be installed before installing Neo4j on Debian 9 (stretch) systems.
-If you do not already have Java 11 installed, run the following commands to install OpenJDK Java 11:
 
 [source, shell]
 ----

--- a/modules/ROOT/pages/installation/requirements.adoc
+++ b/modules/ROOT/pages/installation/requirements.adoc
@@ -82,7 +82,7 @@ For personal use and software development:
 | Operating System                        | Supported JDK
 | *MacOS 10.14+*                          | ZuluJDK 11
 | *Ubuntu Desktop 16.04+*                 | OpenJDK 11, OracleJDK 11, and ZuluJDK 11
-| *Debian 9+*                             | OpenJDK 11, OracleJDK 11, and ZuluJDK 11
+| *Debian 10+*                            | OpenJDK 11, OracleJDK 11, and ZuluJDK 11
 | *SuSE 15+*                              | Oracle JDK 11
 | *Windows 10*                            | OracleJDK 11 and ZuluJDK 11
 |===


### PR DESCRIPTION
In 5.x, the link is not included anymore, thus the decision to remove it here.

Cherry-picked from https://github.com/neo4j/docs-operations/pull/762