### PR TITLE
Fix systemctl enable neo4j.service documentation (#903)

### DIFF
--- a/modules/ROOT/pages/installation/linux/tarball.adoc
+++ b/modules/ROOT/pages/installation/linux/tarball.adoc
@@ -87,16 +87,15 @@ TimeoutSec=120
 
 [Install]
 WantedBy=multi-user.target
-//Reload systemctl to pick up the new service file
-systemctl daemon-reload
 ----
 
-. Configure Neo4j to start at boot time:
+. Reload systemctl to pick up the new service file and configure Neo4j to start at boot time:
 +
 [source, shell]
 ----
 systemctl enable neo4j
 ----
+
 . Start Neo4j:
 +
 [source, shell]


### PR DESCRIPTION
The documentation for neo4j.service systemctl was invalid.  The command "systemctl daemon-reload" must not be part of the neo4j.service definition.

Cherry-picked from #903