### PR TITLE
Creating a database without specifying topology (#797)

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -22,6 +22,13 @@ The command can only be executed successfully if the cluster's servers are able 
 If they are not, the command results in an error.
 For example, if the cluster's servers are set up with mode constraints to contain two primaries and three secondaries, or if only four servers exist, the command fails with an error.
 
+[NOTE]
+====
+If `TOPOLOGY` is not specified, the database is created according to `initial.dbms.default_primaries_count` and `initial.dbms.default_secondaries_count` specified in _neo4j.conf_.
+After cluster startup, these values can be overwritten using the `dbms.setDefaultAllocationNumbers` procedure.
+====
+
+
 [[alter-topology]]
 == `ALTER DATABASE`
 


### PR DESCRIPTION
Adds a note on what allocation numbers are used if `TOPOLOGY` is not set.

---------
Cherry-picked from #797 