### PR TITLE
Sync `neo4j-admin` commands (Tools section) with help pages

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/consistency-checker.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/consistency-checker.adoc
@@ -15,7 +15,7 @@ neo4j-admin database check [-h] [--expand-commands] [--force] [--verbose]
                            [--check-counts[=true|false]] [--check-graph[=true|false]]
                            [--check-indexes[=true|false]] [--check-property-owners[=true|false]]
                            [--additional-config=<file>] [--max-off-heap-memory=<size>]
-                           [--report-path=<path>][--threads=<number of threads>]
+                           [--report-path=<path>] [--threads=<number of threads>]
                            [[--from-path-data=<path> --from-path-txn=<path>] | [--from-path=<path> [--temp-path=<path>]]]
                            <database>
 ----
@@ -73,7 +73,7 @@ The `neo4j-admin database check` command has the following options:
 |
 
 |--force
-| `Force a consistency check to be run, despite resources, and may run a more thorough check.
+| Force a consistency check to be run, despite resources, and may run a more thorough check.
 |
 
 |--check-indexes[=true\|false]
@@ -114,11 +114,11 @@ Value can be plain numbers, like `10000000` or e.g. `20G` for 20 gigabytes, or e
 | xref:reference/configuration-settings.adoc#config_server.directories.transaction.logs.root[`server.directories.transaction.logs.root`]
 
 |--from-path=<path>
-|Path to a directory containing dump/backup artifacts to check the consistency of.
+|Path to directory containing dump/backup artifacts to check the consistency of.
 |
 
 |--temp-path=<path>
-|Path to a directory to be used as a staging area to extract dump/backup artifacts, if needed.
+|Path to directory to be used as a staging area to extract dump/backup artifacts, if needed.
 |<from-path>
 |===
 

--- a/modules/ROOT/pages/tools/neo4j-admin/migrate-database.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/migrate-database.adoc
@@ -38,7 +38,7 @@ The `neo4j-admin database migrate` command is run only on a stopped database.
 | Description
 
 |<database>
-|Name of the database to migrate. Can contain `\*` and `?` for globbing. Note that `*` and `?` have special, meaning in some shells and might need to be escaped or used with quotes.
+|Name of the database to migrate. Can contain `\*` and `?` for globbing. Note that `*` and `?` have special meaning in some shells and might need to be escaped or used with quotes.
 |===
 
 === Options

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -118,7 +118,7 @@ For more information, please contact Neo4j Professional Services.
 |
 
 |--array-delimiter=<char>
-|Delimiter character between array elements within a value in CSV data. Also accepts 'TAB' and 'U+20AC' for specifying a character using Unicode.
+|Delimiter character between array elements within a value in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
 * ASCII character -- e.g. `--array-delimiter=";"`.

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -144,7 +144,7 @@ Format errors in input data are still treated as errors.
 |1000
 
 |--delimiter=<char>
-|Delimiter character between values in CSV data. Also accepts 'TAB' and e.g. 'U+20AC' for specifying a character using Unicode.
+|Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
 * ASCII character -- e.g. `--delimiter=","`.
@@ -187,11 +187,11 @@ Possible values are:
 * `actual` -- (advanced) actual node IDs.
 |string
 
-|--ignore-empty-strings[=<true\|false>]
+|--ignore-empty-strings[=true\|false]
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=<true\|false>]
+|--ignore-extra-columns[=true\|false]
 |If unspecified columns should be ignored during the import.
 |false
 
@@ -199,18 +199,18 @@ Possible values are:
 |Character set that input data is encoded in.
 |UTF-8
 
-|--legacy-style-quoting[=<true\|false>]
+|--legacy-style-quoting[=true\|false]
 |Whether or not a backslash-escaped quote e.g. \" is interpreted as an inner quote.
 |false
 
 |--max-off-heap-memory=<size>
-|Maximum off-heap memory that `neo4j-admin` can use for various data structures and caching to improve performance.
+|Maximum memory that `neo4j-admin` can use for various data structures and caching to improve performance.
 
 Values can be plain numbers such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields[=<true\|false>]
+|--multiline-fields[=true\|false]
 |Whether or not fields from an input source can span multiple lines, i.e. contain newline characters.
 
 Setting `--multiline-fields=true` can severely degrade the performance of the importer.
@@ -228,7 +228,7 @@ Therefore, use it with care, especially with large imports.
 For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |
 
-|--normalize-types[=<true\|false>]
+|--normalize-types[=true\|false]
 |Whether or not to normalize property types to Cypher types, e.g. `int` becomes `long` and `float` becomes `double`.
 |true
 
@@ -247,8 +247,8 @@ You cannot escape using `\`.
 |--read-buffer-size=<size>
 |Size of each buffer for reading input data.
 
-It has to at least be large enough to hold the biggest single value in the input data.
-Value can be a plain number or byte units string, e.g. `128k`, `1m`.
+It has to be at least large enough to hold the biggest single value in the input data.
+The value can be a plain number or a byte units string, e.g. `128k`, `1m`.
 |4194304
 
 |--relationships=[<type>=]<files>...
@@ -276,25 +276,25 @@ If you need to debug the import, it might be useful to collect the stack trace.
 This is done by using the `--verbose` option.
 |import.report
 
-|--skip-bad-entries-logging[=<true\|false>]
+|--skip-bad-entries-logging[=true\|false]
 |Whether or not to skip logging bad entries detected during import.
 |false
 
-|--skip-bad-relationships[=<true\|false>]
+|--skip-bad-relationships[=true\|false]
 |Whether or not to skip importing relationships that refer to missing node IDs, i.e. either start or end node ID/group referring to a node that was not specified by the node input data.
 
-Skipped relationships will be logged, containing at most the number of entities specified by `--bad-tolerance` unless otherwise specified by the `--skip-bad-entries-logging` option.
+Skipped relationships will be logged, containing at most the number of entities specified by `--bad-tolerance`, unless otherwise specified by the `--skip-bad-entries-logging` option.
 |false
 
-|--skip-duplicate-nodes[=<true/false>]
+|--skip-duplicate-nodes[=true\|false]
 |Whether or not to skip importing nodes that have the same ID/group.
 
 In the event of multiple nodes within the same group having the same ID, the first encountered will be imported, whereas consecutive such nodes will be skipped.
 
-Skipped nodes will be logged, containing at most the number of entities specified by `--bad-tolerance` unless otherwise specified by the `--skip-bad-entries-logging` option.
+Skipped nodes will be logged, containing at most the number of entities specified by `--bad-tolerance`, unless otherwise specified by the `--skip-bad-entries-logging` option.
 |false
 
-|--strict[=<true\|false>]
+|--strict[=<true/false>]
 |Whether or not the lookup of nodes referred to from relationships needs to be checked strict.
 If disabled, most but not all relationships referring to non-existent nodes will be detected.
 If enabled all those relationships will be found but at the cost of lower performance.
@@ -303,9 +303,9 @@ If enabled all those relationships will be found but at the cost of lower perfor
 |--threads=<num>
 | (advanced) Max number of worker threads used by the importer. Defaults to the number of available processors reported by the JVM. There is a certain amount of minimum threads needed so for that reason there is no lower bound for this value. For optimal
 performance, this value should not be greater than the number of available processors.
-|10
+|20
 
-|--trim-strings[=<true\|false>]
+|--trim-strings[=true\|false]
 |Whether or not strings should be trimmed for whitespaces.
 |false
 

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -206,7 +206,7 @@ Possible values are:
 |--max-off-heap-memory=<size>
 |Maximum memory that `neo4j-admin` can use for various data structures and caching to improve performance.
 
-Values can be plain numbers such as `10000000`, or `20G` for 20 gigabytes.
+Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
@@ -489,7 +489,7 @@ If the database into which you import does not exist prior to importing, you mus
 |
 
 |--array-delimiter=<char>
-|Delimiter character between array elements within a value in CSV data. Also accepts 'TAB' and 'U+20AC' for specifying a character using Unicode.
+|Delimiter character between array elements within a value in CSV data. Also accepts `TAB` and `U+20AC` for specifying a character using Unicode.
 
 ====
 * ASCII character -- e.g. `--array-delimiter=";"`.
@@ -515,7 +515,7 @@ Format errors in input data are still treated as errors.
 |1000
 
 |--delimiter=<char>
-|Delimiter character between values in CSV data. Also accepts 'TAB' and e.g. 'U+20AC' for specifying a character using Unicode.
+|Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
 * ASCII character -- e.g. `--delimiter=","`.

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-memrec.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-memrec.adoc
@@ -43,7 +43,7 @@ The `neo4j-admin server memory-recommendation` command has the following options
 |--docker
 |The recommended memory settings are produced in the form of environment variables that can be
 directly passed to a Neo4j docker container. The recommended use is to save the generated
-environment variables to a file and pass the file to a docker container using `--env-file`
+environment variables to a file and pass the file to a docker container using the `--env-file`
 docker option.
 |
 

--- a/modules/ROOT/pages/tools/neo4j-admin/unbind.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/unbind.adoc
@@ -11,7 +11,7 @@ You can use the `neo4j-admin server unbind` command to remove and archive the cl
 The `neo4j-admin server unbind` command has the following syntax:
 
 ----
-neo4j-admin server unbind [-h][--expand-commands] [--verbose]
+neo4j-admin server unbind [-h] [--expand-commands] [--verbose]
                           [--archive-cluster-state[=true|false]]
                           [--additional-config=<file>]
                           [--archive-path=<path>]

--- a/modules/ROOT/pages/tools/neo4j-admin/upload-to-aura.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/upload-to-aura.adoc
@@ -50,7 +50,8 @@ Push a local database to a Neo4j Aura instance. The target location is a Neo4j A
 | Description
 
 |<database>
-|Name of the database that should be uploaded. The name is used to select a dump file which is expected to be named <database>.dump.
+|Name of the database that should be uploaded.
+The name is used to select a dump file which is expected to be named <database>.dump.
 |===
 
 === Options
@@ -89,7 +90,7 @@ The `neo4j-admin database upload` command has the following options:
 |aura
 
 |--to-password=<password>
-|Password of the target database to push this database to. Prompt will ask for a password if not provided. Alternatively,`NEO4J_PASSWORD` environment variable can be used.
+|Password of the target database to push this database to. Prompt will ask for a password if not provided. Alternatively, `NEO4J_PASSWORD` environment variable can be used.
 |
 
 |--to-uri=<uri>
@@ -97,7 +98,7 @@ The `neo4j-admin database upload` command has the following options:
 |
 
 |--to-user=<username>
-|Username of the target database to push this database to. Prompt will ask for a username if not provided. Alternatively, `NEO4J_USERNAME` environment variable can be used.
+|Username of the target database to push this database to. Prompt will ask for a username if not provided. Alternatively, the `NEO4J_USERNAME` environment variable can be used.
 |
 
 |--verbose

--- a/modules/ROOT/pages/tools/neo4j-admin/upload-to-aura.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/upload-to-aura.adoc
@@ -50,8 +50,7 @@ Push a local database to a Neo4j Aura instance. The target location is a Neo4j A
 | Description
 
 |<database>
-|Name of the database that should be uploaded.
-The name is used to select a dump file which is expected to be named <database>.dump.
+|Name of the database that should be uploaded. The name is used to select a dump file which is expected to be named <database>.dump.
 |===
 
 === Options

--- a/modules/ROOT/pages/tools/neo4j-admin/upload-to-aura.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/upload-to-aura.adoc
@@ -90,7 +90,7 @@ The `neo4j-admin database upload` command has the following options:
 |aura
 
 |--to-password=<password>
-|Password of the target database to push this database to. Prompt will ask for a password if not provided. Alternatively, `NEO4J_PASSWORD` environment variable can be used.
+|Password of the target database to push this database to. Prompt will ask for a password if not provided. Alternatively, the `NEO4J_PASSWORD` environment variable can be used.
 |
 
 |--to-uri=<uri>


### PR DESCRIPTION
Small changes to match the help pages of the commands.

Info on testing: https://github.com/neo4j/docs-testing/blob/operations/operations/README.md
Sister PR for help pages: https://github.com/neo-technology/neo4j/pull/20600