### PR TITLE
Update ssl-framework.adoc

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -96,8 +96,8 @@ xsUBvcQuyxewlvWRS18YB51J+yu0Xg==
 -----END CERTIFICATE-----
 ----
 
-The instructions on this page assume that you have already obtained the required certificates from the CA.
-Be sure to include the certificate chain used by your CA to be included in the `public.crt` file, by concatenating each `PEM-encoded` certificate in the `public.crt` file starting from the leaf certificate to the root.
+The instructions on this page assume that you have already obtained the required certificates from the CA and added them to the _public.crt_ file.
+To achieve this, you should concatenate each PEM-encoded certificate, starting from the leaf certificate and moving up the chain toward the root.
 
 [TIP]
 ====

--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -97,6 +97,7 @@ xsUBvcQuyxewlvWRS18YB51J+yu0Xg==
 ----
 
 The instructions on this page assume that you have already obtained the required certificates from the CA.
+Be sure to include the certificate chain used by your CA to be included in the `public.crt` file, by concatenating each `PEM-encoded` certificate in the `public.crt` file starting from the leaf certificate to the root.
 
 [TIP]
 ====


### PR DESCRIPTION
I think we should mention to include the certificate chain in the `public.crt` file for clients to be able to verify them properly.