### PR TITLE
fixed neoj4 <> neo4j typo in memory config docs

### DIFF
--- a/modules/ROOT/pages/performance/memory-configuration.adoc
+++ b/modules/ROOT/pages/performance/memory-configuration.adoc
@@ -17,7 +17,7 @@ If you do not leave enough space for the OS, it will start to swap memory to dis
 However, there are cases where the amount reserved for the OS is significantly larger than 1GB, such as servers with exceptionally large RAM.
 
 *JVM Heap*::
-The JVM heap is a separate dynamic memory allocation that Neoj4 uses to store instantiated Java objects.
+The JVM heap is a separate dynamic memory allocation that Neo4j uses to store instantiated Java objects.
 The memory for the Java objects are managed automatically by a garbage collector.
 Particularly important is that a garbage collector automatically handles the deletion of unused objects.
 For more information on how the garbage collector works and how to tune it, see xref:performance/gc-tuning.adoc[Tuning of the garbage collector].


### PR DESCRIPTION
Fixing small typo spotted while reading that page.