### PR TITLE
Restructured Docker section and added documentation about mount points and plugins

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -19,11 +19,14 @@
 
 * xref:docker/index.adoc[]
 ** xref:docker/introduction.adoc[]
+** xref:docker/mounting-volumes.adoc[]
 ** xref:docker/configuration.adoc[]
+** xref:docker/plugins.adoc[]
 ** xref:docker/clustering.adoc[]
 ** xref:docker/operations.adoc[]
+** xref:docker/dump-load.adoc[]
+** xref:docker/backup-restore.adoc[]
 ** xref:docker/security.adoc[]
-** xref:docker/maintenance.adoc[]
 ** xref:docker/ref-settings.adoc[]
 
 * xref:kubernetes/index.adoc[]

--- a/modules/ROOT/pages/configuration/file-locations.adoc
+++ b/modules/ROOT/pages/configuration/file-locations.adoc
@@ -80,7 +80,7 @@ _/etc/neo4j/user-log.xml_
 
 | Logs
 | The Neo4j log files.
-| _<neo4j-home>/logs_ footnote:[To view _neo4j.log_ in Docker, use xref:docker/maintenance.adoc#docker-monitoring[`docker logs <containerID/name>`].]
+| _<neo4j-home>/logs_ footnote:[To view _neo4j.log_ in Docker, use xref:docker/mounting-volumes.adoc#docker-volumes-logs[`docker logs <containerID/name>`].]
 | _<neo4j-home>\logs_
 | _/var/log/neo4j/_ footnote:[To view the neo4j.log for Debian and RPM, use `journalctl --unit=neo4j`.]
 | From the _Open_ dropdown menu of your active Neo4j DBMS, select _Terminal_, and run `cd logs`.

--- a/modules/ROOT/pages/configuration/plugins.adoc
+++ b/modules/ROOT/pages/configuration/plugins.adoc
@@ -52,8 +52,12 @@ The following plugins are supported:
 | link:{neo4j-docs-base-uri}/ops-manager/[Neo4j Ops Manager]
 |===
 
+For more information on using plugins in a different Neo4j setup, see:
 
-For more information on using plugins in a different Neo4j setup, see link:{neo4j-docs-base-uri}/desktop-manual/current/operations/install-plugin/[Neo4j Desktop -> Install a plugin], xref:docker/operations.adoc#docker-neo4j-plugins[Docker -> Configure Neo4j plugins], xref:/kubernetes/plugins.adoc[Kubernetes -> Plugins], and link:{neo4j-docs-base-uri}/java-reference/{page-version}/extending-neo4j/project-setup/#_build_dependencies[Java-Reference -> Setting up a plugin project]. 
+* link:{neo4j-docs-base-uri}/desktop-manual/current/operations/install-plugin/[Neo4j Desktop -> Install a plugin]
+* xref:docker/plugins.adoc[Docker -> Configuring Plugins with Docker]
+* xref:/kubernetes/plugins.adoc[Kubernetes -> Plugins]
+* link:{neo4j-docs-base-uri}/java-reference/{page-version}/extending-neo4j/project-setup/#_build_dependencies[Java-Reference -> Setting up a plugin project].
 
 == Install and configure plugins 
 

--- a/modules/ROOT/pages/configuration/plugins.adoc
+++ b/modules/ROOT/pages/configuration/plugins.adoc
@@ -6,7 +6,7 @@ Neo4j distributions come bundled with a range of pre-installed products, such as
 The JAR files for these products are located in the _product_ and _labs_ folders and can be installed as plugins.
 
 If you want to use your own plugins, ensure that you add them to the designated _plugins_ directory.
-This directory serves as the central location where Neo4j looks for and loads the plugins at startup. 
+This directory serves as the central location where Neo4j looks for and loads the plugins at startup.
 
 [NOTE]
 ====
@@ -55,11 +55,11 @@ The following plugins are supported:
 For more information on using plugins in a different Neo4j setup, see:
 
 * link:{neo4j-docs-base-uri}/desktop-manual/current/operations/install-plugin/[Neo4j Desktop -> Install a plugin]
-* xref:docker/plugins.adoc[Docker -> Configuring Plugins with Docker]
+* xref:docker/plugins.adoc[Docker -> Plugins]
 * xref:/kubernetes/plugins.adoc[Kubernetes -> Plugins]
 * link:{neo4j-docs-base-uri}/java-reference/{page-version}/extending-neo4j/project-setup/#_build_dependencies[Java-Reference -> Setting up a plugin project].
 
-== Install and configure plugins 
+== Install and configure plugins
 
 Here are the steps to enable the plugins:
 
@@ -97,6 +97,6 @@ Refer to link:https://neo4j.com/docs/bloom-user-guide/current/bloom-installation
 [NOTE]
 ====
 All installed plugins will automatically be loaded every time Neo4j is started.
-Because of that, the number of plugins may impact the startup time. 
+Because of that, the number of plugins may impact the startup time.
 Install only the necessary plugins to avoid performance issues.
 ====

--- a/modules/ROOT/pages/docker/backup-restore.adoc
+++ b/modules/ROOT/pages/docker/backup-restore.adoc
@@ -1,65 +1,19 @@
-:description: Basic maintenance operations when running Neo4j in a Docker container.
-[[docker-maintenance]]
-= Docker maintenance operations
-
-This page describes how to perform basic maintenance operations when running Neo4j in a Docker container.
-
-[[docker-neo4j-dump]]
-== Dump and load a Neo4j database (offline)
-
-The xref:backup-restore/offline-backup.adoc[`neo4j-admin database dump`] and xref:backup-restore/restore-dump.adoc[`neo4j-admin database load`] commands can be run locally to dump and load an offline database.
-
-The following are examples of how to dump and load the default `neo4j` database.
-Because these commands are run on a stopped database, you have to launch a container for each operation (dump and load), with the `--rm` flag.
-
-.Invoke `neo4j-admin database dump` to dump your database.
-====
-[source, shell, subs="attributes+,+macros"]
-----
-docker run --interactive --tty --rm \
-   --volume=$HOME/neo4j/data:/data \  #<1>
-   --volume=$HOME/neo4j/backups:/backups \  #<2>
-   neo4j/neo4j-admin:{neo4j-version-exact} \
-neo4j-admin database dump neo4j --to-path=/backups
-----
-<1> The volume that contains the database that you want to dump.
-<2> The volume that will be used for the dumped database.
-====
-
-.Invoke `neo4j-admin database load` to load your data into the new database.
-====
-[source, shell, subs="attributes+,+macros"]
-----
-docker run --interactive --tty --rm \
-    --volume=$HOME/neo4j/data:/data \ #<1>
-    --volume=$HOME/neo4j/backups:/backups \ #<2>
-    neo4j/neo4j-admin:{neo4j-version-exact} \
-neo4j-admin database load neo4j --from-path=/backups
-----
-<1> The volume that will contain the database, into which you want to load the dumped data.
-<2> The volume that stores the database dump.
-====
-
-Finally, you xref:docker/introduction.adoc#docker-user[launch a container] with the volume that contains the newly loaded database, and start using it.
-
-[NOTE]
-For more information on the `neo4j-admin database dump and load` syntax and options, see xref:backup-restore/offline-backup.adoc#offline-backup-command-options[`neo4j-admin database dump`] and xref:backup-restore/restore-dump.adoc#restore-dump-command-options[`neo4j-admin database load`]. +
-For more information on managing volumes, see https://docs.docker.com/storage/volumes/[the official Docker documentation^].
-
+:description: Backup and restore operations when running Neo4j in a Docker container.
 [role=enterprise-edition]
 [[docker-neo4j-backup-restore]]
-== Back up and restore a Neo4j database (online)
+= Back up and restore a Neo4j database (online)
+
 The Neo4j backup and restore commands can be run locally to backup and restore a live database.
 
 
 You can also get a `neo4j-admin` image that can be run on a dedicated machine, under the terms of an existing Enterprise licensing agreement.
 
-If Neo4j (a single instance or any member of a Neo4j cluster) is running inside a docker container, you can use `docker exec` to invoke `neo4-admin` from inside the container and take a backup of a database.
+If Neo4j (a single instance or any member of a Neo4j cluster) is running inside a Docker container, you can use `docker exec` to invoke `neo4-admin` from inside the container and take a backup of a database.
 
 
 [role=enterprise-edition]
 [[docker-neo4j-backup-exec]]
-=== Back up a database using `docker exec`
+== Back up a database using `docker exec`
 
 To back up a database, you must first mount the host backup folder onto the container.
 Because Docker does not allow new mounts to be added to a running container, you have to do this when starting the container.
@@ -101,10 +55,10 @@ For more information on the `neo4j-admin database backup` syntax and options, se
 
 [role=enterprise-edition]
 [[docker-neo4j-backup-admin]]
-=== Back up a database using `neo4j-admin` image
+== Back up a database using `neo4j-admin` image
 
 To perform a backup, the cluster needs at least one server with backup enabled and the backup listen address port set and exposed.
-Ports cannot be exposed on a docker container once it has started, so this must be done when starting the container.
+Ports cannot be exposed on a Docker container once it has started, so this must be done when starting the container.
 
 .A `docker run` command that starts a database configured for backing up.
 ====
@@ -150,7 +104,7 @@ docker run --interactive --tty --rm \
 
 [role=enterprise-edition]
 [[docker-neo4j-restore-exec]]
-=== Restore a database using `docker exec`
+== Restore a database using `docker exec`
 
 The following are examples of how to restore a database backup on a stopped database in a running Neo4j instance.
 
@@ -192,7 +146,7 @@ docker exec --interactive --tty <containerID/name> neo4j-admin database restore 
 
 [role=enterprise-edition]
 [[docker-neo4j-restore-admin]]
-=== Restore a database using `neo4j-admin` image
+== Restore a database using `neo4j-admin` image
 
 The `neo4j-admin database restore` action cannot be performed remotely, as it requires access to the neo4j _/data_ folder.
 Consequently, backup files must be copied over to the new machine prior to a restore,
@@ -245,17 +199,4 @@ docker exec -it <containerID/name> cypher-shell -u neo4j -p <my-password> -d sys
 ====
 For more information on the `neo4j-admin database restore` syntax and options, see xref:backup-restore/restore-backup.adoc[Restore a database backup].
 ====
-
 Finally, you can use xref:docker/operations.adoc#docker-cypher-shell-example[the Cypher Shell tool] to verify that your data has been restored.
-
-[[docker-monitoring]]
-== Monitor Neo4j
-
-Neo4j logging output is written to files in the _/logs_ directory.
-This directory is mounted as a _/logs_ volume.
-
-[TIP]
-====
-For more information about configuring Neo4j, see xref:docker/configuration.adoc[Configuration]. +
-For more information about the Neo4j log files, see xref:monitoring/logging.adoc[Logging].
-====

--- a/modules/ROOT/pages/docker/backup-restore.adoc
+++ b/modules/ROOT/pages/docker/backup-restore.adoc
@@ -11,7 +11,6 @@ You can also get a `neo4j-admin` image that can be run on a dedicated machine, u
 If Neo4j (a single instance or any member of a Neo4j cluster) is running inside a Docker container, you can use `docker exec` to invoke `neo4-admin` from inside the container and take a backup of a database.
 
 
-[role=enterprise-edition]
 [[docker-neo4j-backup-exec]]
 == Back up a database using `docker exec`
 
@@ -53,7 +52,6 @@ docker exec --interactive --tty <container name> neo4j-admin database backup --t
 For more information on the `neo4j-admin database backup` syntax and options, see xref:backup-restore/online-backup.adoc[Back up an online database].
 ====
 
-[role=enterprise-edition]
 [[docker-neo4j-backup-admin]]
 == Back up a database using `neo4j-admin` image
 
@@ -102,7 +100,6 @@ docker run --interactive --tty --rm \
 ====
 
 
-[role=enterprise-edition]
 [[docker-neo4j-restore-exec]]
 == Restore a database using `docker exec`
 
@@ -144,7 +141,6 @@ docker exec --interactive --tty <containerID/name> neo4j-admin database restore 
 ====
 
 
-[role=enterprise-edition]
 [[docker-neo4j-restore-admin]]
 == Restore a database using `neo4j-admin` image
 

--- a/modules/ROOT/pages/docker/backup-restore.adoc
+++ b/modules/ROOT/pages/docker/backup-restore.adoc
@@ -26,11 +26,11 @@ Because Docker does not allow new mounts to be added to a running container, you
 docker run --name <container name> \
     --detach \
     --publish=7474:7474 --publish=7687:7687 \
-    --volume=$HOME/neo4j-enterprise/data:/data \ #<1>
-    --volume=$HOME/neo4j-enterprise/backups:/backups \ #<2>
+    --volume=$HOME/neo4j-enterprise/data:/data \ # <1>
+    --volume=$HOME/neo4j-enterprise/backups:/backups \ # <2>
     --user="$(id -u):$(id -g)" \
-    --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ #<3>
-    --env NEO4J_server_backup_enabled=true \ #<4>
+    --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ # <3>
+    --env NEO4J_server_backup_enabled=true \ # <4>
     neo4j:{neo4j-version-exact}-enterprise
 ----
 
@@ -68,11 +68,11 @@ docker run \
     --detach \
     --publish=7474:7474 \
     --publish=7687:7687 \
-    --publish=6362:6362 \ #<1>
-    --volume=$HOME/neo4j-enterprise/data:/data \ #<2>
-    --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ #<3>
-    --env NEO4J_server_backup_enabled=true \ #<4>
-    --env NEO4J_server_backup_listen__address=0.0.0.0:6362 \ #<5>
+    --publish=6362:6362 \ # <1>
+    --volume=$HOME/neo4j-enterprise/data:/data \ # <2>
+    --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ # <3>
+    --env NEO4J_server_backup_enabled=true \ # <4>
+    --env NEO4J_server_backup_listen__address=0.0.0.0:6362 \ # <5>
     neo4j:{neo4j-version-exact}-enterprise
 ----
 <1> The xref:configuration/configuration-settings.adoc#config_server.backup.listen_address[server.backup.listen_address] port defined in 5.
@@ -89,12 +89,12 @@ Once you have a backup enabled cluster node, the `neo4j/neo4j-admin:{neo4j-versi
 [source, shell, subs="attributes+,+macros"]
 ----
 docker run --interactive --tty --rm \
-   --volume=$HOME/neo4j-enterprise/backups:/backups \  #<1>
-   --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ #<2>
+   --volume=$HOME/neo4j-enterprise/backups:/backups \  # <1>
+   --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ # <2>
    neo4j/neo4j-admin:{neo4j-version-exact}-enterprise \
       neo4j-admin database backup <database name> \
          --to-path=/backups \
-         --from=<backup node IP address>:6362 #<3>
+         --from=<backup node IP address>:6362 # <3>
 ----
 <1> The volume that will be used for the backup database files.
 <2> The environment variable that accepts the Neo4j Enterprise Edition license agreement.
@@ -115,10 +115,10 @@ The following are examples of how to restore a database backup on a stopped data
 docker run --name <container name> \
     --detach \
     --publish=7474:7474 --publish=7687:7687 \
-    --volume=$HOME/neo4j-enterprise/data:/data \ #<1>
-    --volume=$HOME/neo4j-enterprise/backups:/backups \ #<2>
+    --volume=$HOME/neo4j-enterprise/data:/data \ # <1>
+    --volume=$HOME/neo4j-enterprise/backups:/backups \ # <2>
     --user="$(id -u):$(id -g)" \
-    --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ #<3>
+    --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ # <3>
     neo4j:{neo4j-version-exact}-enterprise
 ----
 
@@ -158,8 +158,8 @@ and the `neo4j-admin` docker image must be run on the same machine as the databa
 ----
 docker run --name <container name> \
     --detach \
-    --volume=$HOME/neo4j-enterprise/data:/data \ #<1>
-    --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ #<2>
+    --volume=$HOME/neo4j-enterprise/data:/data \ # <1>
+    --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ # <2>
     neo4j:{neo4j-version-exact}-enterprise
 ----
 
@@ -177,9 +177,9 @@ docker exec -it <containerID/name> cypher-shell -u neo4j -p <my-password> -d sys
 [source, shell]
 ----
 docker run --interactive --tty --rm \
-   --volume=$HOME/neo4j-enterprise/data:/data \ #<1>
-   --volume=$HOME/neo4j-enterprise/backups:/backups \  #<2>
-   --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ #<3>
+   --volume=$HOME/neo4j-enterprise/data:/data \ # <1>
+   --volume=$HOME/neo4j-enterprise/backups:/backups \  # <2>
+   --env NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \ # <3>
    neo4j/neo4j-admin:{neo4j-version-exact}-enterprise \
       neo4j-admin database restore \
          --from=/backups/<databasename>-<timestamp>.backup \

--- a/modules/ROOT/pages/docker/configuration.adoc
+++ b/modules/ROOT/pages/docker/configuration.adoc
@@ -1,4 +1,4 @@
-:description: This chapter describes how to configure Neo4j to run in a Docker container. It also describes how to use a custom Neo4j Docker image to run Neo4j in a Docker container.
+:description: This chapter describes how to configure Neo4j to run in a Docker container.
 [[docker-neo4j-configuration]]
 = Configuration
 
@@ -84,7 +84,7 @@ This can be done by setting `server.default_listen_address=0.0.0.0`.
 ====
 
 To dump the initial set of configuration files, run the image with the `dump-config` command.
-You must set the `neo4j` user as the owner of _$HOME/neo4j/conf_ to allow _write_ access from the Neo4j docker container:
+You must set the `neo4j` user as the owner of _$HOME/neo4j/conf_ to allow _write_ access from the Neo4j Docker container:
 
 [source, shell, subs="attributes"]
 ----

--- a/modules/ROOT/pages/docker/configuration.adoc
+++ b/modules/ROOT/pages/docker/configuration.adoc
@@ -1,8 +1,8 @@
 :description: This chapter describes how to configure Neo4j to run in a Docker container.
 [[docker-neo4j-configuration]]
-= Configuration
+= Modify the default configuration
 
-The default configuration provided by the Neo4j image is intended for learning about Neo4j, but must be modified to make it suitable for production use.
+The default configuration provided by the Neo4j image is intended for learning about Neo4j but must be modified to make it suitable for production use.
 In particular, the default memory assignments to Neo4j are very limited (`NEO4J_server_memory_pagecache_size=512M` and `NEO4J_server_memory_heap_max__size=512M`), to allow multiple containers to be run on the same server.
 You can read more about configuring Neo4j in the xref:docker/ref-settings.adoc[Docker specific configuration settings].
 
@@ -18,7 +18,7 @@ Which one to choose depends on how much you need to customize the image.
 [[docker-environment-variables]]
 == Environment variables
 
-Pass environment variables to the container when you run it.
+Pass environment variables to the container when you run it, for example:
 
 [source, shell, subs="attributes"]
 ----

--- a/modules/ROOT/pages/docker/dump-load.adoc
+++ b/modules/ROOT/pages/docker/dump-load.adoc
@@ -1,0 +1,53 @@
+:description: Dump and load operations when running Neo4j in a Docker container.
+[[docker-neo4j-dump]]
+= Dump and load a Neo4j database (offline)
+
+The xref:backup-restore/offline-backup.adoc[`neo4j-admin database dump`] and xref:backup-restore/restore-dump.adoc[`neo4j-admin database load`] commands can be run locally to dump and load an offline database.
+
+The following are examples of how to dump and load the default `neo4j` database.
+Because these commands are run on a stopped database, you have to launch a container for each operation (dump and load), with the `--rm` flag.
+
+.Invoke `neo4j-admin database dump` to dump your database.
+====
+[source, shell, subs="attributes+,+macros"]
+----
+docker run --interactive --tty --rm \
+   --volume=$HOME/neo4j/data:/data \  #<1>
+   --volume=$HOME/neo4j/backups:/backups \  #<2>
+   neo4j/neo4j-admin:{neo4j-version-exact} \
+neo4j-admin database dump neo4j --to-path=/backups
+----
+<1> The volume that contains the database that you want to dump.
+<2> The volume that will be used for the dumped database.
+====
+
+.Invoke `neo4j-admin database load` to load your data into the new database.
+====
+[source, shell, subs="attributes+,+macros"]
+----
+docker run --interactive --tty --rm \
+    --volume=$HOME/neo4j/newdata:/data \ #<1>
+    --volume=$HOME/neo4j/backups:/backups \ #<2>
+    neo4j/neo4j-admin:{neo4j-version-exact} \
+neo4j-admin database load neo4j --from-path=/backups
+----
+<1> The volume that will contain the database, into which you want to load the dumped data.
+<2> The volume that stores the database dump.
+====
+
+Finally, you xref:docker/introduction.adoc#docker-image[launch a container] with the volume that contains the newly loaded database, and start using it.
+
+.Launching a container from restored data
+[source, shell, subs="attributes+,+macros"]
+----
+docker run --interactive --tty --rm \
+    --volume=$HOME/neo4j/newdata:/data \ #<1>
+    neo4j:{neo4j-version-exact}
+----
+<1> The volume containing the restored data
+====
+
+[NOTE]
+For more information on the `neo4j-admin database dump and load` syntax and options, see xref:backup-restore/offline-backup.adoc#offline-backup-command-options[`neo4j-admin database dump`] and xref:backup-restore/restore-dump.adoc#restore-dump-command[`neo4j-admin database load`]. +
+For more information on managing volumes, see https://docs.docker.com/storage/volumes/[the official Docker documentation^].
+====

--- a/modules/ROOT/pages/docker/dump-load.adoc
+++ b/modules/ROOT/pages/docker/dump-load.adoc
@@ -12,8 +12,8 @@ Because these commands are run on a stopped database, you have to launch a conta
 [source, shell, subs="attributes+,+macros"]
 ----
 docker run --interactive --tty --rm \
-   --volume=$HOME/neo4j/data:/data \  #<1>
-   --volume=$HOME/neo4j/backups:/backups \  #<2>
+   --volume=$HOME/neo4j/data:/data \  # <1>
+   --volume=$HOME/neo4j/backups:/backups \  # <2>
    neo4j/neo4j-admin:{neo4j-version-exact} \
 neo4j-admin database dump neo4j --to-path=/backups
 ----
@@ -26,8 +26,8 @@ neo4j-admin database dump neo4j --to-path=/backups
 [source, shell, subs="attributes+,+macros"]
 ----
 docker run --interactive --tty --rm \
-    --volume=$HOME/neo4j/newdata:/data \ #<1>
-    --volume=$HOME/neo4j/backups:/backups \ #<2>
+    --volume=$HOME/neo4j/newdata:/data \ # <1>
+    --volume=$HOME/neo4j/backups:/backups \ # <2>
     neo4j/neo4j-admin:{neo4j-version-exact} \
 neo4j-admin database load neo4j --from-path=/backups
 ----
@@ -41,7 +41,7 @@ Finally, you xref:docker/introduction.adoc#docker-image[launch a container] with
 [source, shell, subs="attributes+,+macros"]
 ----
 docker run --interactive --tty --rm \
-    --volume=$HOME/neo4j/newdata:/data \ #<1>
+    --volume=$HOME/neo4j/newdata:/data \ # <1>
     neo4j:{neo4j-version-exact}
 ----
 <1> The volume containing the restored data

--- a/modules/ROOT/pages/docker/index.adoc
+++ b/modules/ROOT/pages/docker/index.adoc
@@ -6,9 +6,9 @@ Neo4j can be run in a Docker container.
 
 This chapter describes the following:
 
-* xref:docker/introduction.adoc[Introduction] -- Introduction to running Neo4j in a Docker container.
-* xref:docker/mounting-volumes.adoc[Mounting Storage] -- How and where to mount persistent storage to the Docker container.
-* xref:docker/configuration.adoc[Configuration] -- How to configure Neo4j to run in a Docker container.
+* xref:docker/introduction.adoc[Getting Started with Neo4j in Docker] -- Introduction to running Neo4j in a Docker container.
+* xref:docker/mounting-volumes.adoc[Persisting data with Docker volumes] -- How and where to mount persistent storage to the Docker container.
+* xref:docker/configuration.adoc[Modify the default configuration] -- How to configure Neo4j to run in a Docker container.
 * xref:docker/plugins.adoc[Plugins] -- How to load plugins when using Neo4j in Docker.
 * xref:docker/clustering.adoc[Deploy a Neo4j cluster on Docker] -- How to set up and deploy a Neo4j cluster on Docker.
 * xref:docker/operations.adoc[Docker specific operations] -- Descriptions of various `neo4j-admin` and `cypher-shell` operations that are specific to using Docker.

--- a/modules/ROOT/pages/docker/index.adoc
+++ b/modules/ROOT/pages/docker/index.adoc
@@ -7,12 +7,15 @@ Neo4j can be run in a Docker container.
 This chapter describes the following:
 
 * xref:docker/introduction.adoc[Introduction] -- Introduction to running Neo4j in a Docker container.
+* xref:docker/mounting-volumes.adoc[Mounting Storage] -- How and where to mount persistent storage to the Docker container.
 * xref:docker/configuration.adoc[Configuration] -- How to configure Neo4j to run in a Docker container.
+* xref:docker/plugins.adoc[Plugins] -- How to load plugins when using Neo4j in Docker.
 * xref:docker/clustering.adoc[Deploy a Neo4j cluster on Docker] -- How to set up and deploy a Neo4j cluster on Docker.
-* xref:docker/operations.adoc[Docker specific operations] - Descriptions of various operations that are specific to using Docker.
-* xref:docker/security.adoc[Security] - Information about using encryption with a Neo4j Docker image.
-* xref:docker/maintenance.adoc[Docker maintenance operations] How to maintain Neo4j when running in a Docker container.
-* xref:docker/ref-settings.adoc[Docker specific configuration settings] - A conversion table for the Neo4j configuration settings to Docker format.
+* xref:docker/operations.adoc[Docker specific operations] -- Descriptions of various `neo4j-admin` and `cypher-shell` operations that are specific to using Docker.
+* xref:docker/dump-load.adoc[Offline dump and load] -- How to perform dump and load of a containerized Neo4j database.
+* xref:docker/dump-load.adoc[Online backup and restore] -- How to perform backup and restore of a containerized Neo4j database. Enterprise Only.
+* xref:docker/security.adoc[Security] -- Information about using encryption with a Neo4j Docker image.
+* xref:docker/ref-settings.adoc[Docker specific configuration settings] -- A conversion table for the Neo4j configuration settings to Docker format.
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/docker/index.adoc
+++ b/modules/ROOT/pages/docker/index.adoc
@@ -13,7 +13,7 @@ This chapter describes the following:
 * xref:docker/clustering.adoc[Deploy a Neo4j cluster on Docker] -- How to set up and deploy a Neo4j cluster on Docker.
 * xref:docker/operations.adoc[Docker specific operations] -- Descriptions of various `neo4j-admin` and `cypher-shell` operations that are specific to using Docker.
 * xref:docker/dump-load.adoc[Offline dump and load] -- How to perform dump and load of a containerized Neo4j database.
-* xref:docker/dump-load.adoc[Online backup and restore] -- How to perform backup and restore of a containerized Neo4j database. Enterprise Only.
+* xref:docker/backup-restore.adoc[Online backup and restore] -- How to perform backup and restore of a containerized Neo4j database. Enterprise Only.
 * xref:docker/security.adoc[Security] -- Information about using encryption with a Neo4j Docker image.
 * xref:docker/ref-settings.adoc[Docker specific configuration settings] -- A conversion table for the Neo4j configuration settings to Docker format.
 

--- a/modules/ROOT/pages/docker/introduction.adoc
+++ b/modules/ROOT/pages/docker/introduction.adoc
@@ -1,19 +1,19 @@
 :description: An introduction to how Neo4j runs in a Docker container.
 [[docker-overview]]
-= Getting Started with Neo4j in Docker
+= Getting started with Neo4j in Docker
 
 Docker can be downloaded for macOS, Windows, and Linux operating systems from https://www.docker.com/get-started.
 DockerHub hosts an link:https://hub.docker.com/_/neo4j[official Neo4j image] that provides a standard, ready-to-run package of Neo4j Community Edition and Enterprise Edition for a variety of versions.
 
 [[getting-docker-image]]
-== Getting the Neo4j Image
+== Getting the Neo4j image
 Variants of the Neo4j image are tagged according to
 Community/Enterprise Edition and the operating system used as the base image.
 
 
 All supported tags can be found at https://hub.docker.com/_/neo4j/tags.
 
-=== Neo4j Editions
+=== Neo4j editions
 Tags are available for both Community Edition and Enterprise Edition.
 Version-specific Enterprise Edition tags have an `-enterprise` suffix after the version number, for example: `neo4j:{neo4j-version-exact}-enterprise`.
 Community Edition tags have no suffix, for example `neo4j:{neo4j-version-exact}`.
@@ -33,15 +33,18 @@ Email inquiries can be sent using the form https://neo4j.com/contact-us[Contact 
 More information is also available at: https://neo4j.com/licensing/
 ____
 
-=== Base Operating System
+=== Base operating system
+
+The Neo4j image is available with either `debian:bullseye-slim` or `redhat/ubi8-minimal:latest` as the base image.
+The default is `debian:bullseye-slim`.
+
 [TIP]
 ====
-If you are unsure which base image to use, or have no preference, just use the default of `neo4j:{neo4j-version-exact}`.
+If you are unsure which base image to use or have no preference, just use the default of `neo4j:{neo4j-version-exact}`.
 ====
-Neo4j images are available with either `debian:bullseye-slim` or `redhat/ubi8-minimal:latest` as the base image.
+
 
 To specify which base image to use, the image tags optionally have a `-bullseye` or `-ubi8` suffix.
-If no base image is specified, the debian variant will be used by default.
 
 For example:
 
@@ -75,7 +78,7 @@ neo4j:{neo4j-version-exact}-enterprise        # debian 11 enterprise
 
 [NOTE]
 ====
-The redhat variant images are only available from 5.10.0 and onwards.
+The Red Hat variant images are only available from 5.10.0 and onwards.
 For earlier Neo4j versions, do not specify a base image.
 ====
 
@@ -93,7 +96,7 @@ docker run \
     neo4j:{neo4j-version-exact}
 ----
 
-You can try out your Neo4j container by opening _http://localhost:7474/_ (the Neo4j's Browser interface) in a web browser. 
+You can try out your Neo4j container by opening _http://localhost:7474/_ (the Neo4j's Browser interface) in a web browser.
 By default, Neo4j requires authentication and prompts you to log in with a username/password of `neo4j/neo4j` at the first connection.
 You are then prompted to set a new password.
 
@@ -106,7 +109,7 @@ Use the `dbms.security.auth_minimum_password_length` configuration to change it.
 The following sections provide more information about how to set an initial password, configure Neo4j to persist data between restarts, and use the Neo4j Docker image.
 
 [[docker-simple-volumes]]
-== Persisting data using Volumes
+== Persisting data between restarts
 
 The `--volume` option maps a local folder to the container, where you can persist data between restarts.
 To persist the contents of the database between containers, mount a volume to the `/data` directory on starting the container:
@@ -123,7 +126,7 @@ docker run \
 
 [CAUTION]
 ====
-The folders that you want to mount must exist before starting Docker, otherwise Neo4j will fail to start due to permissions errors.
+The folders that you want to mount must exist before starting Docker, otherwise, Neo4j fails to start due to permissions errors.
 ====
 
 For more information about mounting volumes, see xref:docker/mounting-volumes.adoc[].
@@ -149,49 +152,48 @@ Alternatively, you can disable authentication by specifying `NEO4J_AUTH` to `non
 --env NEO4J_AUTH=none
 ----
 
-Please note that there is currently no way to change the initial username from `neo4j`.
+Note that there is currently no way to change the initial username from `neo4j`.
 
 [CAUTION]
 ====
-*Setting `NEO4J_AUTH` will not override existing authentication.*
+*Setting `NEO4J_AUTH` does not override the existing authentication.*
 
 If you have mounted a _/data_ volume containing an existing database, setting `NEO4J_AUTH` will have no effect because that database already has authentication configured.
 The Neo4j Docker service will start, but you will need a username and password already associated with the database to log in.
 ====
 
 
-
-== More useful Docker Run options
+== Useful `docker run` options
 
 This table lists some of the options available:
 
 .Options for `docker run`
-[options="header",cols="m,a,m"]
+[options="header",cols="1m,3a,3m"]
 |===
 |Option |Description  |Example
 
 |--name
-|Name your container to avoid generic ID
+|Name your container to avoid generic ID.
 |docker run --name myneo4j neo4j
 
 |-p
-|Specify which container port to expose
+|Specify which container port to expose.
 |docker run -p7687:7687 neo4j
 
 |-d
-|Detach container to run in background
+|Detach container to run in the background.
 |docker run -d neo4j
 
 |-v
-|Bind mount a volume
+|Bind mount a volume.
 |docker run -v $HOME/neo4j/data:/data neo4j
 
 |--env
-|Set config as environment variables for the Neo4j database
+|Set config as environment variables for the Neo4j database.
 |docker run --env NEO4J_AUTH=neo4j/your_password neo4j
 
 |--user
-|Run neo4j as the given user, instead of `neo4j`
+|Run neo4j as the given user, instead of `neo4j`.
 |docker run --user="$(id -u):$(id -g)" neo4j
 
 |--restart
@@ -207,14 +209,8 @@ This table lists some of the options available:
 ====
 The `--restart always` option sets the Neo4j container (and Neo4j) to restart automatically whenever the Docker daemon is restarted.
 
-If you no longer want to have the container auto-start on machine boot, you can disable this setting using the flag `no`:
-
-[source, shell]
-----
-docker update --restart=no <containerID>
-----
-
-For more information on Docker restart policies, see link:https://docs.docker.com/config/containers/start-containers-automatically[The official Docker documentation].
+If you no longer want to have the container auto-start on machine boot, you can disable this setting using the flag `no`, for example, `docker update --restart=no <containerID>`. +
+For more information on Docker restart policies, see the link:https://docs.docker.com/config/containers/start-containers-automatically[official Docker documentation].
 ====
 
 [[docker-offline-installation]]

--- a/modules/ROOT/pages/docker/introduction.adoc
+++ b/modules/ROOT/pages/docker/introduction.adoc
@@ -1,27 +1,30 @@
 :description: An introduction to how Neo4j runs in a Docker container.
 [[docker-overview]]
-= Introduction
+= Getting Started with Neo4j in Docker
 
 Docker can be downloaded for macOS, Windows, and Linux operating systems from https://www.docker.com/get-started.
 DockerHub hosts an link:https://hub.docker.com/_/neo4j[official Neo4j image] that provides a standard, ready-to-run package of Neo4j Community Edition and Enterprise Edition for a variety of versions.
 
-[[docker-edition]]
-== Neo4j editions
+[[getting-docker-image]]
+== Getting the Neo4j Image
+Variants of the Neo4j image are tagged according to
+Community/Enterprise Edition and the operating system used as the base image.
 
-Tags are available for both Community Edition and Enterprise Edition.
-Version-specific Enterprise Edition tags have an `-enterprise` suffix, for example: `neo4j:{neo4j-version-exact}-enterprise`.
-Community Edition tags have no suffix, for example `neo4j:{neo4j-version-exact}`.
-The latest Neo4j Enterprise Edition release is available as `neo4j:enterprise`.
 
 All supported tags can be found at https://hub.docker.com/_/neo4j/tags.
 
+=== Neo4j Editions
+Tags are available for both Community Edition and Enterprise Edition.
+Version-specific Enterprise Edition tags have an `-enterprise` suffix after the version number, for example: `neo4j:{neo4j-version-exact}-enterprise`.
+Community Edition tags have no suffix, for example `neo4j:{neo4j-version-exact}`.
+The latest Neo4j Enterprise Edition release is available as `neo4j:enterprise`.
 
 Neo4j Enterprise Edition license::
 To use Neo4j Enterprise Edition, you must accept the license agreement by setting the environment variable `NEO4J_ACCEPT_LICENSE_AGREEMENT=yes`.
 +
 +
 ____
-(C) Network Engine for Objects in Lund AB.  2022.  All Rights Reserved.
+(C) Network Engine for Objects in Lund AB.  2023.  All Rights Reserved.
 Use of this Software without a proper commercial license with Neo4j,
 Inc. or its affiliates is prohibited.
 
@@ -29,6 +32,52 @@ Email inquiries can be sent using the form https://neo4j.com/contact-us[Contact 
 
 More information is also available at: https://neo4j.com/licensing/
 ____
+
+=== Base Operating System
+[TIP]
+====
+If you are unsure which base image to use, or have no preference, just use the default of `neo4j:{neo4j-version-exact}`.
+====
+Neo4j images are available with either `debian:bullseye-slim` or `redhat/ubi8-minimal:latest` as the base image.
+
+To specify which base image to use, the image tags optionally have a `-bullseye` or `-ubi8` suffix.
+If no base image is specified, the debian variant will be used by default.
+
+For example:
+
+[source, subs="attributes"]
+----
+neo4j:{neo4j-version-exact}-bullseye            # debian 11 community
+neo4j:{neo4j-version-exact}-enterprise-bullseye # debian 11 enterprise
+neo4j:{neo4j-version-exact}-ubi8              # redhat UBI8 community
+neo4j:{neo4j-version-exact}-enterprise-ubi8   # redhat UBI8 enterprise
+neo4j:{neo4j-version-exact}                   # debian 11 community
+neo4j:{neo4j-version-exact}-enterprise        # debian 11 enterprise
+----
+
+
+.Base images and the corresponding tag suffix.
+[options="header", cols="2"]
+|===
+| tag suffix
+| Base Image
+
+| `-bullseye`
+| `debian:bullseye-slim`
+
+| `-ubi8`
+| `redhat/ubi8-minimal:latest`
+
+| _unspecified_
+| `debian:bullseye-slim`
+|===
+
+
+[NOTE]
+====
+The redhat variant images are only available from 5.10.0 and onwards.
+For earlier Neo4j versions, do not specify a base image.
+====
 
 [[docker-image]]
 == Using the Neo4j Docker image
@@ -56,10 +105,33 @@ Use the `dbms.security.auth_minimum_password_length` configuration to change it.
 
 The following sections provide more information about how to set an initial password, configure Neo4j to persist data between restarts, and use the Neo4j Docker image.
 
+[[docker-simple-volumes]]
+== Persisting data using Volumes
+
+The `--volume` option maps a local folder to the container, where you can persist data between restarts.
+To persist the contents of the database between containers, mount a volume to the `/data` directory on starting the container:
+
+[source, shell, subs="attributes"]
+----
+docker run \
+    --restart always \
+    --publish=7474:7474 --publish=7687:7687 \
+    --env NEO4J_AUTH=neo4j/your_password \
+    --volume=/path/to/your/data:/data \
+    neo4j:{neo4j-version-exact}
+----
+
+[CAUTION]
+====
+The folders that you want to mount must exist before starting Docker, otherwise Neo4j will fail to start due to permissions errors.
+====
+
+For more information about mounting volumes, see xref:docker/mounting-volumes.adoc[].
+
 [[docker-auth]]
 == Using `NEO4J_AUTH` to set an initial password
 
-When using Neo4j in a Docker container, you can set the initial password for the container directly by specifying the `NEO4J_AUTH` in your run directive:
+When using Neo4j in a Docker container, you can set the initial password for the database directly by specifying the `NEO4J_AUTH` in your run directive:
 
 [source, shell, subs="attributes"]
 ----
@@ -69,14 +141,6 @@ docker run \
     --env NEO4J_AUTH=neo4j/your_password \
     neo4j:{neo4j-version-exact}
 ----
-
-[NOTE]
-====
-With no persistent storage for the databases, `NEO4J_AUTH` takes effect each time the container is recreated, even if you have changed the password.
-
-However, with persistent storage for the databases, `NEO4J_AUTH` only takes effect on the initial startup.
-It is ignored when the container is recreated and cannot override a changed password.
-====
 
 Alternatively, you can disable authentication by specifying `NEO4J_AUTH` to `none`:
 
@@ -87,44 +151,15 @@ Alternatively, you can disable authentication by specifying `NEO4J_AUTH` to `non
 
 Please note that there is currently no way to change the initial username from `neo4j`.
 
-[[docker-volumes]]
-== Persisting data using Volumes
-
-The `--volume` option maps a local folder to the container, where you can persist data between restarts. 
-
-[source, shell, subs="attributes"]
-----
-docker run \
-    --restart always \
-    --publish=7474:7474 --publish=7687:7687 \
-    --env NEO4J_AUTH=neo4j/your_password \
-    --volume=/path/to/your/data:/data \
-    --volume=/path/to/your/logs:/logs \
-    neo4j:{neo4j-version-exact}
-----
-
-The folders that you want to mount must exist before starting Docker, otherwise, Neo4j will fail to start due to permissions errors.
-
-[NOTE]
+[CAUTION]
 ====
-If you have mounted a _/data_ volume containing an existing database, setting `NEO4J_AUTH` will have no effect.
+*Setting `NEO4J_AUTH` will not override existing authentication.*
+
+If you have mounted a _/data_ volume containing an existing database, setting `NEO4J_AUTH` will have no effect because that database already has authentication configured.
 The Neo4j Docker service will start, but you will need a username and password already associated with the database to log in.
 ====
 
-[[docker-user]]
-== Running Neo4j as a non-root user
 
-For security reasons, Neo4j runs as the `neo4j` user inside the container.
-You can specify which user to run as by invoking docker with the `--user` argument.
-For example, the following runs Neo4j as your current user:
-
-[source, shell, subs="attributes"]
-----
-docker run \
-    --publish=7474:7474 --publish=7687:7687 \
-    --user="$(id -u):$(id -g)" \
-    neo4j:{neo4j-version-exact}
-----
 
 == More useful Docker Run options
 
@@ -153,7 +188,11 @@ This table lists some of the options available:
 
 |--env
 |Set config as environment variables for the Neo4j database
-|docker run --env NEO4J_AUTH=neo4j/your_password
+|docker run --env NEO4J_AUTH=neo4j/your_password neo4j
+
+|--user
+|Run neo4j as the given user, instead of `neo4j`
+|docker run --user="$(id -u):$(id -g)" neo4j
 
 |--restart
 |Control whether Neo4j containers start automatically when they exit, or when Docker restarts.

--- a/modules/ROOT/pages/docker/mounting-volumes.adoc
+++ b/modules/ROOT/pages/docker/mounting-volumes.adoc
@@ -1,44 +1,94 @@
 :description: How to use persistent storage when using Neo4j in Docker.
 [[docker-volumes]]
-= Mounting Storage to Docker
-// Mounting Docker Volumes
-// persistent storage in docker
+= Persisting data with Docker volumes
 
-Storage, in the form of a folder on the host file system or a Docker volume, can be mounted to Docker containers on `docker run` in order to:
+Docker containers are ephemeral.
+When a container is stopped, any data written to it is lost.
+Therefore, if you want to persist data when using Neo4j in Docker, you must mount storage to the container.
+Storages also allow you to get data in and out of the container.
 
-* persist data if the container is stopped
-* get data in or out of the container
+Storage can be mounted to a container in two ways:
 
-We provide a number of special mount points for storage to simplify using Neo4j in Docker.
+* A folder on the host file system.
+* A Docker volume -- a named storage location that is managed by Docker.
 
+For instructions on _how_ to mount storage to a Docker container, refer to the official Docker documentation link:https://docs.docker.com/storage/bind-mounts/[Bind mounts^] and link:https://docs.docker.com/storage/volumes/[Volumes^].
 
+Neo4j provides several mount points for storage to simplify using Neo4j in Docker.
+The following sections describe the mount points and how to use them.
 
+[[docker-volumes-mount-points]]
+== Neo4j mount points and permissions
 
-For instructions on _how_ to mount storage to a Docker container, it is best to refer to the official Docker documentation:
+The following table is a complete reference of the mount points recognized by the Neo4j Docker image, and file permissions.
 
-* link:https://docs.docker.com/storage/bind-mounts/[mounting a folder as persistent storage]
-* link:https://docs.docker.com/storage/volumes/[mounting a named volume as persistent storage]
+All the listed mount points are *optional*.
+Neo4j can run in Docker without any volumes mounted at all.
+However, mounting storage to `/data` is considered essential for all but the most basic use cases.
 
-In this documentation we mostly use folder mounts to demonstrate Neo4j Docker use, but named volume mounting is also supported.
+[WARNING]
+====
+Running containerized Neo4j without a `/data` mount results in *unrecoverable data loss* if anything happens to the container.
+====
 
+.Mount points for the Neo4j container
+[options="header", cols="1m,1,4"]
+|===
+| Mount point
+| Permissions required
+| Description
 
+| /data
+| read, write
+| The data store for the Neo4j database. See xref:#docker-volumes-data[].
+
+| /logs
+| read, write
+| Output directory for Neo4j logs. See xref:#docker-volumes-logs[].
+
+| /conf
+| readfootnote:[Write permissions are required when using the xref:docker/configuration.adoc#docker-conf-volume[`dump-config`] feature.]
+| Pass configuration files to Neo4j on startup. +
+See xref:docker/configuration.adoc[].
+
+| /plugins
+| readfootnote:[Write permissions are required when using the xref:docker/plugins.adoc#docker-plugins-caching[`NEO4J_PLUGINS` feature] to download and store plugins.]
+| Allows you to install plugins in containerized Neo4j. +
+See xref:docker/plugins.adoc[].
+
+| /licenses
+| read
+| Provide licenses for Neo4j and any plugins by mounting the license folder. +
+See xref:docker/plugins.adoc#docker-plugins-licenses[Installing Plugin Licenses].
+
+| /import
+| read
+| Make _csv_ and other importable files available to xref:docker/operations.adoc#docker-neo4j-import[neo4j-admin import].
+
+| /ssl
+| read
+| Provide SSL certificates to Neo4j for message encryption. +
+See xref:docker/security.adoc[]
+
+| /metrics
+| write
+| label:enterprise[Enterprise Edition] Output directory for metrics files.
+See xref:monitoring/metrics/index.adoc[Metrics].
+|===
 
 [[docker-volumes-data]]
-== The `/data` folder
+=== Mounting storage to `/data`
 
 Neo4j inside Docker stores database files in the `/data` folder.
-By mounting storage to `/data`, any data written to neo4j will persist after the container is stopped.
+By mounting storage to `/data`, any data written to Neo4j will persist after the container is stopped.
 
-Stopping the container and then restarting with the same folder mounted to `/data` will
-start a new containerized Neo4j instance with the same data.
+Stopping the container and then restarting with the same folder mounted to `/data` starts a new containerized Neo4j instance with the same data.
 
 [CAUTION]
 ====
-If Neo4j could not properly close down, it may have left data in a bad state, and is likely to fail on startup.
-This is the same as if Neo4j was run outside a container and not closed properly.
+If Neo4j could not properly close down, it may have left data in a bad state and is likely to fail on startup.
+This is the same as if Neo4j is run outside a container and not closed properly.
 ====
-
-
 
 .Two ways to mount storage to the `/data` mount point
 ====
@@ -58,16 +108,16 @@ docker run -it --rm \
    --volume neo4jdata:/data \  # <2>
    neo4j:{neo4j-version-exact}
 ----
-<1> Create a Docker volume named `neo4jdata`
-<2> Mount the volume name `neo4jdata` to `/data`
+<1> Create a Docker volume named `neo4jdata`.
+<2> Mount the volume name `neo4jdata` to `/data`.
 ====
 
 [[docker-volumes-logs]]
-== The `/logs` folder and Monitoring Neo4j
+=== Mounting storage to `/logs`
 
 Neo4j logging output is written to files in the _/logs_ directory.
 This directory is mounted as a _/logs_ volume.
-By mounting storage to `/logs` the log files will be available outside the container. +
+By mounting storage to `/logs`, the log files become available outside the container. +
 
 [TIP]
 ====
@@ -75,76 +125,21 @@ For more information about configuring Neo4j, see xref:docker/configuration.adoc
 For more information about the Neo4j log files, see xref:monitoring/logging.adoc[Logging].
 ====
 
-[[docker-volumes-mount-points]]
-== All Recognized Mount Points
-
-The following table is a complete reference of the mount points recognized by the Neo4j Docker image, and file permissions.
-
-All the listed mount points are *optional*. Neo4j will still run in Docker without any volumes mounted at all.
-However, mounting storage to `/data` is considered essential for all but the most basic use-cases.
-
-[WARNING]
-====
-Running containerized Neo4j without a `/data` mount *will* result in unrecoverable data loss if anything happens to the container.
-====
-
-.Mount points for the Neo4j container
-[options="header", cols="1m,1,4"]
-|===
-| Mount point
-| permissions required
-| Description
-
-| /data
-| read, write
-| The data store for the Neo4j database. See xref:#docker-volumes-data[]
-
-| /logs
-| read, write
-| Output directory for Neo4j logs. See xref:#docker-volumes-logs[]
-
-| /conf
-| readfootnote:[Write permissions also required if using the `dump-config` feature.]
-| Pass configuration files to Neo4j on start up. +
-See xref:docker/configuration.adoc[Docker Configuration].
-
-| /plugins
-| readfootnote:[Write permissions also required if using the xref:docker/plugins.adoc#docker-plugins-caching[`NEO4J_PLUGINS` feature] to download and store plugins.]
-| Allows you to install plugins in containerized Neo4j. +
-See xref:docker/plugins.adoc[].
-
-| /licenses
-| read
-| Provide licenses for Neo4j and any plugins by mounting the license folder here. +
-See xref:docker/plugins.adoc#docker-plugins-licenses[Installing Plugin Licenses].
-
-| /import
-| read
-| Make _csv_ and other importable files available to xref:docker/operations.adoc#docker-neo4j-import[neo4j-admin import].
-
-| /ssl
-| read
-| Provide SSL certificates to Neo4j for message encryption. +
-See xref:docker/security.adoc[]
-
-| /metrics
-| write
-| Enterprise only. Output directory for metrics files.
-See xref:monitoring/metrics/index.adoc[Metrics].
-|===
-
 
 [[docker-volumes-file-permissions]]
-== File Permissions
+== File permissions
 
-For security reasons, by default Neo4j runs as the `neo4j` user inside the container.
-This user has user ID 7474.
-If `neo4j` needs read or write access to a mounted folder, but does not have it, the folder will be automatically re-owned to 7474.
-This is a convenience feature so users do not have to worry about the finer details of file permissions in Docker and can get started more easily.
-It does however mean that mounted folders will change ownership, and you may find you can no longer read your files without root access.
+For security reasons, by default, Neo4j runs as the `neo4j` user inside the container.
+This user has user ID `7474`.
+If `neo4j` needs read or write access to a mounted folder, but does not have it, the folder will be automatically re-owned to `7474`.
 
+[NOTE]
+====
+This is a convenient feature, so you do not have to worry about the finer details of file permissions in Docker and can get started more easily.
+It does however mean that mounted folders change ownership, and you may find you can no longer read your files without root access.
+====
 
 === Docker `run` with `--user` flag
 
 The `--user` flag to `docker run` forces Docker to run as the provided user.
-In this situation, if that user does not have the required read or write access to any mounted folders then Neo4j will fail to start.
+In this situation, if that user does not have the required read or write access to any mounted folders, Neo4j will fail to start.

--- a/modules/ROOT/pages/docker/mounting-volumes.adoc
+++ b/modules/ROOT/pages/docker/mounting-volumes.adoc
@@ -61,6 +61,19 @@ docker run -it --rm \
 <2> Mount the volume name `neo4jdata` to `/data`
 ====
 
+[[docker-volumes-logs]]
+== The `/logs` folder and Monitoring Neo4j
+
+Neo4j logging output is written to files in the _/logs_ directory.
+This directory is mounted as a _/logs_ volume.
+By mounting storage to `/logs` the log files will be available outside the container. +
+
+[TIP]
+====
+For more information about configuring Neo4j, see xref:docker/configuration.adoc[Configuration]. +
+For more information about the Neo4j log files, see xref:monitoring/logging.adoc[Logging].
+====
+
 [[docker-volumes-mount-points]]
 == All Recognized Mount Points
 
@@ -87,8 +100,7 @@ Running containerized Neo4j without a `/data` mount *will* result in unrecoverab
 
 | /logs
 | read, write
-| Output directory for Neo4j logs. By mounting storage to `/logs` the log files will be available outside the container. +
-For more information about the Neo4j log files, see xref:monitoring/logging.adoc[Logging].
+| Output directory for Neo4j logs. See xref:#docker-volumes-logs[]
 
 | /conf
 | readfootnote:[Write permissions also required if using the `dump-config` feature.]

--- a/modules/ROOT/pages/docker/mounting-volumes.adoc
+++ b/modules/ROOT/pages/docker/mounting-volumes.adoc
@@ -1,0 +1,137 @@
+:description: How to use persistent storage when using Neo4j in Docker.
+[[docker-volumes]]
+= Mounting Storage to Docker
+// Mounting Docker Volumes
+// persistent storage in docker
+
+Storage, in the form of a folder on the host file system or a Docker volume, can be mounted to Docker containers on `docker run` in order to:
+
+* persist data if the container is stopped
+* get data in or out of the container
+
+We provide a number of special mount points for storage to simplify using Neo4j in Docker.
+
+
+
+
+For instructions on _how_ to mount storage to a Docker container, it is best to refer to the official Docker documentation:
+
+* link:https://docs.docker.com/storage/bind-mounts/[mounting a folder as persistent storage]
+* link:https://docs.docker.com/storage/volumes/[mounting a named volume as persistent storage]
+
+In this documentation we mostly use folder mounts to demonstrate Neo4j Docker use, but named volume mounting is also supported.
+
+
+
+[[docker-volumes-data]]
+== The `/data` folder
+
+Neo4j inside Docker stores database files in the `/data` folder.
+By mounting storage to `/data`, any data written to neo4j will persist after the container is stopped.
+
+Stopping the container and then restarting with the same folder mounted to `/data` will
+start a new containerized Neo4j instance with the same data.
+
+[CAUTION]
+====
+If Neo4j could not properly close down, it may have left data in a bad state, and is likely to fail on startup.
+This is the same as if Neo4j was run outside a container and not closed properly.
+====
+
+
+
+.Two ways to mount storage to the `/data` mount point
+====
+.Mounting a folder to `/data`
+[source, shell, subs="attributes"]
+----
+docker run -it --rm \
+   --volume $HOME/neo4j/data:/data \
+   neo4j:{neo4j-version-exact}
+----
+.Creating a named volume and mounting it to `/data`
+[source, shell, subs="attributes"]
+----
+docker volume create neo4jdata #<1>
+docker run -it --rm \
+   --volume neo4jdata:/data \ #<2>
+   neo4j:{neo4j-version-exact}
+----
+<1> Create a Docker volume named `neo4jdata`
+<2> Mount the volume name `neo4jdata` to `/data`
+====
+
+[[docker-volumes-mount-points]]
+== All Recognized Mount Points
+
+The following table is a complete reference of the mount points recognized by the Neo4j Docker image, and file permissions.
+
+All the listed mount points are *optional*. Neo4j will still run in Docker without any volumes mounted at all.
+However, mounting storage to `/data` is considered essential for all but the most basic use-cases.
+
+[WARNING]
+====
+Running containerized Neo4j without a `/data` mount *will* result in unrecoverable data loss if anything happens to the container.
+====
+
+.Mount points for the Neo4j container
+[options="header", cols="1m,1,4"]
+|===
+| Mount point
+| permissions required
+| Description
+
+| /data
+| read, write
+| The data store for the Neo4j database. See xref:#docker-volumes-data[]
+
+| /logs
+| read, write
+| Output directory for Neo4j logs. By mounting storage to `/logs` the log files will be available outside the container. +
+For more information about the Neo4j log files, see xref:monitoring/logging.adoc[Logging].
+
+| /conf
+| readfootnote:[Write permissions also required if using the `dump-config` feature.]
+| Pass configuration files to Neo4j on start up. +
+See xref:docker/configuration.adoc[Docker Configuration].
+
+| /plugins
+| readfootnote:[Write permissions also required if using the xref:docker/plugins.adoc#docker-plugins-caching[`NEO4J_PLUGINS` feature] to download and store plugins.]
+| Allows you to install plugins in containerized Neo4j. +
+See xref:docker/plugins.adoc[].
+
+| /licenses
+| read
+| Provide licenses for Neo4j and any plugins by mounting the license folder here. +
+See xref:docker/plugins.adoc#docker-plugins-licenses[Installing Plugin Licenses].
+
+| /import
+| read
+| Make _csv_ and other importable files available to xref:docker/operations.adoc#docker-neo4j-import[neo4j-admin import].
+
+| /ssl
+| read
+| Provide SSL certificates to Neo4j for message encryption. +
+See xref:docker/security.adoc[]
+
+| /metrics
+| write
+| Enterprise only. Output directory for metrics files.
+See xref:monitoring/metrics/index.adoc[Metrics].
+|===
+
+
+[[docker-volumes-file-permissions]]
+== File Permissions
+
+For security reasons, by default Neo4j runs as the `neo4j` user inside the container.
+This user has user ID 7474.
+If `neo4j` needs read or write access to a mounted folder, but does not have it, the folder will be automatically re-owned to 7474.
+This is a convenience feature so users do not have to worry about the finer details of file permissions in Docker and can get started more easily.
+It does however mean that mounted folders will change ownership, and you may find you can no longer read your files without root access.
+
+
+=== Docker `run` with `--user` flag
+
+The `--user` flag to `docker run` forces Docker to run as the provided user.
+In this situation, if that user does not have the required read or write access to any mounted folders then Neo4j will fail to start.

--- a/modules/ROOT/pages/docker/mounting-volumes.adoc
+++ b/modules/ROOT/pages/docker/mounting-volumes.adoc
@@ -49,12 +49,13 @@ docker run -it --rm \
    --volume $HOME/neo4j/data:/data \
    neo4j:{neo4j-version-exact}
 ----
+
 .Creating a named volume and mounting it to `/data`
-[source, shell, subs="attributes"]
+[source, shell, subs="attributes+,+macros"]
 ----
-docker volume create neo4jdata #<1>
+docker volume create neo4jdata # <1>
 docker run -it --rm \
-   --volume neo4jdata:/data \ #<2>
+   --volume neo4jdata:/data \  # <2>
    neo4j:{neo4j-version-exact}
 ----
 <1> Create a Docker volume named `neo4jdata`

--- a/modules/ROOT/pages/docker/operations.adoc
+++ b/modules/ROOT/pages/docker/operations.adoc
@@ -116,13 +116,13 @@ The `neo4j-admin-report` script is just a wrapper around `neo4j-admin server rep
 .Example of getting a Neo4j report from a containerised Neo4j database
 ====
 Start a Neo4j container and mount a folder for the report output to be written to.
-[source, shell, subs="attributes"]
+[source, shell, subs="attributes+,+macros"]
 ----
 docker run --interactive --tty --rm \
     --name=neo4j \
     --publish=7474:7474 --publish=7687:7687 \
     --volume=$HOME/neo4j/data:/data \
-    --volume=$HOME/neo4j/reports:/reports \ #<1>
+    --volume=$HOME/neo4j/reports:/reports \ # <1>
     neo4j:{neo4j-version-exact}
 ----
 <1> The folder the reports will be written to.
@@ -130,11 +130,11 @@ docker run --interactive --tty --rm \
 
 Then in a `docker exec`, run the `neo4j-admin-report` wrapper script, specifying the output directory for the reports.
 
-[source, shell]
+[source, shell, subs="attributes+,+macros"]
 ----
 docker exec --interactive --tty <containerID/name> \
     neo4j-admin-report \
-        --to-path=/reports \ #<1>
+        --to-path=/reports \ # <1>
 ----
 <1> If no `--to-path` option is specified, the reports will be written to `/tmp/reports`.
 

--- a/modules/ROOT/pages/docker/operations.adoc
+++ b/modules/ROOT/pages/docker/operations.adoc
@@ -94,14 +94,12 @@ NEO4J_server_jvm_additional='-XX:+ExitOnOutOfMemoryError'
 ====
 
 [[docker-neo4j-admin-report]]
-== Use Neo4j Admin Report
+== Use Neo4j Admin report
 
-The `neo4j-admin server report` command is a useful reporting tool for analyzing the status of a running Neo4j database.
-Documentation for this tool can be found at xref:tools/neo4j-admin/neo4j-admin-report.adoc[], including additional options.
-
-
-In a containerized environment, neo4j report must be invoked using the script `neo4j-admin-report`. This ensures that the reporter is running with all the necessary file permissions required to analyze the running Neo4j processes.
-This script takes all the same arguments as the xref:tools/neo4j-admin/neo4j-admin-report.adoc[]
+The xref:tools/neo4j-admin/neo4j-admin-report.adoc[Neo4j Admin report tool] generates a report of the status of a running Neo4j database. +
+In a containerized environment, its command `neo4j-admin server report` must be invoked using the script `neo4j-admin-report`.
+This ensures that the reporter is running with all the necessary file permissions required to analyze the running Neo4j processes.
+This script takes all the arguments of the `neo4j-admin server report` command.
 
 
 [NOTE]
@@ -111,11 +109,9 @@ It is possible to use `docker exec` to run `neo4j-admin server report` directly 
 The `neo4j-admin-report` script is just a wrapper around `neo4j-admin server report` which automatically handles most permission problems.
 ====
 
-
-
 .Example of getting a Neo4j report from a containerised Neo4j database
 ====
-Start a Neo4j container and mount a folder for the report output to be written to.
+Start a Neo4j container and mount a folder for storing the reports.
 [source, shell, subs="attributes+,+macros"]
 ----
 docker run --interactive --tty --rm \
@@ -125,10 +121,10 @@ docker run --interactive --tty --rm \
     --volume=$HOME/neo4j/reports:/reports \ # <1>
     neo4j:{neo4j-version-exact}
 ----
-<1> The folder the reports will be written to.
+<1> The output folder for the reports.
 
 
-Then in a `docker exec`, run the `neo4j-admin-report` wrapper script, specifying the output directory for the reports.
+Then, using `docker exec`, run the `neo4j-admin-report` wrapper script, specifying the output directory for the reports.
 
 [source, shell, subs="attributes+,+macros"]
 ----

--- a/modules/ROOT/pages/docker/operations.adoc
+++ b/modules/ROOT/pages/docker/operations.adoc
@@ -93,6 +93,56 @@ NEO4J_server_jvm_additional='-XX:+ExitOnOutOfMemoryError'
 ----
 ====
 
+[[docker-neo4j-admin-report]]
+== Use Neo4j Admin Report
+
+The `neo4j-admin server report` command is a useful reporting tool for analyzing the status of a running Neo4j database.
+Documentation for this tool can be found at xref:tools/neo4j-admin/neo4j-admin-report.adoc[], including additional options.
+
+
+In a containerized environment, neo4j report must be invoked using the script `neo4j-admin-report`. This ensures that the reporter is running with all the necessary file permissions required to analyze the running Neo4j processes.
+This script takes all the same arguments as the xref:tools/neo4j-admin/neo4j-admin-report.adoc[]
+
+
+[NOTE]
+====
+It is possible to use `docker exec` to run `neo4j-admin server report` directly inside the container, but the file permissions required to access running processes _and_ to write files to a mounted folder can be conflicting.
+
+The `neo4j-admin-report` script is just a wrapper around `neo4j-admin server report` which automatically handles most permission problems.
+====
+
+
+
+.Example of getting a Neo4j report from a containerised Neo4j database
+====
+Start a Neo4j container and mount a folder for the report output to be written to.
+[source, shell, subs="attributes"]
+----
+docker run --interactive --tty --rm \
+    --name=neo4j \
+    --publish=7474:7474 --publish=7687:7687 \
+    --volume=$HOME/neo4j/data:/data \
+    --volume=$HOME/neo4j/reports:/reports \ #<1>
+    neo4j:{neo4j-version-exact}
+----
+<1> The folder the reports will be written to.
+
+
+Then in a `docker exec`, run the `neo4j-admin-report` wrapper script, specifying the output directory for the reports.
+
+[source, shell]
+----
+docker exec --interactive --tty <containerID/name> \
+    neo4j-admin-report \
+        --to-path=/reports \ #<1>
+----
+<1> If no `--to-path` option is specified, the reports will be written to `/tmp/reports`.
+
+The `$HOME/neo4j/reports` folder should now contain a zip file of reports.
+====
+
+
+
 [[docker-cypher-shell]]
 == Use Cypher Shell
 
@@ -247,78 +297,3 @@ Actors, Movies, MovieYear
 These commands take the contents of the script file and pass it into the Docker container using Cypher Shell.
 Then, they run a Cypher example, `LOAD CSV` dataset, which might be hosted somewhere on a server (with `curl`), create indexes, constraints, or do other administrative operations.
 
-[[docker-procedures]]
-== Install user-defined procedures
-
-To install link:{neo4j-docs-base-uri}/java-reference/{page-version}/extending-neo4j/procedures#extending-neo4j-procedures[user-defined procedures], mount the _/plugins_ volume containing the jars.
-
-[source, shell, subs="attributes"]
-----
-docker run \
-   --publish=7474:7474 --publish=7687:7687 \
-   --volume=$HOME/neo4j/plugins:/plugins \
-   neo4j:{neo4j-version-exact}
-----
-
-[[docker-neo4j-plugins]]
-== Configure Neo4j plugins
-
-The Neo4j Docker image includes a startup script that can automatically download and configure certain Neo4j plugins at runtime.
-
-[NOTE]
-====
-This feature is intended to facilitate using Neo4j plugins in development environments, but it is not recommended for use in production environments.
-
-To use plugins in production with Neo4j Docker containers, see xref:docker/operations.adoc#docker-procedures[Install user-defined procedures].
-====
-
-The `NEO4J_PLUGINS` environment variable can be used to specify the plugins to install using this method.
-This should be set to a JSON-formatted list of the xref:configuration/plugins.adoc[supported plugins].
-
-[NOTE]
-====
-Running Bloom in a Docker container requires Neo4j Docker image 4.2.3-enterprise or later.
-====
-
-From Neo4j 5.6 onwards, if invalid `NEO4J_PLUGINS` values are passed, Neo4j returns a notification that the plugin is not known.
-For example, `--env NEO4J_PLUGINS='["gds"]'` returns the following notification:
-
-.Example output
-[source, shell, role="noheader"]
-----
-"gds" is not a known Neo4j plugin. Options are:
-apoc
-apoc-core
-bloom
-graph-data-science
-graphql
-n10s
-----
-
-.Install the APOC Core plugin (`apoc`)
-====
-You can use the Docker argument `--env NEO4J_PLUGINS='["apoc"]'` and run the following command:
-
-[source, shell, subs="attributes"]
-----
-docker run -it --rm \
-  --publish=7474:7474 --publish=7687:7687 \
-  --env NEO4J_AUTH=none \
-  --env NEO4J_PLUGINS='["apoc"]' \
-  neo4j:{neo4j-version-exact}
-----
-====
-
-.Install the APOC Core plugin (`apoc`) and the Neo Semantics plugin (`n10s`)
-====
-You can use the Docker argument `--env NEO4J_PLUGINS='["apoc", "n10s"]'` and run the following command:
-
-[source, shell, subs="attributes"]
-----
-docker run -it --rm \
-  --publish=7474:7474 --publish=7687:7687 \
-  --env NEO4J_AUTH=none \
-  --env NEO4J_PLUGINS='["apoc", "n10s"]' \
-  neo4j:{neo4j-version-exact}
-----
-====

--- a/modules/ROOT/pages/docker/plugins.adoc
+++ b/modules/ROOT/pages/docker/plugins.adoc
@@ -1,0 +1,173 @@
+:description: How to load plugins when using Neo4j in Docker.
+[[docker-plugins]]
+= Configuring Plugins with Docker
+
+
+This page describes how to install plugins into a Neo4j instance running inside a Docker container.
+For instructions about plugins in general see xref:configuration/plugins.adoc[Configuration -> Plugins].
+
+
+
+[[docker-plugins-procedures]]
+== Installing Plugins
+
+To install plugins, including  link:{neo4j-docs-base-uri}/java-reference/{page-version}/extending-neo4j/procedures#extending-neo4j-procedures[user-defined procedures], mount the folder or volume containing the plugin jars to `/plugins`:
+
+[source, shell, subs="attributes"]
+----
+docker run \
+   --publish=7474:7474 --publish=7687:7687 \
+   --volume=$HOME/neo4j/plugins:/plugins \
+   neo4j:{neo4j-version-exact}
+----
+
+Neo4j will automatically load any plugins found in the `/plugins` folder on start up.
+
+
+[[docker-plugins-neo4jplugins]]
+== `NEO4J_PLUGINS` utility
+
+The Neo4j Docker image includes a startup script that can automatically download and configure certain Neo4j plugins at runtime.
+
+[NOTE]
+====
+This feature is intended to facilitate using Neo4j plugins in development environments, but it is not recommended for use in production environments.
+
+To use plugins in production with Neo4j Docker containers, see xref:docker/plugins.adoc#docker-plugins-procedures[Install user-defined procedures].
+====
+
+The `NEO4J_PLUGINS` environment variable can be used to specify the plugins to install using this method.
+This should be set to a JSON-formatted list of the xref:configuration/plugins.adoc[supported plugins].
+
+[NOTE]
+====
+Running Bloom in a Docker container requires Neo4j Docker image 4.2.3-enterprise or later.
+====
+
+If invalid `NEO4J_PLUGINS` values are passed, Neo4j returns a notification that the plugin is not known.
+For example, `--env NEO4J_PLUGINS='["gds"]'` returns the following notification:
+
+.Example output
+[source, shell, role="noheader"]
+----
+"gds" is not a known Neo4j plugin. Options are:
+apoc
+apoc-extended
+bloom
+graph-data-science
+graphql
+n10s
+----
+
+.Install the APOC Core plugin (`apoc`)
+====
+You can use the Docker argument `--env NEO4J_PLUGINS='["apoc"]'` and run the following command:
+
+[source, shell, subs="attributes"]
+----
+docker run -it --rm \
+  --publish=7474:7474 --publish=7687:7687 \
+  --env NEO4J_AUTH=none \
+  --env NEO4J_PLUGINS='["apoc"]' \
+  neo4j:{neo4j-version-exact}
+----
+====
+
+.Install the APOC Core plugin (`apoc`) and the Graph Data Science plugin (`graph-data-science`)
+====
+You can use the Docker argument `--env NEO4J_PLUGINS='["apoc", "graph-data-science"]'` and run the following command:
+
+[source, shell, subs="attributes"]
+----
+docker run -it --rm \
+  --publish=7474:7474 --publish=7687:7687 \
+  --env NEO4J_AUTH=none \
+  --env NEO4J_PLUGINS='["apoc", "graph-data-science"]' \
+  neo4j:{neo4j-version-exact}
+----
+====
+
+[[docker-plugins-caching]]
+=== Storing Downloaded Plugins
+
+In situations where bandwidth is limited, or Neo4j is stopped and started frequently, it may be desirable to download plugins once and re-use them rather than downloading them each time.
+
+By using the `NEO4J_PLUGINS` utility in combination with mounting storage to `/plugins`, the plugin jars will be downloaded into the `/plugins` folder.
+This can then be used again later to supply the same plugins to Neo4j without needing to set `NEO4J_PLUGINS`.
+
+
+
+.Example of automatically downloading and re-using plugins with docker.
+====
+.Get the APOC plugin and save it into `$HOME/neo4j/plugins`
+[source, shell, subs="attributes"]
+----
+docker run -it --rm \
+  --publish=7474:7474 --publish=7687:7687 \
+  --env NEO4J_AUTH=none \
+  --env NEO4J_PLUGINS='["apoc"]' \
+   --volume=$HOME/neo4j/plugins:/plugins \ #<1>
+  neo4j:{neo4j-version-exact}
+----
+<1> Mounts host folder `$HOME/neo4j/plugins` to `/plugins`
+
+.Verify the apoc plugin was downloaded
+[source, shell]
+----
+docker kill <containerID/name>
+ls $HOME/neo4j/plugins
+  apoc.jar
+----
+
+.Start a new container and verify apoc is installed
+[source, shell, subs="attributes"]
+----
+docker run -it --rm \
+  --publish=7474:7474 --publish=7687:7687 \
+  --env NEO4J_AUTH=none \
+   --volume=$HOME/neo4j/plugins:/plugins \
+  neo4j:{neo4j-version-exact}
+
+cypher-shell "RETURN apoc.version();"
+----
+====
+
+[[docker-plugins-licenses]]
+== Installing Plugin Licenses
+
+If a plugin requires a license, the license file can be supplied to the container by mounting the folder or volume containing license file(s) to `/licenses`.
+
+[NOTE]
+====
+To check if the plugin requires a license, refer to the xref:configuration/plugins.adoc[general plugin documentation].
+====
+
+
+.Installing plugins and licenses by mounting folders to the container
+====
+[source, shell, subs="attributes"]
+----
+docker run \
+   --publish=7474:7474 --publish=7687:7687 \
+   --volume=$HOME/neo4j/plugins:/plugins \ #<1>
+   --volume=$HOME/neo4j/licenses:/licenses \ #<2>
+   neo4j:{neo4j-version-exact}
+----
+<1> folder containing plugin jars.
+<2> folder containing license files.
+====
+
+The licenses must also be provided if using the `NEO4J_PLUGINS` utility to install the plugins.
+
+.Installing plugins and licenses by mounting folders to the container using `NEO4J_PLUGINS` utility
+====
+[source, shell, subs="attributes"]
+----
+docker run \
+   --publish=7474:7474 --publish=7687:7687 \
+   --env NEO4J_PLUGINS='["bloom"]' \
+   --volume=$HOME/neo4j/licenses:/licenses \ #<1>
+   neo4j:{neo4j-version-exact}
+----
+<1> folder containing license files.
+====

--- a/modules/ROOT/pages/docker/plugins.adoc
+++ b/modules/ROOT/pages/docker/plugins.adoc
@@ -1,6 +1,6 @@
 :description: How to load plugins when using Neo4j in Docker.
 [[docker-plugins]]
-= Configuring Plugins with Docker
+= Plugins
 
 
 This page describes how to install plugins into a Neo4j instance running inside a Docker container.
@@ -9,9 +9,9 @@ For instructions about plugins in general see xref:configuration/plugins.adoc[Co
 
 
 [[docker-plugins-procedures]]
-== Installing Plugins
+== Installing plugins
 
-To install plugins, including  link:{neo4j-docs-base-uri}/java-reference/{page-version}/extending-neo4j/procedures#extending-neo4j-procedures[user-defined procedures], mount the folder or volume containing the plugin jars to `/plugins`:
+To install plugins, including  link:{neo4j-docs-base-uri}/java-reference/{page-version}/extending-neo4j/procedures#extending-neo4j-procedures[user-defined procedures], mount the folder or volume containing the plugin JARs to `/plugins`, for example:
 
 [source, shell, subs="attributes"]
 ----
@@ -21,7 +21,7 @@ docker run \
    neo4j:{neo4j-version-exact}
 ----
 
-Neo4j will automatically load any plugins found in the `/plugins` folder on start up.
+Neo4j automatically loads any plugins found in the `/plugins` folder on startup.
 
 
 [[docker-plugins-neo4jplugins]]
@@ -31,7 +31,7 @@ The Neo4j Docker image includes a startup script that can automatically download
 
 [NOTE]
 ====
-This feature is intended to facilitate using Neo4j plugins in development environments, but it is not recommended for use in production environments.
+This feature is intended to facilitate the use of the Neo4j plugins in development environments, but it is not recommended for production environments.
 
 To use plugins in production with Neo4j Docker containers, see xref:docker/plugins.adoc#docker-plugins-procedures[Install user-defined procedures].
 ====
@@ -88,14 +88,12 @@ docker run -it --rm \
 ====
 
 [[docker-plugins-caching]]
-=== Storing Downloaded Plugins
+== Storing downloaded plugins
 
 In situations where bandwidth is limited, or Neo4j is stopped and started frequently, it may be desirable to download plugins once and re-use them rather than downloading them each time.
 
-By using the `NEO4J_PLUGINS` utility in combination with mounting storage to `/plugins`, the plugin jars will be downloaded into the `/plugins` folder.
+By using the `NEO4J_PLUGINS` utility in combination with mounting storage to `/plugins`, the plugin jars are downloaded into the `/plugins` folder.
 This can then be used again later to supply the same plugins to Neo4j without needing to set `NEO4J_PLUGINS`.
-
-
 
 .Example of automatically downloading and re-using plugins with docker.
 ====
@@ -109,9 +107,9 @@ docker run -it --rm \
    --volume=$HOME/neo4j/plugins:/plugins \ # <1>
   neo4j:{neo4j-version-exact}
 ----
-<1> Mounts host folder `$HOME/neo4j/plugins` to `/plugins`
+<1> Mounts host folder `$HOME/neo4j/plugins` to `/plugins`.
 
-.Verify the apoc plugin was downloaded
+.Verify the `apoc` plugin is downloaded.
 [source, shell]
 ----
 docker kill <containerID/name>
@@ -119,7 +117,7 @@ ls $HOME/neo4j/plugins
   apoc.jar
 ----
 
-.Start a new container and verify apoc is installed
+.Start a new container and verify `apoc` is installed.
 [source, shell, subs="attributes"]
 ----
 docker run -it --rm \
@@ -133,7 +131,7 @@ cypher-shell "RETURN apoc.version();"
 ====
 
 [[docker-plugins-licenses]]
-== Installing Plugin Licenses
+== Installing plugin licenses
 
 If a plugin requires a license, the license file can be supplied to the container by mounting the folder or volume containing license file(s) to `/licenses`.
 
@@ -141,7 +139,6 @@ If a plugin requires a license, the license file can be supplied to the containe
 ====
 To check if the plugin requires a license, refer to the xref:configuration/plugins.adoc[general plugin documentation].
 ====
-
 
 .Installing plugins and licenses by mounting folders to the container
 ====
@@ -169,5 +166,5 @@ docker run \
    --volume=$HOME/neo4j/licenses:/licenses \ # <1>
    neo4j:{neo4j-version-exact}
 ----
-<1> folder containing license files.
+<1> A folder containing license files.
 ====

--- a/modules/ROOT/pages/docker/plugins.adoc
+++ b/modules/ROOT/pages/docker/plugins.adoc
@@ -100,13 +100,13 @@ This can then be used again later to supply the same plugins to Neo4j without ne
 .Example of automatically downloading and re-using plugins with docker.
 ====
 .Get the APOC plugin and save it into `$HOME/neo4j/plugins`
-[source, shell, subs="attributes"]
+[source, shell, subs="attributes+,+macros"]
 ----
 docker run -it --rm \
   --publish=7474:7474 --publish=7687:7687 \
   --env NEO4J_AUTH=none \
   --env NEO4J_PLUGINS='["apoc"]' \
-   --volume=$HOME/neo4j/plugins:/plugins \ #<1>
+   --volume=$HOME/neo4j/plugins:/plugins \ # <1>
   neo4j:{neo4j-version-exact}
 ----
 <1> Mounts host folder `$HOME/neo4j/plugins` to `/plugins`
@@ -145,12 +145,12 @@ To check if the plugin requires a license, refer to the xref:configuration/plugi
 
 .Installing plugins and licenses by mounting folders to the container
 ====
-[source, shell, subs="attributes"]
+[source, shell, subs="attributes+,+macros"]
 ----
 docker run \
    --publish=7474:7474 --publish=7687:7687 \
-   --volume=$HOME/neo4j/plugins:/plugins \ #<1>
-   --volume=$HOME/neo4j/licenses:/licenses \ #<2>
+   --volume=$HOME/neo4j/plugins:/plugins \   # <1>
+   --volume=$HOME/neo4j/licenses:/licenses \ # <2>
    neo4j:{neo4j-version-exact}
 ----
 <1> folder containing plugin jars.
@@ -161,12 +161,12 @@ The licenses must also be provided if using the `NEO4J_PLUGINS` utility to insta
 
 .Installing plugins and licenses by mounting folders to the container using `NEO4J_PLUGINS` utility
 ====
-[source, shell, subs="attributes"]
+[source, shell, subs="attributes+,+macros"]
 ----
 docker run \
    --publish=7474:7474 --publish=7687:7687 \
    --env NEO4J_PLUGINS='["bloom"]' \
-   --volume=$HOME/neo4j/licenses:/licenses \ #<1>
+   --volume=$HOME/neo4j/licenses:/licenses \ # <1>
    neo4j:{neo4j-version-exact}
 ----
 <1> folder containing license files.

--- a/modules/ROOT/pages/docker/security.adoc
+++ b/modules/ROOT/pages/docker/security.adoc
@@ -86,11 +86,11 @@ For more information on configuring connectors, see xref:configuration/connector
 [source, shell, subs="attributes+,+macros"]
 ----
 docker run \
-    --publish=7473:7473 \ #<1>
+    --publish=7473:7473 \ # <1>
     --publish=7687:7687 \
-    --user="$(id -u):$(id -g)" \ #<2>
-    --volume=$HOME/neo4j/certificates:/ssl \ #<3>
-    --volume=$HOME/neo4j/conf:/conf \ #<4>
+    --user="$(id -u):$(id -g)" \ # <2>
+    --volume=$HOME/neo4j/certificates:/ssl \ # <3>
+    --volume=$HOME/neo4j/conf:/conf \ # <4>
     neo4j:{neo4j-version-exact}
 ----
 
@@ -112,13 +112,13 @@ For more information on how to convert the Neo4j settings to the form accepted b
 [source, shell, subs="attributes+,+macros"]
 ----
 docker run \
-    --publish=7473:7473 \ #<1>
+    --publish=7473:7473 \ # <1>
     --publish=7687:7687 \
-    --user="$(id -u):$(id -g)" \ #<2>
-    --volume=$HOME/neo4j/certificates:/ssl \ #<3>
-    --env NEO4J_dbms_connector_https_enabled=true \ #<4>
-    --env NEO4J_dbms_ssl_policy_https_enabled=true \ #<5>
-    --env NEO4J_dbms_ssl_policy_https_base__directory=/ssl/https \ #<6>
+    --user="$(id -u):$(id -g)" \ # <2>
+    --volume=$HOME/neo4j/certificates:/ssl \ # <3>
+    --env NEO4J_dbms_connector_https_enabled=true \ # <4>
+    --env NEO4J_dbms_ssl_policy_https_enabled=true \ # <5>
+    --env NEO4J_dbms_ssl_policy_https_base__directory=/ssl/https \ # <6>
     neo4j:{neo4j-version-exact}
 ----
 <1> The port to access the HTTPS endpoint.


### PR DESCRIPTION
changes include:

* separated maintenance.adoc into 2 separate pages, for backup/restore and dump/load.
* new information about tagging, now that we have both debian and redhat images
* documentation for mount points and what they do, including cross references to other parts of the docker doc.
* Neo4j admin report usage
* a dedicated page about plugins. Most of this is taken from operations.adoc about user defined procedures.


I still need to add documentation for the `EXTENDED_CONF` feature which lets you do `--expand-commands`. But while I was writing the doc I realised the feature is terrible and needs renaming and fixing, so that change is still to come.
