### PR TITLE
Use HTML codes for "<EOF >" to prevent interpretation as HTML element

### DIFF
--- a/modules/ROOT/pages/installation/linux/rpm.adoc
+++ b/modules/ROOT/pages/installation/linux/rpm.adoc
@@ -55,7 +55,7 @@ To use the repository for generally available versions of Neo4j, run the followi
 [source, shell, subs="attributes"]
 ----
 rpm --import https://debian.neo4j.com/neotechnology.gpg.key
-cat <<EOF >  /etc/yum.repos.d/neo4j.repo
+cat <&lt;EOF &gt;  /etc/yum.repos.d/neo4j.repo
 [neo4j]
 name=Neo4j RPM Repository
 baseurl=https://yum.neo4j.com/stable/{neo4j-version}


### PR DESCRIPTION
## The Problem

Currently, the documentation generator is not doing any escaping of the `<` and the `>` in the code snipped, so browsers are interpreting `<EOF >` an HTML element tag:

![Screenshot 2023-07-06 at 12 02 49 PM](https://github.com/neo4j/docs-operations/assets/3915596/7a548c73-8b6a-497d-ab5f-bc6f79c3c7f5)

Thus, "&lt;EOF &gt;" is not being rendered:

![Screenshot 2023-07-06 at 12 01 06 PM](https://github.com/neo4j/docs-operations/assets/3915596/2ec0b1bc-52b3-4842-aff4-0495a60276f5)

This is a problem because copying and pasting the code snippet as it is rendered (without the `<EOF >`) does not work because the shell doesn't recognize the multi-line input as one command.

## The Fix

Escaping the carets using HTML `&gt;` and `&lt;` codes leads to proper rendering of the code snippet:

<img width="866" alt="Screenshot 2023-07-14 at 4 52 56 PM" src="https://github.com/neo4j/docs-operations/assets/3915596/dfd88bd4-a0c4-48b0-9433-a7e532060b94">
