### PR TITLE
Add collapse nested JSON objects in the query logger when db.logs.query.annotation_data_as_json_enabled setting is true

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -1885,6 +1885,7 @@ label:dynamic[Dynamic]
 |===
 |Description
 a|Log the annotation data as JSON strings instead of a Cypher map. This configuration has an effect only when the query log is in JSON format.
+If `true`, it collapses the nested JSON objects in the query logger.
 |Valid values
 a|a boolean
 |Default value


### PR DESCRIPTION
Cherry-picked from #843 