### PR TITLE
Update ssl-framework.adoc (#778)

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -96,7 +96,8 @@ xsUBvcQuyxewlvWRS18YB51J+yu0Xg==
 -----END CERTIFICATE-----
 ----
 
-The instructions on this page assume that you have already obtained the required certificates from the CA.
+The instructions on this page assume that you have already obtained the required certificates from the CA and added them to the _public.crt_ file.
+To achieve this, you should concatenate each PEM-encoded certificate, starting from the leaf certificate and moving up the chain toward the root.
 
 [TIP]
 ====


### PR DESCRIPTION
I think we should mention to include the certificate chain in the `public.crt` file for clients to be able to verify them properly.

---------

Cherry-picked from #778 