### PR TITLE
Mark incremental import as enterprise only

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -399,6 +399,7 @@ If importing to a database that has not explicitly been created prior to the imp
 ====
 
 
+[role=enterprise-edition]
 [[import-tool-incremental]]
 == Incremental import
 


### PR DESCRIPTION
Has always been enterprise only, but it is not obvious from just looking at the command docs.