### PR TITLE
Polish server side routing information and settings.

### DIFF
--- a/modules/ROOT/pages/clustering/internals.adoc
+++ b/modules/ROOT/pages/clustering/internals.adoc
@@ -56,14 +56,14 @@ In such clusters, the Single instance is the leader of all databases and there i
 [[causal-clustering-routing]]
 == Server-side routing
 
-Server-side routing is a complement to the client-side routing, performed by a Neo4j Driver.
+Server-side routing is a complement to the client-side routing.
 
 In a Causal Cluster deployment of Neo4j, Cypher queries may be directed to a cluster member that is unable to run the given query.
 With server-side routing enabled, such queries will be rerouted internally to a cluster member that is expected to be able to run it.
 This situation can occur for write-transaction queries when they address a database for which the receiving cluster member is not the leader.
 
 The cluster role for core cluster members is per database.
-Thus, if a write-transaction query is sent to a cluster member that is not the leader for the specified database (specified either via the Bolt Protocol or by the Cypher syntax: link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/use[`USE` clause]), server-side routing will be performed if properly configured.
+Thus, if a write-transaction query is sent to a cluster member that is not the leader for the specified database (specified either via the link:{neo4j-docs-base-uri}/bolt/current/bolt[Bolt Protocol] or with the Cypher link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/use[`USE` clause]), server-side routing will be performed if properly configured.
 
 Server-side routing is enabled by the DBMS, by setting xref:reference/configuration-settings.adoc#config_dbms.routing.enabled[`dbms.routing.enabled=true`] for each cluster member.
 The listen address (xref:reference/configuration-settings.adoc#config_dbms.routing.listen_address[`dbms.routing.listen_address`]) and advertised address (xref:reference/configuration-settings.adoc#config_dbms.routing.advertised_address[`dbms.routing.advertised_address`]) also need to be configured for server-side routing communication.
@@ -127,7 +127,7 @@ h|Routes the query
 
 
 Server-side routing connector configuration::
-Rerouted queries are communicated over the link:https://7687.org[Bolt Protocol] using a designated communication channel.
+Rerouted queries are communicated over the link:{neo4j-docs-base-uri}/bolt/current/bolt[Bolt Protocol] using a designated communication channel.
 The receiving end of the communication is configured using the following settings:
 +
 * xref:reference/configuration-settings.adoc#config_dbms.routing.enabled[`dbms.routing.enabled`]
@@ -139,11 +139,6 @@ Server-side routing uses the Neo4j Java driver to connect to other cluster membe
 This driver is configured with settings of the format:
 +
 * xref:reference/configuration-settings.adoc#config_dbms.routing.driver.api[`dbms.routing.driver.*`]
-+
-[NOTE]
-====
-The configuration options described in _Configuration_ in the link:{neo4j-docs-base-uri}[Neo4j Driver manuals] have an equivalent in the server-side routing configuration.
-====
 
 Server-side routing encryption::
 Encryption of server-side routing communication is configured by the cluster SSL policy.

--- a/modules/ROOT/partials/neo4j-config/all-settings.adoc
+++ b/modules/ROOT/partials/neo4j-config/all-settings.adoc
@@ -3923,7 +3923,7 @@ m|+++CLIENT+++
 [cols="<1s,<4"]
 |===
 |Description
-a|Determines which driver API will be used. ASYNC must be used when the remote instance is 3.5.
+a|Determines which driver API will be used. `ASYNC` must be used when the remote instance is 3.5, but is only retained for backwards-compatibility reasons. `RX` should be used in all other cases.
 |Valid values
 a|dbms.routing.driver.api, one of [RX, ASYNC]
 |Default value


### PR DESCRIPTION
From Petr,

> The fact that server-side-routing uses Java driver is an internal detail. One cluster member forwards the query to another cluster member. The fact that it uses Java driver to do that is an implementation detail.

that's the reason for the change in the first sentence.

Sister PR: https://github.com/neo4j/docs-operations/pull/779