### PR TITLE
Add a page about the reconciler pattern in a clustered DBMS

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -133,6 +133,7 @@
 ** xref:clustering/clustering-advanced/index.adoc[]
 *** xref:clustering/clustering-advanced/default-database.adoc[]
 *** xref:clustering/clustering-advanced/multi-data-center-routing.adoc[]
+*** xref:clustering/clustering-advanced/reconciler.adoc[]
 ** xref:clustering/glossary.adoc[]
 
 * xref:backup-restore/index.adoc[]

--- a/modules/ROOT/pages/clustering/clustering-advanced/default-database.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/default-database.adoc
@@ -1,7 +1,7 @@
 [role=enterprise-edition]
 [[cluster-default-database]]
 = Default database in a cluster
-:description: This section describers how the creation of the initial default database works in a cluster.
+:description: This section describes how the creation of the initial default database works in a cluster.
 
 [[default-database-introduction]]
 == Introduction

--- a/modules/ROOT/pages/clustering/clustering-advanced/index.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/index.adoc
@@ -7,6 +7,7 @@ This section includes information about advanced deployments of a Neo4j Cluster.
 
 * xref:clustering/clustering-advanced/default-database.adoc[Default database in a cluster] -- Details of the creation of the default database in a cluster.
 * xref:clustering/clustering-advanced/multi-data-center-routing.adoc[Multi-data center routing] -- Information about routing in multi-data center deployments.
+* xref:clustering/clustering-advanced/reconciler.adoc[Reconciler] -- Details about the way database management operations are processed.
 
 For details on the configuration and operation of a Neo4j cluster, see xref:clustering/index.adoc[Clustering].
 

--- a/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
@@ -3,7 +3,6 @@
 = Reconciler
 :description: This section describes how changes to the DBMS are processed by each server.
 
-[[cluster-reconciler-introduction]]
 == Introduction
 
 In Neo4j, administrative operations such as database creation do not happen synchronously.
@@ -14,12 +13,10 @@ When the reconciler on `server-1` becomes aware of that, it starts `bar`.
 
 Executing an operation and getting back a successful response means that the desire is safely committed to the `system` database, and will be processed by each member of the cluster at some point, assuming the server is healthy enough.
 
-[[cluster-reconciler-async]]
 == Asynchronicity
 Servers can become aware the same operation at different times, since the `system` database is just another Raft group, where followers and replicas can lag behind the leader in some situations.
 Each server should eventually see the new state though, and take action on it.
 
-[[cluster-reconciler-wait]]
 == Waiting
 
 If you want to be sure that each server has processed an administrative operation before running the next action, you can use the link:{neo4j-docs-base-uri}/cypher-manual/current/administration/databases/#administration-wait-nowait[`WAIT`] keyword.
@@ -27,7 +24,7 @@ If you want to be sure that each server has processed an administrative operatio
 
 [NOTE]
 ====
-A statements with `WAIT` returning does not mean that your operation is necessarily successful everywhere.
+When a statement with `WAIT` returns, it does not mean that the operation was necessarily successful everywhere.
 `WAIT` just ensures the operation has been processed.
 For example, a request to start a database is considered _processed_ if the reconciler tried to start it, but the database failed and went into the dirty state.
 ====
@@ -38,7 +35,6 @@ For example, a request to start a database is considered _processed_ if the reco
 CREATE DATABASE foo WAIT
 ----
 
-[[cluster-reconciler-errors]]
 == Errors
 
 An operation might only succeed on some servers.
@@ -50,7 +46,6 @@ Other failures only require the underlying problem to be resolved.
 When the issue is fixed, the reconciler will make the intended change, because it is still trying to achieve the desired state.
 For example, if a new server fails during a `DEALLOCATE DATABASES FROM SERVER` (meaning a database cannot be safely moved), fixing the new server should be enough to resolve the problem, as the new server will start its copy of the database as soon as the target is ready, allowing the deallocating server to shut down its copy.
 
-[[cluster-reconciler-reason]]
 == Why use the reconciler pattern
 
 This approach is robust to more failures.

