### PR TITLE
Adding information about port 7688

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -7,7 +7,7 @@ The SSL framework provides support for securing the following Neo4j communicatio
 
 * `bolt` (port - `7687`)
 * `https` (port - `7473`)
-* `cluster` (ports - `5000`, `6000`, and `7000`)
+* `cluster` (ports - `5000`, `6000`, `7000`, and `7688`)
 * `backups` (port - `6362`)
 
 This page describes how to set up SSL within your environment, how to view, validate, and test the certificates.
@@ -271,7 +271,7 @@ Each policy needs to be explicitly enabled by setting:
 === Configure SSL over Bolt
 
 Bolt protocol is based on the link:https://neo4j.com/docs/bolt/current/packstream/[PackStream serialization] and supports the Cypher type system, protocol versioning, authentication, and TLS via certificates.
-For Neo4j clusters, Bolt provides smart client routing with load balancing and failover.
+For Neo4j clusters, Bolt provides smart client routing with load balancing and failover through port 7688.
 Bolt connector is used by Cypher Shell, Neo4j Browser, and by the officially supported language drivers.
 Bolt connector is enabled by default but its encryption is disabled.
 To enable the encryption over Bolt, create the folder structure and place the key file and the certificates under those.
@@ -649,11 +649,12 @@ openssl s_client -connect my_domain.com:7473
 === Configure SSL for intra-cluster communications
 
 Intra-cluster encryption is the security solution for the cluster communication.
-The Neo4j cluster communicates on 3 ports:
+The Neo4j cluster communicates on 4 ports:
 
 * 5000 - Discovery management
 * 6000 - Transactions
 * 7000 - Raft communications
+* 7688 - Server side routing
 
 To set up intra-cluster encryption, on each server create the folder structure and place the key file and the certificates under those.
 Then, you need to configure the SSL cluster policies in the _neo4j.conf_ file and test that the intra-cluster communication is encrypted.

--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -271,7 +271,10 @@ Each policy needs to be explicitly enabled by setting:
 === Configure SSL over Bolt
 
 Bolt protocol is based on the link:https://neo4j.com/docs/bolt/current/packstream/[PackStream serialization] and supports the Cypher type system, protocol versioning, authentication, and TLS via certificates.
-For Neo4j clusters, Bolt provides smart client routing with load balancing and failover through port 7688.
+For Neo4j clusters, Bolt provides smart client routing with load balancing and failover.
+When server side routing is enabled, an additional Bolt port is open on `7688`.
+It can be used only within the cluster and with all the same settings as the external Bolt port.
+
 Bolt connector is used by Cypher Shell, Neo4j Browser, and by the officially supported language drivers.
 Bolt connector is enabled by default but its encryption is disabled.
 To enable the encryption over Bolt, create the folder structure and place the key file and the certificates under those.


### PR DESCRIPTION
The SSL Framework page (https://neo4j.com/docs/operations-manual/5/security/ssl-framework/ ) does not mention port 7688 (Server Side Routing).

This port would be encrypted if you use the cluster policy (or Bolt).
We should add that to the documentation to eliminate any possible confusion.