### PR TITLE
[online backup] database parameter table headers fix

### DIFF
--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -80,8 +80,8 @@ neo4j-admin database backup [-h] [--expand-commands] [--verbose]
 [options="header", cols="1m,3a,1m"]
 |===
 | Parameter
-| Default
 | Description
+| Default
 
 |<database>
 |Name of the remote database to backup. Can contain `*` and `?` for globbing (required unless `--inspect-path` is used).


### PR DESCRIPTION
The table headers in the online backup docs have the wrong order for `Description` and `Default`, this PR fixes it.

![Screenshot 2023-07-11 at 11 31 15](https://github.com/neo4j/docs-operations/assets/1222009/e5e9b536-9151-4462-b8c0-58c3bdd7e9a3)