--- a/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
@@ -1,0 +1,51 @@
+[role=enterprise-edition]
+[[cluster-reconciler]]
+= Reconciler
+:description: This section describes how changes to the DBMS are processed by each server.
+
+[[cluster-reconciler-introduction]]
+== Introduction
+
+Administrative operations in Neo4j, such as creating a database, do not happen synchronously.
+Instead we have a model where the changes are written to the `system` database, and record the desired state of the DBMS.
+Each server has an internal component called the reconciler, which will then make any changes relevant to that server once it observes that desire, for example starting a local copy of a database because it has been allocated to them.
+Servers can observe the same operation at different times, since the `system` database is just another Raft group, where followers and replicas can lag behind the leader in some situations.
+Executing an operation and getting back a successful response means that the desire is safely committed to the `system` database, and will be processed by each member of the cluster at some point, assuming the server is healthy enough.
+
+[[cluster-reconciler-wait]]
+== Waiting
+
+If you want to be sure that each server has processed an administrative operation before you run the next action, you can use the `WAIT` keyword.
+This makes the statement not return until all servers have seen the transaction, and their reconciler has finished processing it.
+
+[NOTE]
+====
+This does not mean that your operation is necessarily successful everywhere.
+`WAIT` just ensures the operation has been processed.
+A request to start a database has still been processed if the reconciler tried to start it and the database failed and went into the dirty state.
+====
+
+=== Example using `WAIT`
+[source, cypher, role="noplay"]
+----
+CREATE DATABASE foo WAIT
+----
+
+[[cluster-reconciler-errors]]
+== Errors
+
+An operation might only succeed on some servers.
+For instance some servers might be offline when you create a database, or a disk error might cause a server to fail to start a database.
+In this situation the operation has not 'failed' as a whole, since you may even have a running database, just with less fault tolerance than you desired.
+
+Some failures can just be re-attempted, for example `START DATABASE` can be run if not all members started successfully, and you think the reason has been resolved.
+Other failures will need just the underlying problem to be resolved and the reconciler will make the change, because it is still trying to achieve the desired state.
+For example if a new server fails during a `DEALLOCATE DATABASES FORM SERVER`, meaning a database cannot be safely moved, fixing the new server should be enough to resolve the problem, as the new server will start its copy of the database, allowing the deallocating server to shut down its copy.
+
+[[cluster-reconciler-reason]]
+== Why use the reconciler pattern
+
+This approach is robust to more failures.
+Each server is responsible for getting its local state to match its copy of the global desire.
+This means the loss of any one server cannot prevent all progress on that operation.
+If there was for instance one coordinator making changes to all other servers, a failure of that coordinator would result in progress stopping until the failure could be detected, and a replacement started.

--- a/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
@@ -6,18 +6,16 @@
 == Introduction
 
 In Neo4j, administrative operations such as database creation do not happen synchronously.
-Instead, the changes are first written to the `system` database, recording the desired state of the DBMS.
-Each server has a _reconciler_, an internal component which observes the desired state and makes changes to the local server to match that state.
+Instead, the changes are first written to the `system` database, recording the requested state of the DBMS.
+Each server has a _reconciler_, an internal component which observes the requested state and makes changes to the local server to match that state.
 For example, the `system` database may record that the database `bar` is expected to be running on `server-1`.
 When the reconciler on `server-1` becomes aware of that, it starts `bar`.
+This means the loss of any one server cannot prevent all progress on an operation.
 
-Executing an operation and getting back a successful response means that the desire is safely committed to the `system` database, and will be processed by each member of the cluster at some point, assuming the server is healthy enough.
+Executing an operation and getting back a successful response means that the request is safely committed to the `system` database, and will be processed by each member of the cluster at some point, assuming the server is healthy enough.
 
-== Asynchronicity
 Servers can become aware the same operation at different times, since the `system` database is just another Raft group, where followers and replicas can lag behind the leader in some situations.
-Each server should eventually see the new state though, and take action on it.
-
-== Waiting
+Eventually, the new state gets propagated to all healthy servers, and they take action on it.
 
 If you want to be sure that each server has processed an administrative operation before running the next action, you can use the link:{neo4j-docs-base-uri}/cypher-manual/current/administration/databases/#administration-wait-nowait[`WAIT`] keyword.
 `WAIT` makes the statement not return until all servers have seen the transaction, and their reconciler has finished processing it.
@@ -43,12 +41,5 @@ In this situation, the operation has not _failed_ as a whole, since the database
 
 Some failed operations can just be re-tried: for example, `START DATABASE` can be re-run if not all members started successfully, and you think the cause of that has been resolved.
 Other failures only require the underlying problem to be resolved. 
