### PR TITLE
Deprecate upgrade procedures

### DIFF
--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -374,13 +374,13 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :
 | xref:reference/procedures.adoc#procedure_dbms_upgrade[`dbms.upgrade()`]
 | label:yes[]
 | label:yes[]
-| label:admin-only[]
+| label:admin-only[] label:deprecated[] Deprecated in 5.9.
 
 // New in 4.1
 | xref:reference/procedures.adoc#procedure_dbms_upgradestatus[`dbms.upgradeStatus()`]
 | label:yes[]
 | label:yes[]
-| label:admin-only[]
+| label:admin-only[] label:deprecated[] Deprecated in 5.9.
 
 | xref:reference/procedures.adoc#procedure_tx_getmetadata[`tx.getMetaData()`]
 | label:yes[]
@@ -1750,12 +1750,12 @@ m|READ
 |===
 
 [[procedure_dbms_upgrade]]
-.dbms.upgrade() label:admin-only[]
+.dbms.upgrade() label:admin-only[] label:deprecated[]
 [cols="<15s,<85"]
 |===
 | Description
 a|
-Upgrade the system database schema if it is not the current schema.
+Upgrade the system database schema if it is not the current schema. Deprecated in 5.9.
 | Signature
 m|dbms.upgrade() :: (status :: STRING?, upgradeResult :: STRING?)
 | Mode
@@ -1766,12 +1766,12 @@ m|WRITE
 
 
 [[procedure_dbms_upgradestatus]]
-.dbms.upgradeStatus() label:admin-only[]
+.dbms.upgradeStatus() label:admin-only[] label:deprecated[]
 [cols="<15s,<85"]
 |===
 | Description
 a|
-Report the current status of the system database sub-graph schema.
+Report the current status of the system database sub-graph schema. Deprecated in 5.9.
 | Signature
 m|dbms.upgradeStatus() :: (status :: STRING?, description :: STRING?, resolution :: STRING?)
 | Mode

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -1,6 +1,6 @@
 [[neo4j-procedures]]
 = Procedures
-:description: This page provides a complete reference to the Neo4j procedures. 
+:description: This page provides a complete reference to the Neo4j procedures.
 
 :description: Reference for Neo4j procedures.
 
@@ -150,7 +150,7 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :
 | xref:reference/procedures.adoc#procedure_db_schema_reltypeproperties[`db.schema.relTypeProperties()`]
 | label:yes[]
 | label:yes[]
-| 
+|
 
 | xref:reference/procedures.adoc#procedure_db_schema_visualization[`db.schema.visualization()`]
 | label:yes[]
@@ -215,7 +215,7 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :
 | label:yes[]
 | label:admin-only[]
 
-| xref:reference/procedures.adoc#procedure_dbms_cluster_cordonServer[`dbms.cluster.cordonServer()`] 
+| xref:reference/procedures.adoc#procedure_dbms_cluster_cordonServer[`dbms.cluster.cordonServer()`]
 | label:no[]
 | label:yes[]
 | label:admin-only[]
@@ -233,7 +233,8 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :
 | xref:reference/procedures.adoc#procedure_dbms_cluster_readreplicatoggle[`dbms.cluster.readReplicaToggle()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[] label:deprecated[] Deprecated in 5.6 and replaced by xref:reference/procedures.adoc#procedure_dbms_cluster_secondaryreplicationdisable[`dbms.cluster.secondaryReplicationDisable()`].
+| label:admin-only[] label:deprecated[Deprecated in 5.6]. +
+Replaced by xref:reference/procedures.adoc#procedure_dbms_cluster_secondaryreplicationdisable[`dbms.cluster.secondaryReplicationDisable()`].
 
 // New in 5.6
 | xref:reference/procedures.adoc#procedure_dbms_cluster_secondaryreplicationdisable[`dbms.cluster.secondaryReplicationDisable()`]
@@ -283,7 +284,7 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :
 | xref:reference/procedures.adoc#procedure_dbms_listcapabilities[`dbms.listCapabilities()`]
 | label:yes[]
 | label:yes[]
-| 
+|
 
 | xref:reference/procedures.adoc#procedure_dbms_listconfig[`dbms.listConfig()`]
 | label:yes[]
@@ -315,7 +316,7 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :
 | xref:reference/procedures.adoc#procedure_dbms_routing_getroutingtable[`dbms.routing.getRoutingTable()`]
 | label:yes[]
 | label:yes[]
-| 
+|
 
 // New in 4.2
 | xref:reference/procedures.adoc#procedure_dbms_scheduler_failedjobs[`dbms.scheduler.failedJobs()`]
@@ -374,13 +375,13 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :
 | xref:reference/procedures.adoc#procedure_dbms_upgrade[`dbms.upgrade()`]
 | label:yes[]
 | label:yes[]
