### PR TITLE
added debian 12 to the list of supported operating systems (#896)

### DIFF
--- a/modules/ROOT/pages/installation/requirements.adoc
+++ b/modules/ROOT/pages/installation/requirements.adoc
@@ -85,7 +85,7 @@ For personal use and software development:
 [options="header"]
 |===
 | Operating System                        | Supported JDK
-| *Debian 11*                             | OpenJDK 17, OracleJDK 17, and ZuluJDK 17
+| *Debian 11, 12*                         | OpenJDK 17, OracleJDK 17, and ZuluJDK 17
 | *MacOS 11, 12*                          | ZuluJDK 17
 | *SuSE Enterprise Desktop 15*            | OpenJDK 17, Oracle JDK 17
 | *Ubuntu Desktop 22.04+*                 | OpenJDK 17, OracleJDK 17, and ZuluJDK 17
@@ -100,7 +100,7 @@ For cloud environments, and server-based, on-premise environments:
 | Operating System                                 | Supported JDK
 | *Amazon Linux 2022 AMI*                          | Amazon Corretto 17, and OracleJDK 17
 | *CentOS Stream 8, 9*                             | OpenJDK 17, OracleJDK 17, and ZuluJDK 17
-| *Debian 11*                                      | OpenJDK 17, OracleJDK 17, and ZuluJDK 17
+| *Debian 11, 12*                                  | OpenJDK 17, OracleJDK 17, and ZuluJDK 17
 | *Red Hat Enterprise Linux Server 8.6, 8.8, 9.0*  | Red Hat OpenJDK 17,  Oracle JDK 17, and ZuluJDK 17
 | *Ubuntu Server 16.04, 18.04, 20.04, 22.04*       | OpenJDK 17, OracleJDK 17, and ZuluJDK 17
 | *Windows Server 2016, 2019, 2022*                | OracleJDK 17, ZuluJDK 17


### PR DESCRIPTION
Debian 12 was released recently, and so we should support it.
Cherry-picked from #896