### PR TITLE
Update db.tx_log.rotation.retention_policy to include period-based transaction log pruning strategy with max size restriction

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -4582,7 +4582,13 @@ label:dynamic[Dynamic]
 |Description
 a|Tell Neo4j how long logical transaction logs should be kept to backup the database.For example, "10 days" will prune logical logs that only contain transactions older than 10 days.Alternatively, "100k txs" will keep the 100k latest transactions from each database and prune any older transactions.
 |Valid values
-a|a string which matches the pattern `^(true{vbar}keep_all{vbar}false{vbar}keep_none{vbar}(\d+[KkMmGg]?( (files{vbar}size{vbar}txs{vbar}entries{vbar}hours{vbar}days))))$` (Must be `true` or `keep_all`, `false` or `keep_none`, or of format `<number><optional unit> <type>`. Valid units are `K`, `M`, and `G`. Valid types are `files`, `size`, `txs`, `entries`, `hours`, and `days`. For example, `100M size` will limit logical log space on the disk to 100MB per database, and `200K txs` will limit the number of transactions kept to 200 000 per database.)
+a|a string which matches the pattern, `^(true\|keep_all\|false\|keep_none\|(\\d+[KkMmGg]?( (files\|size\|txs\|entries\|hours( \\d+[KkMmGg]?)?\|days( \\d+[KkMmGg]?)?))))$`
+Must be `true` or `keep_all`, `false` or `keep_none`, or of format `<number><optional unit> <type> <optional space restriction>`.
+Valid units are `K`, `M`, and `G`.
+Valid types are `files`, `size`, `txs`, `entries`, `hours`, and `days`.
+Valid optional space restriction is a logical log space restriction like `100M`.
+For example, `100M size` will limit logical log space on the disk to 100MB per database, and `200K txs` will limit the number of transactions kept to 200 000 per database.
+An example of a valid logical log space limit that is period-based but also includes a maximum size restriction is `7days 100M`.
 |Default value
 m|+++2 days+++
 |===


### PR DESCRIPTION
Cherry-picked from #844