### PR TITLE
Document index metrics

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -263,6 +263,30 @@ By default, database metrics include:
 |<prefix>.transaction.tx_size_native|The transactions' size in native memory in bytes. (histogram)
 |===
 
+.Database index metrics
+
+[options="header",cols="<3m,<4"]
+|===
+|Name |Description
+|<prefix>.index.fulltext.queried|The total number of times fulltext indexes have been queried. (counter)
+|<prefix>.index.fulltext.populated|The total number of fulltext index population jobs that have been completed. (counter)
+
+|<prefix>.index.lookup.queried|The total number of times lookup indexes have been queried. (counter)
+|<prefix>.index.lookup.populated|The total number of lookup index population jobs that have been completed. (counter)
+
+|<prefix>.index.text.queried|The total number of times text indexes have been queried. (counter)
+|<prefix>.index.text.populated|The total number of text index population jobs that have been completed. (counter)
+
+|<prefix>.index.range.queried|The total number of times range indexes have been queried. (counter)
+|<prefix>.index.range.populated|The total number of range index population jobs that have been completed. (counter)
+
+|<prefix>.index.point.queried|The total number of times point indexes have been queried. (counter)
+|<prefix>.index.point.populated|The total number of point index population jobs that have been completed. (counter)
+
+|<prefix>.index.vector.queried|The total number of times vector indexes have been queried. (counter)
+|<prefix>.index.vector.populated|The total number of vector index population jobs that have been completed. (counter)
+|===
+
 .Server metrics
 
 [options="header",cols="<3m,<4"]


### PR DESCRIPTION
Admittedly it's not very pretty to enumerate each metric like this because they are identical except for the index type, but that's how they're defined in the software. Thoughts?