### PR TITLE
Improve the description of the metric cluster.raft.message_processing_delay

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -317,7 +317,8 @@ By default, database metrics include:
 |<prefix>.cluster.raft.raft_log_entry_prefetch_buffer.size|Raft Log Entry Prefetch buffer size. (gauge)
 |<prefix>.cluster.raft.raft_log_entry_prefetch_buffer.async_put|Raft Log Entry Prefetch buffer async puts. (gauge)
 |<prefix>.cluster.raft.raft_log_entry_prefetch_buffer.sync_put|Raft Log Entry Prefetch buffer sync puts. (gauge)
-|<prefix>.cluster.raft.message_processing_delay|Delay between Raft message receive and process. (gauge)
+|<prefix>.cluster.raft.message_processing_delay|The time the Raft message stays in the queue after being received and before being processed, i.e. append and commit to the store. The higher the value, the longer the messages wait to be processed. This metric is closely linked to disk write performance.
+(gauge)
 |<prefix>.cluster.raft.message_processing_timer|Timer for Raft message processing. (counter, histogram)
 |<prefix>.cluster.raft.replication_new|The total number of Raft replication requests. It increases with write transactions (possibly internal) activity. (counter)
 |<prefix>.cluster.raft.replication_attempt|The total number of Raft replication requests attempts. It is bigger or equal to the replication requests. (counter)


### PR DESCRIPTION
Cherry-picked from #929)