### PR TITLE
Clarify that database status endpoints only work for local databases …

### DIFF
--- a/modules/ROOT/pages/clustering/monitoring/endpoints.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/endpoints.adoc
@@ -48,6 +48,11 @@ http://localhost:7474/db/neo4j/cluster/available
 http://localhost:7474/db/neo4j/cluster/status
 --------------
 
+[NOTE]
+====
+Attempting to access endpoints for a database not hosted on a server produces a `404` response.
+====
+
 .Unified HTTP endpoint responses
 [options="header", cols="<3a,1,<2a,<2a"]
 |===


### PR DESCRIPTION
…(#941)

Databases hosted on other servers and not the local one do not have status endpoints on the local server, so you get `404`.

---------