### PR TITLE
Fix list formatting

### DIFF
--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -189,7 +189,7 @@ WARNING! You are using an unsupported Java runtime.
 
 To fix this, you can install Java 17 manually, then either uninstall OpenJDK 19, or set Java 17 as the default.
 
-To install OpenJDK 17 manually:
+* To install OpenJDK 17 manually:
 +
 [source, shell, subs="attributes"]
 ----


### PR DESCRIPTION
As I was reading the docs, I noticed "+" signs in the section "Verify Correct Java is Installed" (see image below). Don't know if this is the right way to correct them, just as a proposal.

![image](https://github.com/neo4j/docs-operations/assets/2542670/c5fcdc92-3307-4171-b1a7-a8b0eef2c0a0)
