### PR TITLE
Clarify that database status endpoints only work for local databases

### DIFF
--- a/modules/ROOT/pages/clustering/monitoring/endpoints.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/endpoints.adoc
@@ -50,7 +50,7 @@ http://localhost:7474/db/neo4j/cluster/status
 
 [NOTE]
 ====
-If a server does not host a database, accessing any of the endpoints on for that database produces a `404` response.
+Attempting to access endpoints for a database not hosted on a server produces a `404` response.
 ====
 
 .Unified HTTP endpoint responses


### PR DESCRIPTION
Databases hosted on other servers and not the local one do not have status endpoints on the local server, so you get `404`.