### PR TITLE
Align default binding timeout (#1050)

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -408,7 +408,7 @@ a|The time allowed for a database on a Neo4j server to either join a cluster or 
 |Valid values
 a|a duration (Valid units are: `ns`, `μs`, `ms`, `s`, `m`, `h` and `d`; default unit is `s`)
 |Default value
-m|+++10m+++
+m|+++24h+++
 |===
 
 [[config_dbms.cluster.raft.client.max_channels]]


### PR DESCRIPTION
Default binding timeout is 24h not 10m.
Cherry-picked from #1050 