### PR TITLE
Fix an error in example for `db.tx_log.rotation.retention_policy`

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -4601,14 +4601,14 @@ label:dynamic[Dynamic]
 a|Specify how long Neo4j should keep logical transaction logs to backup the database.
 For example, `10 days` prunes logical logs that only contain transactions older than 10 days.
 Alternatively, `100k txs` keeps the 100k latest transactions from each database and prunes any older transactions.
-From Neo4j 5.9 onwards, you can optionally add a period-based restriction to the size of logs to keep, for example, `2days 1G` prunes logical logs that only contain transactions older than 2 days or are larger than 1G.
+From Neo4j 5.9 onwards, you can optionally add a period-based restriction to the size of logs to keep, for example, `2 days 1G` prunes logical logs that only contain transactions older than 2 days or are larger than 1G.
 |Valid values
 a|a string which matches the pattern, `^(true\|keep_all\|false\|keep_none\|(\\d+[KkMmGg]?( (files\|size\|txs\|entries\|hours( \\d+[KkMmGg]?)?\|days( \\d+[KkMmGg]?)?))))$`
 Must be `true` or `keep_all`, `false` or `keep_none`, or of format `<number><optional unit> <type> <optional space restriction>`.
 Valid units are `K`, `M`, and `G`.
 Valid types are `files`, `size`, `txs`, `entries`, `hours`, and `days`.
 Valid optional space restriction is a logical log space restriction like `1G`.
-For example, `1G size` limits logical log space on the disk to 1G per database, `200K txs` limits the number of transactions kept to 200 000 per database, and `2days 1G` limits the logical log space on the disk to 1G at most 2 days per database.
+For example, `1G size` limits logical log space on the disk to 1G per database, `200K txs` limits the number of transactions kept to 200 000 per database, and `2 days 1G` limits the logical log space on the disk to 1G at most 2 days per database.
 |Default value
 m|+++2 days+++
 |===


### PR DESCRIPTION
Add space after `2` before `days`