### PR TITLE
Update procedures and functions signatures

### DIFF
--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -95,12 +95,12 @@ For more information, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version
 | xref:reference/procedures.adoc#procedure_db_index_fulltext_querynodes[`db.index.fulltext.queryNodes()`]
 | label:yes[]
 | label:yes[]
-| In 4.1, signature changed to `db.index.fulltext.queryNodes(indexName :: STRING?, queryString :: STRING?, options = {} :: MAP?) :: (node :: NODE?, score :: FLOAT?)`.
+| In 4.1, signature changed to `db.index.fulltext.queryNodes(indexName :: STRING, queryString :: STRING, options = {} :: MAP) :: (node :: NODE, score :: FLOAT)`.
 
 | xref:reference/procedures.adoc#procedure_db_index_fulltext_queryrelationships[`db.index.fulltext.queryRelationships()`]
 | label:yes[]
 | label:yes[]
-| In 4.1, signature changed to `db.index.fulltext.queryRelationships(indexName :: STRING?, queryString :: STRING?, options = {} :: MAP?) :: (relationship :: RELATIONSHIP?, score :: FLOAT?)`.
+| In 4.1, signature changed to `db.index.fulltext.queryRelationships(indexName :: STRING, queryString :: STRING, options = {} :: MAP) :: (relationship :: RELATIONSHIP, score :: FLOAT)`.
 
 | xref:reference/procedures.adoc#procedure_db_index_vector_createNodeIndex[`db.index.vector.createNodeIndex()`]
 | label:yes[]
@@ -126,7 +126,7 @@ For more information, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version
 | label:no[]
 | label:yes[]
 | label:admin-only[] +
-In 4.2, signature changed to `db.listLocks() :: (mode :: STRING?, resourceType :: STRING?, resourceId :: INTEGER?, transactionId :: STRING?)`.
+In 4.2, signature changed to `db.listLocks() :: (mode :: STRING, resourceType :: STRING, resourceId :: INTEGER, transactionId :: STRING)`.
 
 | xref:reference/procedures.adoc#procedure_db_ping[`db.ping()`]
 | label:yes[]
@@ -709,7 +709,7 @@ Wait for an index to come online.
 
 Example: `CALL db.awaitIndex("MyIndex", 300)`
 | Signature
-m|db.awaitIndex(indexName :: STRING?, timeOutSeconds = 300 :: INTEGER?) :: VOID
+m|db.awaitIndex(indexName :: STRING, timeOutSeconds = 300 :: INTEGER)
 | Mode
 m|READ
 // | Default roles
@@ -727,7 +727,7 @@ Wait for all indexes to come online.
 
 Example: `CALL db.awaitIndexes(300)`
 | Signature
-m|db.awaitIndexes(timeOutSeconds = 300 :: INTEGER?) :: VOID
+m|db.awaitIndexes(timeOutSeconds = 300 :: INTEGER)
 | Mode
 m|READ
 // | Default roles
@@ -746,7 +746,7 @@ Initiate and wait for a new check point, or wait any already on-going check poin
 Note that this temporarily disables the `db.checkpoint.iops.limit` setting in order to make the check point complete faster.
 This might cause transaction throughput to degrade slightly, due to increased IO load.
 | Signature
