### PR TITLE
Update note about needed privileges for @admin procedures on the procedures page

### DIFF
--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -29,7 +29,7 @@ Some procedures can only be run by users with `Admin` privileges.
 Specifically, either the `EXECUTE ADMIN PROCEDURES` privilege or both the `EXECUTE PROCEDURES` and `EXECUTE BOOSTED PROCEDURES` privileges.
 These procedures are labeled with label:admin-only[].
 
-For more information, see xref:authentication-authorization/dbms-administration.adoc#access-control-dbms-administration-execute[the `EXECUTE` privileges].
+For more information, see xref:authentication-authorization/dbms-administration.adoc#access-control-dbms-administration-execute[the `EXECUTE` privileges section].
 ====
 
 == List of procedures

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -27,7 +27,7 @@ SHOW PROCEDURES
 ====
 Some procedures can only be run by users with `Admin` privileges.
 Specifically, either the `EXECUTE ADMIN PROCEDURES` or both the `EXECUTE PROCEDURES` and `EXECUTE BOOSTED PROCEDURES` privileges.
-These are labeled with label:admin-only[].
+These procedures are labeled with label:admin-only[].
 
 For more information, see xref:authentication-authorization/dbms-administration.adoc#access-control-dbms-administration-execute[`EXECUTE` privileges].
 ====

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -26,10 +26,10 @@ SHOW PROCEDURES
 [NOTE]
 ====
 Some procedures can only be run by users with `Admin` privileges.
-Specifically, either the `EXECUTE ADMIN PROCEDURES` or both the `EXECUTE PROCEDURES` and `EXECUTE BOOSTED PROCEDURES` privileges.
+Specifically, either the `EXECUTE ADMIN PROCEDURES` privilege or both the `EXECUTE PROCEDURES` and `EXECUTE BOOSTED PROCEDURES` privileges.
 These procedures are labeled with label:admin-only[].
 
-For more information, see xref:authentication-authorization/dbms-administration.adoc#access-control-dbms-administration-execute[`EXECUTE` privileges].
+For more information, see xref:authentication-authorization/dbms-administration.adoc#access-control-dbms-administration-execute[the `EXECUTE` privileges].
 ====
 
 == List of procedures

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -55,7 +55,7 @@ For more information, see xref:authentication-authorization/dbms-administration.
 | xref:reference/procedures.adoc#procedure_cdc_query[`cdc.query()`]
 | label:no[]
 | label:yes[]
-| label:new[Introduced in 5.13] label:beta[]
+| label:new[Introduced in 5.13] label:beta[] label:admin-only[]
 
 | xref:reference/procedures.adoc#procedure_db_awaitindex[`db.awaitIndex()`]
 | label:yes[]
@@ -719,7 +719,7 @@ Replaced by: `ALTER USER`.
 == Procedure descriptions
 
 [[procedure_cdc_current]]
-.cdc.current()
+.cdc.current() label:new[Introduced in 5.13] label:beta[]
 [cols="<15s,<85"]
 |===
 | Description
@@ -732,7 +732,7 @@ m|READ
 |===
 
 [[procedure_cdc_earliest]]
-.cdc.earliest()
+.cdc.earliest() label:new[Introduced in 5.13] label:beta[]
 [cols="<15s,<85"]
 |===
 | Description
@@ -745,7 +745,7 @@ m|READ
 |===
 
 [[procedure_cdc_query]]
-.cdc.query()
+.cdc.query() label:new[Introduced in 5.13] label:beta[] label:admin-only[]
 [cols="<15s,<85"]
 |===
 | Description

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -26,9 +26,10 @@ SHOW PROCEDURES
 [NOTE]
 ====
 Some procedures can only be run by users with `Admin` privileges.
+Specifically, either the `EXECUTE ADMIN PROCEDURES` or both the `EXECUTE PROCEDURES` and `EXECUTE BOOSTED PROCEDURES` privileges.
 These are labeled with label:admin-only[].
 
-For more information, see xref:authentication-authorization/manage-privileges.adoc[RBAC and fine-grained privileges].
+For more information, see xref:authentication-authorization/dbms-administration.adoc#access-control-dbms-administration-execute[`EXECUTE` privileges].
 ====
 
 == List of procedures

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -877,28 +877,6 @@ m|WRITE
 |===
 
 
-[[procedure_db_createnodekey]]
-.db.createNodeKey() label:enterprise-edition[] label:deprecated[Deprecated in 4.2]
-[cols="<15s,<85"]
-|===
-| Description
-a|
-Create a named node key constraint.
-Backing index will use specified index provider and configuration (optional).
-
-Yield: name, labels, properties, providerName, status
-| Signature
-m|db.createNodeKey(constraintName :: STRING, labels :: LIST<STRING>, properties :: LIST<STRING>, providerName :: STRING, config = {} :: MAP) :: (name :: STRING, labels :: LIST<STRING>, properties :: LIST<STRING>, providerName :: STRING, status :: STRING)
-| Mode
-m|SCHEMA
-// | Default roles
-// m|architect, admin
-| Replaced by
-a|`CREATE CONSTRAINT ... IS NODE KEY`.
-For more information, see xref:authentication-authorization/database-administration.adoc[Database administration].
-|===
-
-
 [[procedure_db_createproperty]]
 .db.createProperty()
 [cols="<15s,<85"]


### PR DESCRIPTION
in an attempt to clarify better what is needed and updating the link to point to the `EXECUTE` privileges instead of just general privilege handling.

Also included some other procedure related things I noticed:
* Add `Admin only` label to the @admin cdc procedure
* Added `introduced in` and `beta` labels to the procedure description section for cdc procedures (like how it was done for vector index procedures)
* Remove removed procedure from procedure description (only one of the removed procedures still had description table)