### PR TITLE
Update minimum value for minimum system primaries (#809)

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -340,7 +340,7 @@ label:enterprise-edition[Enterprise Edition]
 |Description
 a|Minimum number of machines initially required to form a clustered DBMS. The cluster is considered formed when at least this many members have discovered each other, bound together and bootstrapped a highly available system database. As a result, at least this many of the cluster's initial machines must have `<<config_server.cluster.system_database_mode,server.cluster.system_database_mode>>` set to 'PRIMARY'.NOTE: If `<<config_dbms.cluster.discovery.resolver_type,dbms.cluster.discovery.resolver_type>>` is set to 'LIST' and `<<config_dbms.cluster.discovery.endpoints,dbms.cluster.discovery.endpoints>>` is empty then the user is assumed to be deploying a standalone DBMS, and the value of this setting is ignored.
 |Valid values
-a|dbms.cluster.minimum_initial_system_primaries_count, an integer which is minimum `1`
+a|dbms.cluster.minimum_initial_system_primaries_count, an integer which is minimum `2`
 |Default value
 m|+++3+++
 |===


### PR DESCRIPTION
Setting this to 1 didn't work, so the constraint has been changed in https://github.com/neo-technology/neo4j/pull/20735.