-| label:admin-only[] label:deprecated[] Deprecated in 5.9.
+| label:admin-only[] label:deprecated[Deprecated in 5.9]
 
 // New in 4.1
 | xref:reference/procedures.adoc#procedure_dbms_upgradestatus[`dbms.upgradeStatus()`]
 | label:yes[]
 | label:yes[]
-| label:admin-only[] label:deprecated[] Deprecated in 5.9.
+| label:admin-only[] label:deprecated[Deprecated in 5.9]
 
 | xref:reference/procedures.adoc#procedure_tx_getmetadata[`tx.getMetaData()`]
 | label:yes[]
@@ -498,20 +499,20 @@ Replaced by: `SHOW DATABASES`.
 | xref:reference/procedures.adoc#procedure_dbms_cluster_setdefaultdatabase[`dbms.cluster.setDefaultDatabase()`]
 | label:no[]
 | label:yes[]
-| label:removed[] + 
+| label:removed[] +
 Replaced by: `dbms.setDefaultDatabase`.
 
 // Removed in 5.0
 | xref:reference/procedures.adoc#procedure_dbms_database_state[`dbms.database.state()`]
 | label:yes[]
 | label:yes[]
-| label:removed[] + 
+| label:removed[] +
 Replaced by: `SHOW DATABASES`.
 
 | xref:reference/procedures.adoc#procedure_dbms_functions[`dbms.functions()`]
 | label:yes[]
 | label:yes[]
-| label:removed[] + 
+| label:removed[] +
 Replaced by: `SHOW FUNCTIONS`.
 
 | xref:reference/procedures.adoc#procedure_dbms_killqueries[`dbms.killQueries()`]
@@ -1235,8 +1236,8 @@ m|DBMS
 |===
 | Description
 a|
-Checks the connectivity of this instance to other cluster members. 
-Not all ports are relevant to all members. 
+Checks the connectivity of this instance to other cluster members.
+Not all ports are relevant to all members.
 Valid values for 'port-name' are: [CLUSTER, RAFT].
 | Signature
 m|dbms.cluster.checkConnectivity
@@ -1249,8 +1250,8 @@ m|DBMS
 [cols="<15s,<85"]
 |===
 | Description
-a| Marks a server in the topology as not suitable for new allocations. 
-It will not force current allocations off the server. 
+a| Marks a server in the topology as not suitable for new allocations.
+It will not force current allocations off the server.
 This is useful when deallocating databases when you have multiple unavailable servers.
 | Signature
 m|dbms.cluster.cordonServer(server :: STRING?)
@@ -1294,7 +1295,7 @@ m|READ
 
 //deprecate in 5.6
 [[procedure_dbms_cluster_readreplicatoggle]]
-.dbms.cluster.readReplicaToggle() label:enterprise-edition[] label:admin-only[] label:deprecated[]
+.dbms.cluster.readReplicaToggle() label:enterprise-edition[] label:admin-only[] label:deprecated[Deprecated in 5.6]
 [cols="<15s,<85"]
 |===
 | Description
@@ -1302,57 +1303,15 @@ a|
 The toggle can pause or resume the pulling of new transactions for a specific database.
 If paused, the database secondary does not pull new transactions from the other cluster members for the specific database.
 The database secondary is still available for reads, you can perform a backup, etc.
-Deprecated in 5.6 and replaced by xref:reference/procedures.adoc#procedure_dbms_cluster_secondaryreplicationdisable[`dbms.cluster.secondaryReplicationDisable()`].
-
-[TIP]
-====
-_What is it for?_
-
-You can perform a point in time backup, as the backup will contain only the transactions up to the point where the transaction pulling was paused.
-Follow these steps to do so:
-
-. Connect directly to the server hosting the database in secondary mode. (Neo4j Driver use `bolt://` or use the HTTP API).
-. Pause transaction pulling for the specified database.
-. Back up the database, see xref:backup-restore/online-backup.adoc[Back up an online database].
-
-If connected directly to a server hosting a database in secondary mode, Data Scientists can execute analysis on a specific database that is paused, the data will not unexpectedly change while performing the analysis.
-====
-
-[NOTE]
-====
-This procedure can only be executed on a database which runs in a secondary role on the connected server.
-====
-
-.Pause transaction pulling for database `neo4j`
-[source, cypher, role="noheader"]
-----
-CALL dbms.cluster.readReplicaToggle("neo4j", true)
-----
-
-.Resume transaction pulling for database `neo4j`
-[source, cypher, role="noheader"]
-----
-CALL dbms.cluster.readReplicaToggle("neo4j", false)
-----
-
 | Signature
 m|dbms.cluster.readReplicaToggle(databaseName :: STRING?, pause :: BOOLEAN?) :: (state :: STRING?)
 | Mode
 m|READ
+| Replaced by
+a|xref:reference/procedures.adoc#procedure_dbms_cluster_secondaryreplicationdisable[`dbms.cluster.secondaryReplicationDisable()`]
 // | Default roles
 // m|admin
 |===
