### PR TITLE
Automatically enable free servers

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -571,12 +571,12 @@ a|a duration (Valid units are: `ns`, `μs`, `ms`, `s`, `m`, `h` and `d`; default
 m|+++20m+++
 |===
 
-[[config_initial.dbms.cluster.automatically_enable_free_servers]]
-=== `initial.dbms.cluster.automatically_enable_free_servers`
+[[config_initial.dbms.automatically_enable_free_servers]]
+=== `initial.dbms.automatically_enable_free_servers`
 
 label:enterprise-edition[Enterprise Edition]
 
-.initial.dbms.cluster.automatically_enable_free_servers
+.initial.dbms.automatically_enable_free_servers
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -571,6 +571,22 @@ a|a duration (Valid units are: `ns`, `μs`, `ms`, `s`, `m`, `h` and `d`; default
 m|+++20m+++
 |===
 
+[[config_initial.dbms.cluster.automatically_enable_free_servers]]
+=== `initial.dbms.cluster.automatically_enable_free_servers`
+
+label:enterprise-edition[Enterprise Edition]
+
+.initial.dbms.cluster.automatically_enable_free_servers
+[frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
+|===
+|Description
+a|Automatically enable free servers.
+|Valid values
+a|a boolean
+|Default value
+m|+++false+++
+|===
+
 [[config_initial.dbms.database_allocator]]
 === `initial.dbms.database_allocator`
 

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -1744,7 +1744,7 @@ m|DBMS
 | Description
 a| With this method the configuration of the Topology Graph can be displayed.
 | Signature
-m|dbms.showTopologyGraphConfig() :: (allocator :: STRING?, defaultPrimariesCount :: INTEGER?, defaultSecondariesCount :: INTEGER?, defaultDatabase :: STRING?)
+m|dbms.showTopologyGraphConfig() :: (allocator :: STRING?, defaultPrimariesCount :: INTEGER?, defaultSecondariesCount :: INTEGER?, defaultDatabase :: STRING?, autoEnableFreeServers :: BOOLEAN?)
 | Mode
 m|READ
 |===

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -1246,6 +1246,7 @@ With this method you can set whether free servers are automatically enabled.
 m|dbms.cluster.setAutomaticallyEnableFreeServers(autoEnable :: BOOLEAN?)
 | Mode
 m|WRITE
+|===
 
 [[procedure_dbms_cluster_checkConnectivity]]
 .dbms.cluster.checkConnectivity() label:enterprise-edition[] label:admin-only[]

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -210,6 +210,11 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :
 // Internal
 // dbms.clientConfig()
 
+| xref:reference/procedures.adoc#procedure_dbms_cluster_setAutomaticallyEnableFreeServers[`dbms.cluster.setAutomaticallyEnableFreeServers()`]
+| label:no[]
+| label:yes[]
+| label:admin-only[]
+
 | xref:reference/procedures.adoc#procedure_dbms_cluster_checkConnectivity[`dbms.cluster.checkConnectivity()`]
 | label:no[]
 | label:yes[]
@@ -1229,6 +1234,18 @@ m|DBMS
 // | Default roles
 // m|admin
 |===
+
+[[procedure_dbms_cluster_setAutomaticallyEnableFreeServers]]
+.dbms.cluster.setAutomaticallyEnableFreeServers() label:enterprise-edition[] label:admin-only[]
+[cols="<15s,<85"]
+|===
+| Description
+a|
+With this method you can set whether free servers are automatically enabled.
+| Signature
+m|dbms.cluster.setAutomaticallyEnableFreeServers(autoEnable :: BOOLEAN?)
+| Mode
+m|WRITE
 
 [[procedure_dbms_cluster_checkConnectivity]]
 .dbms.cluster.checkConnectivity() label:enterprise-edition[] label:admin-only[]


### PR DESCRIPTION
The ability to automatically enable free servers results in the following docs change: 
1. Addition of a config setting `initial.dbms.automatically_enable_free_servers`
2. Adjustment of `dbms.showTopologyGraphConfig()` procedure's output
3. Introduction of `dbms.cluster.setAutomaticallyEnableFreeServers()` procedure