### PR TITLE
Be explicit that reallocate is optional

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -27,7 +27,12 @@ For example, if the cluster's servers are set up with mode constraints to contai
 If `TOPOLOGY` is not specified, the database is created according to `initial.dbms.default_primaries_count` and `initial.dbms.default_secondaries_count` specified in _neo4j.conf_.
 After cluster startup, these values can be overwritten using the `dbms.setDefaultAllocationNumbers` procedure.
 ====
-
+[NOTE]
+====
+A `CREATE DATABASE` command allocates the database, therefore there is no requirement to execute `REALLOCATE DATABASES` (described in xref:clustering/servers.adoc[Hosting databases on added servers]). 
+However, over time, or after several `CREATE DATABASE` commands have been issued there can be an unbalanced distribution of databases. 
+At this point you can run `REALLOCATE DATABASES` to make the cluster re-balance databases across all servers that are part of the cluster.
+====
 
 [[alter-topology]]
 == `ALTER DATABASE`
@@ -45,7 +50,9 @@ ALTER DATABASE foo SET TOPOLOGY 2 PRIMARIES 1 SECONDARY
 
 Like the `CREATE DATABASE` command, this command results in an error if the cluster does not contain sufficient servers to satisfy the requested topology.
 
-When there is more than one possible permutation of the specified topology, Neo4j uses an allocator to decide how to spread the database across the cluster.
+When there is more than one possible permutation of the specified topology, Neo4j uses an allocator to decide how to spread the database across the cluster. 
+Note, like `CREATE DATABASE`, the `ALTER DATABASE` command allocates the database and there is no requirement to execute `REALLOCATE DATABASES` unless there is a desire to re-balance databases across all servers that are part of the cluster.
+
 This normally happens when the cluster is configured with more servers than the sum of the number of primaries and secondaries for any one database.
 
 It is not possible to automatically transition to a topology with a single primary host. Attempting to do so results in an error.
@@ -56,7 +63,7 @@ Once the database is backed up, the next step is to drop the database, see xref:
 The last step is to either seed a cluster from the backup with the new topology, or to restore the backup on a single server.
 See xref:clustering/databases.adoc#cluster-seed[Seed a cluster] further on for information on seeding.
 
- Also, it is possible to automatically transition _from_ a topology with a single primary host to multiple primary hosts.
+Also, it is possible to automatically transition _from_ a topology with a single primary host to multiple primary hosts.
 Keep in mind that during such a transition, the database will be unavailable for a short period of time.
 
 // This part can be added back once it has been implemented.

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -29,7 +29,7 @@ After cluster startup, these values can be overwritten using the `dbms.setDefaul
 ====
 [NOTE]
 ====
-A `CREATE DATABASE` command allocates the database, therefore there is no requirement to execute `REALLOCATE DATABASES` (described in xref:clustering/servers.adoc[Hosting databases on added servers]). 
+A `CREATE DATABASE` command allocates the database, therefore there is no requirement to execute `REALLOCATE DATABASES` (described in xref:clustering/servers.adoc#_hosting_databases_on_added_servers[Hosting databases on added servers]). 
 However, over time, or after several `CREATE DATABASE` commands have been issued, the distribution of databases can become unbalanced. 
 At this point you can run `REALLOCATE DATABASES` to make the cluster re-balance databases across all servers that are part of the cluster.
 ====

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -30,7 +30,7 @@ After cluster startup, these values can be overwritten using the `dbms.setDefaul
 [NOTE]
 ====
 A `CREATE DATABASE` command allocates the database, therefore there is no requirement to execute `REALLOCATE DATABASES` (described in xref:clustering/servers.adoc[Hosting databases on added servers]). 
-However, over time, or after several `CREATE DATABASE` commands have been issued there can be an unbalanced distribution of databases. 
+However, over time, or after several `CREATE DATABASE` commands have been issued, the distribution of databases can become unbalanced. 
 At this point you can run `REALLOCATE DATABASES` to make the cluster re-balance databases across all servers that are part of the cluster.
 ====
 


### PR DESCRIPTION
Be explicit around `CREATE/ALTER DATABASE` that one does not need to call `REALLOCATE` after every allocation operation. 

For `ALTER SERVER` and `DEALLOCATE DATABASES` this already seems clear.