-
-New in 5.6
-[[procedure_dbms_cluster_secondaryreplicationdisable]]
-.dbms.cluster.secondaryReplicationDisable() label:enterprise-edition[] label:admin-only[]
-[cols="<15s,<85"]
-|===
-| Description
-a|
-The toggle can pause or resume the pulling of new transactions for a specific database.
-If paused, the database secondary does not pull new transactions from the other cluster members for the specific database.
-The database secondary is still available for reads, you can perform a backup, etc.
 
 [TIP]
 ====
@@ -1370,7 +1329,56 @@ If connected directly to a server hosting a database in secondary mode, Data Sci
 
 [NOTE]
 ====
-This procedure can only be executed on a database which runs in a secondary role on the connected server.
+This procedure can only be executed on a database that runs in a secondary role on the connected server.
+====
+
+.Pause transaction pulling for database `neo4j`
+[source, cypher, role="noheader"]
+----
+CALL dbms.cluster.readReplicaToggle("neo4j", true)
+----
+
+.Resume transaction pulling for database `neo4j`
+[source, cypher, role="noheader"]
+----
+CALL dbms.cluster.readReplicaToggle("neo4j", false)
+----
+
+// New in 5.6
+[[procedure_dbms_cluster_secondaryreplicationdisable]]
+.dbms.cluster.secondaryReplicationDisable() label:enterprise-edition[] label:admin-only[]
+[cols="<15s,<85"]
+|===
+| Description
+a|
+The toggle can pause or resume the pulling of new transactions for a specific database.
+If paused, the database secondary does not pull new transactions from the other cluster members for the specific database.
+The database secondary is still available for reads, you can perform a backup, etc.
+| Signature
+m|dbms.cluster.secondaryReplicationDisable(databaseName :: STRING?, pause :: BOOLEAN?) :: (state :: STRING?)
+| Mode
+m|READ
+// | Default roles
+// m|admin
+|===
+
+[TIP]
+====
+_What is it for?_
+
+You can perform a point-in-time backup, as the backup will contain only the transactions up to the point where the transaction pulling was paused.
+Follow these steps to do so:
+
+. Connect directly to the server hosting the database in secondary mode. (Neo4j Driver use `bolt://` or use the HTTP API).
+. Pause transaction pulling for the specified database.
+. Back up the database, see xref:backup-restore/online-backup.adoc[Back up an online database].
+
+If connected directly to a server hosting a database in secondary mode, Data Scientists can execute analysis on a specific database that is paused, the data will not unexpectedly change while performing the analysis.
+====
+
+[NOTE]
+====
+This procedure can only be executed on a database that runs in a secondary role on the connected server.
 ====
 
 .Pause transaction pulling for database `neo4j`
@@ -1384,14 +1392,6 @@ CALL dbms.cluster.secondaryReplicationDisable("neo4j", true)
 ----
 CALL dbms.cluster.secondaryReplicationDisable("neo4j", false)
 ----
-
-| Signature
-m|dbms.cluster.secondaryReplicationDisable(databaseName :: STRING?, pause :: BOOLEAN?) :: (state :: STRING?)
-| Mode
-m|READ
-// | Default roles
-// m|admin
-|===
 
 [[procedure_dbms_cluster_uncordonServer]]
 .dbms.cluster.uncordonServer() label:enterprise-edition[] label:admin-only[]
@@ -1633,7 +1633,7 @@ a|WRITE
 [cols="<15s,<85"]
 |===
 | Description
-a| Changes the default database to the provided value. 
+a| Changes the default database to the provided value.
 The database must exist and the old default database must be stopped.
 | Signature
 m|dbms.setDefaultDatabase(databaseName :: STRING?) :: (result :: STRING?)
@@ -1750,12 +1750,12 @@ m|READ
 |===
 
 [[procedure_dbms_upgrade]]
-.dbms.upgrade() label:admin-only[] label:deprecated[]
+.dbms.upgrade() label:admin-only[] label:deprecated[Deprecated in 5.9]
 [cols="<15s,<85"]
 |===
 | Description
 a|
-Upgrade the system database schema if it is not the current schema. Deprecated in 5.9.
+Upgrade the system database schema if it is not the current schema.
 | Signature
 m|dbms.upgrade() :: (status :: STRING?, upgradeResult :: STRING?)
 | Mode
@@ -1766,12 +1766,12 @@ m|WRITE
 
 
 [[procedure_dbms_upgradestatus]]
-.dbms.upgradeStatus() label:admin-only[] label:deprecated[]
+.dbms.upgradeStatus() label:admin-only[] label:deprecated[Deprecated in 5.9]
 [cols="<15s,<85"]
 |===
 | Description
 a|
-Report the current status of the system database sub-graph schema. Deprecated in 5.9.
+Report the current status of the system database sub-graph schema.
 | Signature
 m|dbms.upgradeStatus() :: (status :: STRING?, description :: STRING?, resolution :: STRING?)
 | Mode


### PR DESCRIPTION
This PR deprecates the following procedures:

- `dbms.upgrade`
- `dbms.upgradeStatus`