### PR TITLE
added additional step to set NEO4J_PLUGINS env

### DIFF
--- a/modules/ROOT/pages/kubernetes/plugins.adoc
+++ b/modules/ROOT/pages/kubernetes/plugins.adoc
@@ -29,6 +29,14 @@ apoc_config:
   apoc.import.file.enabled: "true"
 ----
 
+. Under `env`, set the `NEO4J_PLUGINS` variable to `'["apoc"]'`, for example:
++
+[source, yaml]
+----
+env:
+  NEO4J_PLUGINS: '["apoc"]'
+----
+
 . Run `helm upgrade` to apply the changes:
 +
 [source, shell]


### PR DESCRIPTION
Hello,

Looks like in order to have the apoc plugin installed, the NEO4J_PLUGINS env must be set and this was not apparent from the documentation.