### PR TITLE
Fix systemctl enable neo4j.service documentation

### DIFF
--- a/modules/ROOT/pages/installation/linux/tarball.adoc
+++ b/modules/ROOT/pages/installation/linux/tarball.adoc
@@ -87,8 +87,13 @@ TimeoutSec=120
 
 [Install]
 WantedBy=multi-user.target
-//Reload systemctl to pick up the new service file
-systemctl daemon-reload
+----
+
+. Reload systemctl to pick up the new service file:
++
+[source, shell]
+----
+systemctl enable neo4j
 ----
 
 . Configure Neo4j to start at boot time:

--- a/modules/ROOT/pages/installation/linux/tarball.adoc
+++ b/modules/ROOT/pages/installation/linux/tarball.adoc
@@ -89,19 +89,13 @@ TimeoutSec=120
 WantedBy=multi-user.target
 ----
 
-. Reload systemctl to pick up the new service file:
+. Reload systemctl to pick up the new service file and configure Neo4j to start at boot time:
 +
 [source, shell]
 ----
 systemctl enable neo4j
 ----
 
-. Configure Neo4j to start at boot time:
-+
-[source, shell]
-----
-systemctl enable neo4j
-----
 . Start Neo4j:
 +
 [source, shell]


### PR DESCRIPTION
The documentation for neo4j.service systemctl was invalid. 
The command "systemctl daemon-reload" must not be part of the neo4j.service definition.