-m|db.checkpoint() :: (success :: BOOLEAN?, message :: STRING?)
+m|db.checkpoint() :: (success :: BOOLEAN, message :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -762,7 +762,7 @@ m|DBMS
 a|
 Clears all query caches.
 | Signature
-m|db.clearQueryCaches() :: (value :: STRING?)
+m|db.clearQueryCaches() :: (value :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -779,7 +779,7 @@ Update a given node property with the given vector in a more space efficient way
 
 Returns the given node on which the property was set.
 | Signature
-m| db.create.setVectorProperty(node :: NODE?, key :: STRING?, vector :: LIST? OF FLOAT?) :: (node :: NODE?)
+m| db.create.setVectorProperty(node :: NODE, key :: STRING, vector :: LIST<FLOAT>) :: (node :: NODE)
 | Mode
 m| WRITE
 |===
@@ -792,7 +792,7 @@ m| WRITE
 a|
 Create a label
 | Signature
-m|db.createLabel(newLabel :: STRING?) :: VOID
+m|db.createLabel(newLabel :: STRING)
 | Mode
 m|WRITE
 // | Default roles
@@ -811,7 +811,7 @@ Backing index will use specified index provider and configuration (optional).
 
 Yield: name, labels, properties, providerName, status
 | Signature
-m|db.createNodeKey(constraintName :: STRING?, labels :: LIST? OF STRING?, properties :: LIST? OF STRING?, providerName :: STRING?, config = {} :: MAP?) :: (name :: STRING?, labels :: LIST? OF STRING?, properties :: LIST? OF STRING?, providerName :: STRING?, status :: STRING?)
+m|db.createNodeKey(constraintName :: STRING, labels :: LIST<STRING>, properties :: LIST<STRING>, providerName :: STRING, config = {} :: MAP) :: (name :: STRING, labels :: LIST<STRING>, properties :: LIST<STRING>, providerName :: STRING, status :: STRING)
 | Mode
 m|SCHEMA
 // | Default roles
@@ -830,7 +830,7 @@ For more information, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version
 a|
 Create a Property
 | Signature
-m|db.createProperty(newProperty :: STRING?) :: VOID
+m|db.createProperty(newProperty :: STRING)
 | Mode
 m|WRITE
 // | Default roles
@@ -846,7 +846,7 @@ m|WRITE
 a|
 Create a RelationshipType
 | Signature
-m|db.createRelationshipType(newRelationshipType :: STRING?) :: VOID
+m|db.createRelationshipType(newRelationshipType :: STRING)
 | Mode
 m|WRITE
 // | Default roles
@@ -862,7 +862,7 @@ m|WRITE
 a|
 Wait for the updates from recently committed transactions to be applied to any eventually-consistent full-text indexes.
 | Signature
-m|db.index.fulltext.awaitEventuallyConsistentIndexRefresh() :: VOID
+m|db.index.fulltext.awaitEventuallyConsistentIndexRefresh()
 | Mode
 m|READ
 // | Default roles
@@ -878,7 +878,7 @@ m|READ
 a|
 List the available analyzers that the full-text indexes can be configured with.
 | Signature
-m|db.index.fulltext.listAvailableAnalyzers() :: (analyzer :: STRING?, description :: STRING?, stopwords :: LIST? OF STRING?)
+m|db.index.fulltext.listAvailableAnalyzers() :: (analyzer :: STRING, description :: STRING, stopwords :: LIST<STRING>)
 | Mode
 m|READ
 // | Default roles
@@ -905,7 +905,7 @@ Valid _key: value_ pairs for the `options` map are:
 The `options` map and any of the keys are optional.
 An example of the `options` map: `{skip: 30, limit: 10, analyzer: 'whitespace'}`
 | Signature
-m|db.index.fulltext.queryNodes(indexName :: STRING?, queryString :: STRING?, options = {} :: MAP?) :: (node :: NODE?, score :: FLOAT?)
+m|db.index.fulltext.queryNodes(indexName :: STRING, queryString :: STRING, options = {} :: MAP) :: (node :: NODE, score :: FLOAT)
 | Mode
 m|READ
 // | Default roles
@@ -932,7 +932,7 @@ Valid _key: value_ pairs for the `options` map are:
 The `options` map and any of the keys are optional.
 An example of the `options` map: `{skip: 30, limit: 10, analyzer: 'whitespace'}`
 | Signature
-m|db.index.fulltext.queryRelationships(indexName :: STRING?, queryString :: STRING?, options = {} :: MAP?) :: (relationship :: RELATIONSHIP?, score :: FLOAT?)
+m|db.index.fulltext.queryRelationships(indexName :: STRING, queryString :: STRING, options = {} :: MAP) :: (relationship :: RELATIONSHIP, score :: FLOAT)
 | Mode
 m|READ
 // | Default roles
@@ -962,7 +962,7 @@ image::cosine_similarity_equation.svg["The cosine of vector v and vector u is de
 In the above equation, the trigonometric cosine is given by the scalar product of the two unit vectors.
 +
 | Signature
-m| db.index.vector.createNodeIndex(indexName :: STRING?, label :: STRING?, propertyKey :: STRING?, vectorDimension :: INTEGER?, vectorSimilarityFunction :: STRING?) :: VOID
+m| db.index.vector.createNodeIndex(indexName :: STRING, label :: STRING, propertyKey :: STRING, vectorDimension :: INTEGER, vectorSimilarityFunction :: STRING)
 | Mode
 m| SCHEMA
 |===
@@ -979,7 +979,7 @@ Returns the requested number of approximate nearest neighbor nodes and their sim
 
 The similarity score is bounded between `0` and `1`; least to most similar respectively.
 | Signature
-m| db.index.vector.queryNodes(indexName :: STRING?, numberOfNearestNeighbours :: INTEGER?, query :: LIST? OF FLOAT?) :: (node :: NODE?, score :: FLOAT?)
+m| db.index.vector.queryNodes(indexName :: STRING, numberOfNearestNeighbours :: INTEGER, query :: LIST<FLOAT>) :: (node :: NODE, score :: FLOAT)
 | Mode
 m| READ
 |===
@@ -992,7 +992,7 @@ m| READ
 a|
 Provides information regarding the database.
 | Signature
-m|db.info() :: (id :: STRING?, name :: STRING?, creationDate :: STRING?)
+m|db.info() :: (id :: STRING, name :: STRING, creationDate :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1009,7 +1009,7 @@ a|
 List all labels attached to nodes within a database according to the user's access rights.
 The procedure returns empty results if the user is not authorized to view those labels.
 | Signature
-m|db.labels() :: (label :: STRING?)
+m|db.labels() :: (label :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1025,7 +1025,7 @@ m|READ
 a|
 List all locks at this database.
 | Signature
-m|db.listLocks() :: (mode :: STRING?, resourceType :: STRING?, resourceId :: INTEGER?, transactionId :: STRING?)
+m|db.listLocks() :: (mode :: STRING, resourceType :: STRING, resourceId :: INTEGER, transactionId :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1043,7 +1043,7 @@ This procedure can be used by client side tooling to test whether they are corre
 The procedure is available in all databases and always returns true.
 A faulty connection can be detected by not being able to call this procedure.
 | Signature
-m|db.ping() :: (success :: BOOLEAN?)
+m|db.ping() :: (success :: BOOLEAN)
 | Mode
 m|READ
 // | Default roles
@@ -1060,7 +1060,7 @@ a|
 Triggers an index resample and waits for it to complete, and after that clears query caches.
 After this procedure has finished queries will be planned using the latest database statistics.
 | Signature
-m|db.prepareForReplanning(timeOutSeconds = 300 :: INTEGER?) :: VOID
+m|db.prepareForReplanning(timeOutSeconds = 300 :: INTEGER)
 | Mode
 m|READ
 // | Default roles
@@ -1076,7 +1076,7 @@ m|READ
 a|
 List all property keys in the database.
 | Signature
-m|db.propertyKeys() :: (propertyKey :: STRING?)
+m|db.propertyKeys() :: (propertyKey :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1093,7 +1093,7 @@ a|
 List all types attached to relationships within a database according to the user's access rights.  
 The procedure returns empty results if the user is not authorized to view those relationship types.
 | Signature
-m|db.relationshipTypes() :: (relationshipType :: STRING?)
+m|db.relationshipTypes() :: (relationshipType :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1111,7 +1111,7 @@ Schedule resampling of an index.
 
 Example: `CALL db.resampleIndex("MyIndex")`
 | Signature
-m|db.resampleIndex(indexName :: STRING?) :: VOID
+m|db.resampleIndex(indexName :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1127,7 +1127,7 @@ m|READ
 a|
 Schedule resampling of all outdated indexes.
 | Signature
-m|db.resampleOutdatedIndexes() :: VOID
+m|db.resampleOutdatedIndexes()
 | Mode
 m|READ
 // | Default roles
@@ -1143,7 +1143,7 @@ m|READ
 a|
 Show the derived property schema of the nodes in tabular form.
 | Signature
-m|db.schema.nodeTypeProperties() :: (nodeType :: STRING?, nodeLabels :: LIST? OF STRING?, propertyName :: STRING?, propertyTypes :: LIST? OF STRING?, mandatory :: BOOLEAN?)
+m|db.schema.nodeTypeProperties() :: (nodeType :: STRING, nodeLabels :: LIST<STRING>, propertyName :: STRING, propertyTypes :: LIST<STRING>, mandatory :: BOOLEAN)
 | Mode
 m|READ
 // | Default roles
@@ -1159,7 +1159,7 @@ m|READ
 a|
 Show the derived property schema of the relationships in tabular form.
 | Signature
-m|db.schema.relTypeProperties() :: (relType :: STRING?, propertyName :: STRING?, propertyTypes :: LIST? OF STRING?, mandatory :: BOOLEAN?)
+m|db.schema.relTypeProperties() :: (relType :: STRING, propertyName :: STRING, propertyTypes :: LIST<STRING>, mandatory :: BOOLEAN)
 | Mode
 m|READ
 // | Default roles
@@ -1178,7 +1178,7 @@ The properties represented on the node include `name` (label name), `indexes` (l
 A relationship of a given type is returned for all possible combinations of start and end nodes.
 Note that this may include additional relationships that do not exist in the data due to the information available in the count store.
 | Signature
-m|db.schema.visualization() :: (nodes :: LIST? OF NODE?, relationships :: LIST? OF RELATIONSHIP?)
+m|db.schema.visualization() :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)
 | Mode
 m|READ
 // | Default roles
@@ -1196,7 +1196,7 @@ Clear collected data of a given data section.
 
 Valid sections are `'QUERIES'`
 | Signature
-m|db.stats.clear(section :: STRING?) :: (section :: STRING?, success :: BOOLEAN?, message :: STRING?)
+m|db.stats.clear(section :: STRING) :: (section :: STRING, success :: BOOLEAN, message :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1214,7 +1214,7 @@ Start data collection of a given data section.
 
 Valid sections are `'QUERIES'`
 | Signature
-m|db.stats.collect(section :: STRING?, config = {} :: MAP?) :: (section :: STRING?, success :: BOOLEAN?, message :: STRING?)
+m|db.stats.collect(section :: STRING, config = {} :: MAP) :: (section :: STRING, success :: BOOLEAN, message :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1232,7 +1232,7 @@ Retrieve statistical data about the current database.
 
 Valid sections are `'GRAPH COUNTS', 'TOKENS', 'QUERIES', 'META'`
 | Signature
-m|db.stats.retrieve(section :: STRING?, config = {} :: MAP?) :: (section :: STRING?, data :: MAP?)
+m|db.stats.retrieve(section :: STRING, config = {} :: MAP) :: (section :: STRING, data :: MAP)
 | Mode
 m|READ
 // | Default roles
@@ -1248,7 +1248,7 @@ m|READ
 a|
 Retrieve all available statistical data about the current database, in an anonymized form.
 | Signature
-m|db.stats.retrieveAllAnonymized(graphToken :: STRING?, config = {} :: MAP?) :: (section :: STRING?, data :: MAP?)
+m|db.stats.retrieveAllAnonymized(graphToken :: STRING, config = {} :: MAP) :: (section :: STRING, data :: MAP)
 | Mode
 m|READ
 // | Default roles
@@ -1264,7 +1264,7 @@ m|READ
 a|
 Retrieve the status of all available collector daemons, for this database.
 | Signature
-m|db.stats.status() :: (section :: STRING?, status :: STRING?, data :: MAP?)
+m|db.stats.status() :: (section :: STRING, status :: STRING, data :: MAP)
 | Mode
 m|READ
 // | Default roles
@@ -1282,7 +1282,7 @@ Stop data collection of a given data section.
 
 Valid sections are `'QUERIES'`
 | Signature
-m|db.stats.stop(section :: STRING?) :: (section :: STRING?, success :: BOOLEAN?, message :: STRING?)
+m|db.stats.stop(section :: STRING) :: (section :: STRING, success :: BOOLEAN, message :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1306,7 +1306,7 @@ A valid value for a non-dynamic setting requires a restart.
 The message is empty if the value is `valid` and the setting is dynamic.
 
 | Signature
-m|dbms.checkConfigValue(setting :: STRING?, value :: STRING?) :: (valid :: BOOLEAN?, message :: STRING?)
+m|dbms.checkConfigValue(setting :: STRING, value :: STRING) :: (valid :: BOOLEAN, message :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1321,7 +1321,7 @@ m|DBMS
 a|
 With this method you can set whether free servers are automatically enabled.
 | Signature
-m|dbms.cluster.setAutomaticallyEnableFreeServers(autoEnable :: BOOLEAN?)
+m|dbms.cluster.setAutomaticallyEnableFreeServers(autoEnable :: BOOLEAN)
 | Mode
 m|WRITE
 |===
@@ -1350,7 +1350,7 @@ a| Marks a server in the topology as not suitable for new allocations.
 It will not force current allocations off the server.
 This is useful when deallocating databases when you have multiple unavailable servers.
 | Signature
-m|dbms.cluster.cordonServer(server :: STRING?)
+m|dbms.cluster.cordonServer(server :: STRING)
 | Mode
 m|WRITE
 |===
@@ -1365,7 +1365,7 @@ a|
 Returns endpoints of this instance.
 Used in disaster recovery.
 | Signature
-m|dbms.cluster.routing.getRoutingTable(context :: MAP?, database = null :: STRING?) :: (ttl :: INTEGER?, servers :: LIST? OF MAP?)
+m|dbms.cluster.routing.getRoutingTable(context :: MAP, database = null :: STRING) :: (ttl :: INTEGER, servers :: LIST<MAP>)
 | Mode
 m|DBMS
 // | Default roles
@@ -1382,7 +1382,7 @@ Overview of installed protocols.
 
 Note that this can only be executed on a cluster core member.
 | Signature
-m|dbms.cluster.protocols() :: (orientation :: STRING?, remoteAddress :: STRING?, applicationProtocol :: STRING?, applicationProtocolVersion :: INTEGER?, modifierProtocols :: STRING?)
+m|dbms.cluster.protocols() :: (orientation :: STRING, remoteAddress :: STRING, applicationProtocol :: STRING, applicationProtocolVersion :: INTEGER, modifierProtocols :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1399,7 +1399,7 @@ The toggle can pause or resume the pulling of new transactions for a specific da
 If paused, the database secondary does not pull new transactions from the other cluster members for the specific database.
 The database secondary is still available for reads, you can perform a backup, etc.
 | Signature
-m|dbms.cluster.readReplicaToggle(databaseName :: STRING?, pause :: BOOLEAN?) :: (state :: STRING?)
+m|dbms.cluster.readReplicaToggle(databaseName :: STRING, pause :: BOOLEAN) :: (state :: STRING)
 | Mode
 m|READ
 | Replaced by
@@ -1450,7 +1450,7 @@ The toggle can pause or resume the pulling of new transactions for a specific da
 If paused, the database secondary does not pull new transactions from the other cluster members for the specific database.
 The database secondary is still available for reads, you can perform a backup, etc.
 | Signature
-m|dbms.cluster.secondaryReplicationDisable(databaseName :: STRING?, pause :: BOOLEAN?) :: (state :: STRING?)
+m|dbms.cluster.secondaryReplicationDisable(databaseName :: STRING, pause :: BOOLEAN) :: (state :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1495,7 +1495,7 @@ CALL dbms.cluster.secondaryReplicationDisable("neo4j", false)
 | Description
 a| Removes the cordon on a server, returning it to 'enabled'.
 | Signature
-m| dbms.cluster.uncordonServer(server :: STRING?)
+m| dbms.cluster.uncordonServer(server :: STRING)
 | Mode
 m| WRITE
 |===
@@ -1509,7 +1509,7 @@ m| WRITE
 a|
 List DBMS components and their versions.
 | Signature
-m|dbms.components() :: (name :: STRING?, versions :: LIST? OF STRING?, edition :: STRING?)
+m|dbms.components() :: (name :: STRING, versions :: LIST<STRING>, edition :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1524,7 +1524,7 @@ m|DBMS
 a|
 Provides information regarding the DBMS.
 | Signature
-m|dbms.info() :: (id :: STRING?, name :: STRING?, creationDate :: STRING?)
+m|dbms.info() :: (id :: STRING, name :: STRING, creationDate :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1540,7 +1540,7 @@ m|DBMS
 a|
 Kill network connection with the given connection id.
 | Signature
-m|dbms.killConnection(id :: STRING?) :: (connectionId :: STRING?, username :: STRING?, message :: STRING?)
+m|dbms.killConnection(id :: STRING) :: (connectionId :: STRING, username :: STRING, message :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1556,7 +1556,7 @@ m|DBMS
 a|
 Kill all network connections with the given connection ids.
 | Signature
-m|dbms.killConnections(ids :: LIST? OF STRING?) :: (connectionId :: STRING?, username :: STRING?, message :: STRING?)
+m|dbms.killConnections(ids :: LIST<STRING>) :: (connectionId :: STRING, username :: STRING, message :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1572,7 +1572,7 @@ m|DBMS
 a|
 List the active lock requests granted for the transaction executing the query with the given query id.
 | Signature
-m|dbms.listActiveLocks(queryId :: STRING?) :: (mode :: STRING?, resourceType :: STRING?, resourceId :: INTEGER?)
+m|dbms.listActiveLocks(queryId :: STRING) :: (mode :: STRING, resourceType :: STRING, resourceId :: INTEGER)
 | Mode
 m|DBMS
 // | Default roles
@@ -1587,7 +1587,7 @@ m|DBMS
 a|
 List capabilities.
 | Signature
-m|dbms.listCapabilities() :: (name :: STRING?, description :: STRING?, value :: ANY?)
+m|dbms.listCapabilities() :: (name :: STRING, description :: STRING, value :: ANY)
 | Mode
 m|DBMS
 |===
@@ -1612,7 +1612,7 @@ Results include:
 * `validValues`: contains information on data types and possible values for the settings.
 
 | Signature
-m|dbms.listConfig(searchString =  :: STRING?) :: (name :: STRING?, description :: STRING?, value :: STRING?, dynamic :: BOOLEAN?, defaultValue :: STRING?, startupValue :: STRING?, explicitlySet :: BOOLEAN?, validValues :: STRING?)
+m|dbms.listConfig(searchString =  :: STRING) :: (name :: STRING, description :: STRING, value :: STRING, dynamic :: BOOLEAN, defaultValue :: STRING, startupValue :: STRING, explicitlySet :: BOOLEAN, validValues :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1627,7 +1627,7 @@ m|DBMS
 a|
 List all accepted network connections at this instance that are visible to the user.
 | Signature
-m|dbms.listConnections() :: (connectionId :: STRING?, connectTime :: STRING?, connector :: STRING?, username :: STRING?, userAgent :: STRING?, serverAddress :: STRING?, clientAddress :: STRING?)
+m|dbms.listConnections() :: (connectionId :: STRING, connectTime :: STRING, connector :: STRING, username :: STRING, userAgent :: STRING, serverAddress :: STRING, clientAddress :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1642,7 +1642,7 @@ m|DBMS
 a|
 List all memory pools, including sub pools, currently registered at this instance that are visible to the user.
 | Signature
-m|dbms.listPools() :: (pool :: STRING?, databaseName :: STRING?, heapMemoryUsed :: STRING?, heapMemoryUsedBytes :: STRING?, nativeMemoryUsed :: STRING?, nativeMemoryUsedBytes :: STRING?, freeMemory :: STRING?, freeMemoryBytes :: STRING?, totalPoolMemory :: STRING?, totalPoolMemoryBytes :: STRING?)
+m|dbms.listPools() :: (pool :: STRING, databaseName :: STRING, heapMemoryUsed :: STRING, heapMemoryUsedBytes :: STRING, nativeMemoryUsed :: STRING, nativeMemoryUsedBytes :: STRING, freeMemory :: STRING, freeMemoryBytes :: STRING, totalPoolMemory :: STRING, totalPoolMemoryBytes :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1658,7 +1658,7 @@ a|
 Place a database in quarantine or remove thereof.
 It must be executed over `bolt://`.
 | Signature
-m|dbms.quarantineDatabase(databaseName :: STRING?, setStatus :: BOOLEAN?, reason = No reason given :: STRING?) :: (databaseName :: STRING?, quarantined :: BOOLEAN?, result :: STRING?)
+m|dbms.quarantineDatabase(databaseName :: STRING, setStatus :: BOOLEAN, reason = No reason given :: STRING) :: (databaseName :: STRING, quarantined :: BOOLEAN, result :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1676,7 +1676,7 @@ Query JMX management data by domain and name.
 Valid queries should use the syntax outlined in the link:https://docs.oracle.com/en/java/javase/11/docs/api/java.management/javax/management/ObjectName.html[javax.management.ObjectName API documentation]. +
 For instance, use `+"*:*"+` to find all JMX beans.
 | Signature
-m|dbms.queryJmx(query :: STRING?) :: (name :: STRING?, description :: STRING?, attributes :: MAP?)
+m|dbms.queryJmx(query :: STRING) :: (name :: STRING, description :: STRING, attributes :: MAP)
 | Mode
 m|DBMS
 // | Default roles
@@ -1692,7 +1692,7 @@ m|DBMS
 a|
 Returns endpoints of this instance.
 | Signature
-m|dbms.routing.getRoutingTable(context :: MAP?, database = null :: STRING?) :: (ttl :: INTEGER?, servers :: LIST? OF MAP?)
+m|dbms.routing.getRoutingTable(context :: MAP, database = null :: STRING) :: (ttl :: INTEGER, servers :: LIST<MAP>)
 | Mode
 m|DBMS
 // | Default roles
@@ -1706,7 +1706,7 @@ m|DBMS
 | Description
 a| With this method you can set the allocator, which is responsible to select servers for hosting databases. The only current option is `EQUAL_NUMBERS`.
 | Signature
-m|dbms.setDatabaseAllocator(allocator :: STRING?)
+m|dbms.setDatabaseAllocator(allocator :: STRING)
 | Mode
 a|WRITE
 |===
@@ -1718,7 +1718,7 @@ a|WRITE
 | Description
 a| With this method you can set the default number of primaries and secondaries.
 | Signature
-m|dbms.setDefaultAllocationNumbers(primaries :: INTEGER?, secondaries :: INTEGER?)
+m|dbms.setDefaultAllocationNumbers(primaries :: INTEGER, secondaries :: INTEGER)
 | Mode
 a|WRITE
 |===
@@ -1731,7 +1731,7 @@ a|WRITE
 a| Changes the default database to the provided value.
 The database must exist and the old default database must be stopped.
 | Signature
-m|dbms.setDefaultDatabase(databaseName :: STRING?) :: (result :: STRING?)
+m|dbms.setDefaultDatabase(databaseName :: STRING) :: (result :: STRING)
 | Mode
 a|WRITE
 |===
@@ -1744,7 +1744,7 @@ a|WRITE
 a|
 List failed job runs. There is a limit for amount of historical data.
 | Signature
-m|dbms.scheduler.failedJobs() :: (jobId :: STRING?, group :: STRING?, database :: STRING?, submitter :: STRING?, description :: STRING?, type :: STRING?, submitted :: STRING?, executionStart :: STRING?, failureTime :: STRING?, failureDescription :: STRING?)
+m|dbms.scheduler.failedJobs() :: (jobId :: STRING, group :: STRING, database :: STRING, submitter :: STRING, description :: STRING, type :: STRING, submitted :: STRING, executionStart :: STRING, failureTime :: STRING, failureDescription :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1760,7 +1760,7 @@ m|DBMS
 a|
 List the job groups that are active in the database internal job scheduler.
 | Signature
-m|dbms.scheduler.groups() :: (group :: STRING?, threads :: INTEGER?)
+m|dbms.scheduler.groups() :: (group :: STRING, threads :: INTEGER)
 | Mode
 m|DBMS
 // | Default roles
@@ -1776,7 +1776,7 @@ m|DBMS
 a|
 List all jobs that are active in the database internal job scheduler.
 | Signature
-m|dbms.scheduler.jobs() :: (jobId :: STRING?, group :: STRING?, submitted :: STRING?, database :: STRING?, submitter :: STRING?, description :: STRING?, type :: STRING?, scheduledAt :: STRING?, period :: STRING?, state :: STRING?, currentStateDescription :: STRING?)
+m|dbms.scheduler.jobs() :: (jobId :: STRING, group :: STRING, submitted :: STRING, database :: STRING, submitter :: STRING, description :: STRING, type :: STRING, scheduledAt :: STRING, period :: STRING, state :: STRING, currentStateDescription :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1791,7 +1791,7 @@ m|DBMS
 a|
 Clears authentication and authorization cache.
 | Signature
-m|dbms.security.clearAuthCache() :: VOID
+m|dbms.security.clearAuthCache()
 | Mode
 m|DBMS
 // | Default roles
@@ -1809,7 +1809,7 @@ Passing an empty value results in removing the configured value and falling back
 Changes do not persist and are lost if the server is restarted.
 In a clustered environment, `dbms.setConfigValue` affects only the cluster member it is run against.
 | Signature
-m|dbms.setConfigValue(setting :: STRING?, value :: STRING?) :: VOID
+m|dbms.setConfigValue(setting :: STRING, value :: STRING)
 | Mode
 m|DBMS
 // | Default roles
@@ -1825,7 +1825,7 @@ m|DBMS
 a|
 Show the current user.
 | Signature
-m|dbms.showCurrentUser() :: (username :: STRING?, roles :: LIST? OF STRING?, flags :: LIST? OF STRING?)
+m|dbms.showCurrentUser() :: (username :: STRING, roles :: LIST<STRING>, flags :: LIST<STRING>)
 | Mode
 m|DBMS
 // | Default roles
@@ -1839,7 +1839,7 @@ m|DBMS
 | Description
 a| With this method the configuration of the Topology Graph can be displayed.
 | Signature
-m|dbms.showTopologyGraphConfig() :: (allocator :: STRING?, defaultPrimariesCount :: INTEGER?, defaultSecondariesCount :: INTEGER?, defaultDatabase :: STRING?, autoEnableFreeServers :: BOOLEAN?)
+m|dbms.showTopologyGraphConfig() :: (allocator :: STRING, defaultPrimariesCount :: INTEGER, defaultSecondariesCount :: INTEGER, defaultDatabase :: STRING, autoEnableFreeServers :: BOOLEAN)
 | Mode
 m|READ
 |===
@@ -1852,7 +1852,7 @@ m|READ
 a|
 Upgrade the system database schema if it is not the current schema.
 | Signature
-m|dbms.upgrade() :: (status :: STRING?, upgradeResult :: STRING?)
+m|dbms.upgrade() :: (status :: STRING, upgradeResult :: STRING)
 | Mode
 m|WRITE
 // | Default roles
@@ -1868,7 +1868,7 @@ m|WRITE
 a|
 Report the current status of the system database sub-graph schema.
 | Signature
-m|dbms.upgradeStatus() :: (status :: STRING?, description :: STRING?, resolution :: STRING?)
+m|dbms.upgradeStatus() :: (status :: STRING, description :: STRING, resolution :: STRING)
 | Mode
 m|READ
 // | Default roles
@@ -1883,7 +1883,7 @@ m|READ
 a|
 Provides attached transaction metadata.
 | Signature
-m|tx.getMetaData() :: (metadata :: MAP?)
+m|tx.getMetaData() :: (metadata :: MAP)
 | Mode
 m|DBMS
 // | Default roles
@@ -1900,7 +1900,7 @@ a|
 Attaches a map of data to the transaction.
 The data will be printed when listing queries, and inserted into the query log.
 | Signature
-m|tx.setMetaData(data :: MAP?) :: VOID
+m|tx.setMetaData(data :: MAP)
 | Mode
 m|DBMS
 // | Default roles


### PR DESCRIPTION
We are updating the signatures of procedures to match the defaults of the new Cypher Types

Continuation of: https://github.com/neo4j/docs-cypher/pull/676