-When the issue is fixed, the reconciler will make the intended change, because it is still trying to achieve the desired state.
+When the issue is fixed, the reconciler will make the intended change, because it is still trying to achieve the requested state.
 For example, if a new server fails during a `DEALLOCATE DATABASES FROM SERVER` (meaning a database cannot be safely moved), fixing the new server should be enough to resolve the problem, as the new server will start its copy of the database as soon as the target is ready, allowing the deallocating server to shut down its copy.
-
-== Why use the reconciler pattern
-
-This approach is robust to more failures.
-Each server is responsible for getting its local state to match its copy of the global desire.
-This means the loss of any one server cannot prevent all progress on that operation.
-If there was for instance one coordinator making changes to all other servers, a failure of that coordinator would result in progress stopping until the failure could be detected, and a replacement started.

--- a/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
@@ -25,7 +25,7 @@ Each server should eventually see the new state though, and take action on it.
 If you want to be sure that each server has processed an administrative operation before you run the next action, you can use the `WAIT` keyword.
 `WAIT` makes the statement not return until all servers have seen the transaction, and their reconciler has finished processing it.
 
-[WARN]
+[NOTE]
 ====
 A statements with `WAIT` returning does not mean that your operation is necessarily successful everywhere.
 `WAIT` just ensures the operation has been processed.

--- a/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
@@ -1,9 +1,9 @@
 [role=enterprise-edition]
+:page-toclevels: 0
+
 [[cluster-reconciler]]
 = Reconciler
 :description: This section describes how changes to the DBMS are processed by each server.
-
-== Introduction
 
 In Neo4j, administrative operations such as database creation do not happen synchronously.
 Instead, the changes are first written to the `system` database, recording the requested state of the DBMS.
@@ -20,18 +20,18 @@ Eventually, the new state gets propagated to all healthy servers, and they take 
 If you want to be sure that each server has processed an administrative operation before running the next action, you can use the link:{neo4j-docs-base-uri}/cypher-manual/current/administration/databases/#administration-wait-nowait[`WAIT`] keyword.
 `WAIT` makes the statement not return until all servers have seen the transaction, and their reconciler has finished processing it.
 
+.Example of database creation with `WAIT`
+[source, cypher]
+----
+CREATE DATABASE foo WAIT
+----
+
 [NOTE]
 ====
 When a statement with `WAIT` returns, it does not mean that the operation was necessarily successful everywhere.
 `WAIT` just ensures the operation has been processed.
 For example, a request to start a database is considered _processed_ if the reconciler tried to start it, but the database failed and went into the dirty state.
 ====
-
-.Create database with `WAIT`
-[source, cypher]
-----
-CREATE DATABASE foo WAIT
-----
 
 == Errors
 

--- a/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
@@ -8,19 +8,26 @@
 
 Administrative operations in Neo4j, such as creating a database, do not happen synchronously.
 Instead we have a model where the changes are written to the `system` database, and record the desired state of the DBMS.
-Each server has an internal component called the reconciler, which will then make any changes relevant to that server once it observes that desire, for example starting a local copy of a database because it has been allocated to them.
-Servers can observe the same operation at different times, since the `system` database is just another Raft group, where followers and replicas can lag behind the leader in some situations.
+Each server has an internal component called the reconciler, which observes the desired state and makes changes to the local server to match that state.
+For example, the `system` database may record that it wants the database `bar` running on `server-1`.
+When the reconciler on `server-1` sees that, it will start `bar`.
+
 Executing an operation and getting back a successful response means that the desire is safely committed to the `system` database, and will be processed by each member of the cluster at some point, assuming the server is healthy enough.
+
+[[cluster-reconciler-async]]
+== Asynchronicity
+Servers can observe the same operation at different times, since the `system` database is just another Raft group, where followers and replicas can lag behind the leader in some situations.
+Each server should eventually see the new state though, and take action on it.
 
 [[cluster-reconciler-wait]]
 == Waiting
 
 If you want to be sure that each server has processed an administrative operation before you run the next action, you can use the `WAIT` keyword.
-This makes the statement not return until all servers have seen the transaction, and their reconciler has finished processing it.
+`WAIT` makes the statement not return until all servers have seen the transaction, and their reconciler has finished processing it.
 
-[NOTE]
+[WARN]
 ====
-This does not mean that your operation is necessarily successful everywhere.
+A statements with `WAIT` returning does not mean that your operation is necessarily successful everywhere.
 `WAIT` just ensures the operation has been processed.
 A request to start a database has still been processed if the reconciler tried to start it and the database failed and went into the dirty state.
 ====

