### PR TITLE
Polish server side routing information.

### DIFF
--- a/modules/ROOT/pages/clustering/setup/routing.adoc
+++ b/modules/ROOT/pages/clustering/setup/routing.adoc
@@ -120,7 +120,7 @@ Server-side routing driver configuration::
 Server-side routing uses the Neo4j Java driver to connect to other cluster members.
 This driver is configured with settings of the format:
 +
-* xref:configuration/configuration-settings/#config_dbms.routing.driver.connection.connect_timeout[`dbms.routing.driver.*`]  // the first of driver settings in that list
+xref:reference/configuration-settings.adoc#config_dbms.routing.driver.connection.connect_timeout[`dbms.routing.driver.*`]  // the first of driver settings in that list
 
 Server-side routing encryption::
 Encryption of server-side routing communication is configured by the cluster SSL policy.

--- a/modules/ROOT/pages/clustering/setup/routing.adoc
+++ b/modules/ROOT/pages/clustering/setup/routing.adoc
@@ -120,7 +120,8 @@ Server-side routing driver configuration::
 Server-side routing uses the Neo4j Java driver to connect to other cluster members.
 This driver is configured with settings of the format:
 +
-* link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_dbms.routing.driver.connection.connect_timeout[`dbms.routing.driver.<setting>`]  // the settings list doesn't have a drivers section, so we link to the _first_ driver setting in the big list
+* link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_dbms.routing.driver.connection.connect_timeout[`dbms.routing.driver.<setting>`]
+// the settings list doesn't have a drivers section, so the link above is to the _first_ driver setting in the big list
 
 Server-side routing encryption::
 Encryption of server-side routing communication is configured by the cluster SSL policy.

--- a/modules/ROOT/pages/clustering/setup/routing.adoc
+++ b/modules/ROOT/pages/clustering/setup/routing.adoc
@@ -120,8 +120,7 @@ Server-side routing driver configuration::
 Server-side routing uses the Neo4j Java driver to connect to other cluster members.
 This driver is configured with settings of the format:
 +
-*
-link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_dbms.routing.driver.connection.connect_timeout[`dbms.routing.driver.*`]  // the first of driver settings in that list
+* link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_dbms.routing.driver.connection.connect_timeout[`dbms.routing.driver.<setting>`]  // the settings list doesn't have a drivers section, so we link to the _first_ driver setting in the big list
 
 Server-side routing encryption::
 Encryption of server-side routing communication is configured by the cluster SSL policy.

--- a/modules/ROOT/pages/clustering/setup/routing.adoc
+++ b/modules/ROOT/pages/clustering/setup/routing.adoc
@@ -113,7 +113,7 @@ Rerouted queries are communicated over the link:{neo4j-docs-base-uri}/bolt/curre
 The receiving end of the communication is configured using the following settings:
 +
 * xref:reference/configuration-settings.adoc#config_dbms.routing.enabled[`dbms.routing.enabled`]
-* xref:reference/configuration-settings.adoc#config_server.routing.listen_address[`server.routing.listen_address`]
+link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_server.routing.listen_address[`server.routing.listen_address`]
 * xref:reference/configuration-settings.adoc#config_server.routing.advertised_address[`server.routing.advertised_address`]
 
 Server-side routing driver configuration::

--- a/modules/ROOT/pages/clustering/setup/routing.adoc
+++ b/modules/ROOT/pages/clustering/setup/routing.adoc
@@ -113,14 +113,15 @@ Rerouted queries are communicated over the link:{neo4j-docs-base-uri}/bolt/curre
 The receiving end of the communication is configured using the following settings:
 +
 * xref:reference/configuration-settings.adoc#config_dbms.routing.enabled[`dbms.routing.enabled`]
-link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_server.routing.listen_address[`server.routing.listen_address`]
+* xref:reference/configuration-settings.adoc#config_server.routing.listen_address[`server.routing.listen_address`]
 * xref:reference/configuration-settings.adoc#config_server.routing.advertised_address[`server.routing.advertised_address`]
 
 Server-side routing driver configuration::
 Server-side routing uses the Neo4j Java driver to connect to other cluster members.
 This driver is configured with settings of the format:
 +
