### PR TITLE
fix retrieving serverId command for seed cluster section

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -112,18 +112,18 @@ Use any database to connect.
 +
 [source, cypher, role=noplay]
 ----
-SHOW SERVERS;
+SHOW SERVERS YIELD serverId, name, address, state, health, hosting;
 ----
 +
 [queryresult]
 ----
-+------------------------------------------------------------------------------------------------------------+
-| name                                   | address          | state     | health      | hosting              |
-+------------------------------------------------------------------------------------------------------------+
-| "25a7efc7-d063-44b8-bdee-f23357f89f01" | "localhost:7689" | "Enabled" | "Available" | ["system",  "neo4j"] |
-| "782f0ee2-5474-4250-b905-4cd8b8f586ba" | "localhost:7688" | "Enabled" | "Available" | ["system",  "neo4j"] |
-| "8512c9b9-d9e8-48e6-b037-b15b0004ca18" | "localhost:7687" | "Enabled" | "Available" | ["system",  "neo4j"] |
-+------------------------------------------------------------------------------------------------------------+
++-----------------------------------------------------------------------------------------------------------------------------------------------------+
+| serverId                               | name                                   | address          | state     | health      | hosting              |
++-----------------------------------------------------------------------------------------------------------------------------------------------------+
+| "25a7efc7-d063-44b8-bdee-f23357f89f01" | "25a7efc7-d063-44b8-bdee-f23357f89f01" | "localhost:7689" | "Enabled" | "Available" | ["system",  "neo4j"] |
+| "782f0ee2-5474-4250-b905-4cd8b8f586ba" | "782f0ee2-5474-4250-b905-4cd8b8f586ba" | "localhost:7688" | "Enabled" | "Available" | ["system",  "neo4j"] |
+| "8512c9b9-d9e8-48e6-b037-b15b0004ca18" | "8512c9b9-d9e8-48e6-b037-b15b0004ca18" | "localhost:7687" | "Enabled" | "Available" | ["system",  "neo4j"] |
++-----------------------------------------------------------------------------------------------------------------------------------------------------+
 ----
 In this case, the address for `server01` is `localhost:7687` and thus, the server ID is `8512c9b9-d9e8-48e6-b037-b15b0004ca18`.
 +


### PR DESCRIPTION
The section for retrieving the serverId here https://neo4j.com/docs/operations-manual/current/clustering/databases/#cluster-designated-seeder is not correct.

The docs use `SHOW SERVERS` which will return the name of the server, by default it has the same name as the serverId, but in case servers were renamed, using 
```
RENAME SERVER `25a7efc7-d063-44b8-bdee-f23357f89f01` TO `primary1` 
```
then it will not match anymore and trying to use `primary1` as serverId while following the documentation will lead to the following exception when seeding a cluster :
```
Could not create database with specified existingDataSeedInstance 'optimus-001'. Expected server uuid string.
```

This PR ensures that the correct serverId is returned when following the documentation.