--- a/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/reconciler.adoc
@@ -6,34 +6,34 @@
 [[cluster-reconciler-introduction]]
 == Introduction
 
-Administrative operations in Neo4j, such as creating a database, do not happen synchronously.
-Instead we have a model where the changes are written to the `system` database, and record the desired state of the DBMS.
-Each server has an internal component called the reconciler, which observes the desired state and makes changes to the local server to match that state.
-For example, the `system` database may record that it wants the database `bar` running on `server-1`.
-When the reconciler on `server-1` sees that, it will start `bar`.
+In Neo4j, administrative operations such as database creation do not happen synchronously.
+Instead, the changes are first written to the `system` database, recording the desired state of the DBMS.
+Each server has a _reconciler_, an internal component which observes the desired state and makes changes to the local server to match that state.
+For example, the `system` database may record that the database `bar` is expected to be running on `server-1`.
+When the reconciler on `server-1` becomes aware of that, it starts `bar`.
 
 Executing an operation and getting back a successful response means that the desire is safely committed to the `system` database, and will be processed by each member of the cluster at some point, assuming the server is healthy enough.
 
 [[cluster-reconciler-async]]
 == Asynchronicity
-Servers can observe the same operation at different times, since the `system` database is just another Raft group, where followers and replicas can lag behind the leader in some situations.
+Servers can become aware the same operation at different times, since the `system` database is just another Raft group, where followers and replicas can lag behind the leader in some situations.
 Each server should eventually see the new state though, and take action on it.
 
 [[cluster-reconciler-wait]]
 == Waiting
 
-If you want to be sure that each server has processed an administrative operation before you run the next action, you can use the `WAIT` keyword.
+If you want to be sure that each server has processed an administrative operation before running the next action, you can use the link:{neo4j-docs-base-uri}/cypher-manual/current/administration/databases/#administration-wait-nowait[`WAIT`] keyword.
 `WAIT` makes the statement not return until all servers have seen the transaction, and their reconciler has finished processing it.
 
 [NOTE]
 ====
 A statements with `WAIT` returning does not mean that your operation is necessarily successful everywhere.
 `WAIT` just ensures the operation has been processed.
-A request to start a database has still been processed if the reconciler tried to start it and the database failed and went into the dirty state.
+For example, a request to start a database is considered _processed_ if the reconciler tried to start it, but the database failed and went into the dirty state.
 ====
 
-=== Example using `WAIT`
-[source, cypher, role="noplay"]
+.Create database with `WAIT`
+[source, cypher]
 ----
 CREATE DATABASE foo WAIT
 ----
@@ -42,12 +42,13 @@ CREATE DATABASE foo WAIT
 == Errors
 
 An operation might only succeed on some servers.
-For instance some servers might be offline when you create a database, or a disk error might cause a server to fail to start a database.
-In this situation the operation has not 'failed' as a whole, since you may even have a running database, just with less fault tolerance than you desired.
+For instance, some servers might be offline when a database is created, or a disk error might cause a server to fail to start a database.
+In this situation, the operation has not _failed_ as a whole, since the database may even be running (although with less fault tolerance than you intended).
 
-Some failures can just be re-attempted, for example `START DATABASE` can be run if not all members started successfully, and you think the reason has been resolved.
-Other failures will need just the underlying problem to be resolved and the reconciler will make the change, because it is still trying to achieve the desired state.
-For example if a new server fails during a `DEALLOCATE DATABASES FORM SERVER`, meaning a database cannot be safely moved, fixing the new server should be enough to resolve the problem, as the new server will start its copy of the database, allowing the deallocating server to shut down its copy.
+Some failed operations can just be re-tried: for example, `START DATABASE` can be re-run if not all members started successfully, and you think the cause of that has been resolved.
+Other failures only require the underlying problem to be resolved. 
+When the issue is fixed, the reconciler will make the intended change, because it is still trying to achieve the desired state.
+For example, if a new server fails during a `DEALLOCATE DATABASES FROM SERVER` (meaning a database cannot be safely moved), fixing the new server should be enough to resolve the problem, as the new server will start its copy of the database as soon as the target is ready, allowing the deallocating server to shut down its copy.
 
 [[cluster-reconciler-reason]]
 == Why use the reconciler pattern


### PR DESCRIPTION
This was in the 'Clustering internals' page in 4.4, but needed updating for 5.x, and making more useful.