-xref:reference/configuration-settings.adoc#config_dbms.routing.driver.connection.connect_timeout[`dbms.routing.driver.*`]  // the first of driver settings in that list
+*
+link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_dbms.routing.driver.connection.connect_timeout[`dbms.routing.driver.*`]  // the first of driver settings in that list
 
 Server-side routing encryption::
 Encryption of server-side routing communication is configured by the cluster SSL policy.

--- a/modules/ROOT/pages/clustering/setup/routing.adoc
+++ b/modules/ROOT/pages/clustering/setup/routing.adoc
@@ -38,14 +38,14 @@ Additionally, Neo4j automatically transfers database leaderships away from insta
 [[clustering-routing]]
 == Server-side routing
 
-Server-side routing is a complement to the client-side routing, performed by a Neo4j Driver.
+Server-side routing is a complement to the client-side routing.
 
 In a cluster deployment of Neo4j, Cypher queries may be directed to a cluster member that is unable to run the given queries.
 With server-side routing enabled, such queries are rerouted internally to a cluster member that is expected to be able to run them.
 This situation can occur for write-transaction queries when they address a database for which the receiving cluster member is not the leader.
 
 The cluster role for cluster members is per database.
-Thus, if a write-transaction query is sent to a cluster member that is not the leader for the specified database (specified either via the Bolt Protocol or by the Cypher syntax: link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/use[`USE` clause]), server-side routing is performed if properly configured.
+Thus, if a write-transaction query is sent to a cluster member that is not the leader for the specified database (specified either via the link:{neo4j-docs-base-uri}/bolt/current/bolt[Bolt Protocol] or with Cypher link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/use[`USE` clause]), server-side routing is performed if properly configured.
 
 Server-side routing is enabled by the DBMS, by setting xref:reference/configuration-settings.adoc#config_dbms.routing.enabled[`dbms.routing.enabled=true`] for each cluster member.
 The listen address (xref:reference/configuration-settings.adoc#config_server.routing.listen_address[`server.routing.listen_address`]) and advertised address (xref:reference/configuration-settings.adoc#config_server.routing.advertised_address[`server.routing.advertised_address`]) also need to be configured for server-side routing communication.
@@ -109,7 +109,7 @@ The HTTP-API of each member benefits from these settings automatically.
 
 
 Server-side routing connector configuration::
-Rerouted queries are communicated over the link:https://7687.org[Bolt Protocol] using a designated communication channel.
+Rerouted queries are communicated over the link:{neo4j-docs-base-uri}/bolt/current/bolt[Bolt Protocol] using a designated communication channel.
 The receiving end of the communication is configured using the following settings:
 +
 * xref:reference/configuration-settings.adoc#config_dbms.routing.enabled[`dbms.routing.enabled`]
@@ -120,12 +120,7 @@ Server-side routing driver configuration::
 Server-side routing uses the Neo4j Java driver to connect to other cluster members.
 This driver is configured with settings of the format:
 +
-* <<config_dbms.routing.driver.api, `dbms.routing.driver.*`>>
-+
-[NOTE]
-====
-The configuration options described in _Configuration_ in the link:{neo4j-docs-base-uri}[Neo4j Driver manuals] have an equivalent in the server-side routing configuration.
-====
+* xref:configuration/configuration-settings/#config_dbms.routing.driver.connection.connect_timeout[`dbms.routing.driver.*`]  // the first of driver settings in that list
 
 Server-side routing encryption::
 Encryption of server-side routing communication is configured by the cluster SSL policy.


### PR DESCRIPTION
From Petr,

> The fact that server-side-routing uses Java driver is an internal detail. One cluster member forwards the query to another cluster member. The fact that it uses Java driver to do that is an implementation detail.

that's the reason for the change in the first sentence.

Sister PR: https://github.com/neo4j/docs-operations/pull/780