### PR TITLE
Add compatibility guarantee for composite databases (#805)

### DIFF
--- a/modules/ROOT/pages/composite-databases/index.adoc
+++ b/modules/ROOT/pages/composite-databases/index.adoc
@@ -15,12 +15,17 @@ It allows you to efficiently manage your data, computing resources, storage, and
 Composite databases are the means to access this partitioned data or graphs with a single Cypher query.
 
 Composite databases *do not store data* independently.
-They use _database aliases_, which can be local or remote.
+_They contain _database aliases_ that target the local or remote databases (the so-called _constituents_) that constitute the fabric setup.
+Local database aliases target databases within the same DBMS, while remote database aliases target databases from another Neo4j DBMS. 
 For more information, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/aliases/[Database alias management^].
 
 Composite databases are managed using Cypher administrative commands.
 Therefore, you can create them as any other database in Neo4j standalone and cluster deployments without needing to deploy a dedicated proxy server (as with Fabric in Neo4j 4).
 For a detailed example of how to create a Composite database and add database aliases to it, see xref:composite-databases/administration.adoc[Managing Composite databases].
+
+Composite databases cannot guarantee compatibility between constituents from different major versions of Neo4j.
+Therefore, all constituents should belong to the same major version.
+If a new feature is introduced, its availability will be limited to the intersection of features available for all constituents.
 
 The following table summarizes the similarities and differences between Composite databases in Neo4j 5 and Fabric in Neo4j 4:
 


### PR DESCRIPTION
We are expected to support compatibility with minor versions only, but will not actively prevent major version combinations.

This applies to all 5.x and later series.

---------
Cherry-picked from #805 