### PR TITLE
Add temporal and size parameters for `db.tx_log.rotation.retention_policy`

### DIFF
--- a/modules/ROOT/pages/database-internals/transaction-logs.adoc
+++ b/modules/ROOT/pages/database-internals/transaction-logs.adoc
@@ -61,6 +61,10 @@ This configuration setting is dynamic and can be changed at runtime.
 
 By default, it is set to `2 days`, which means Neo4j keeps logical logs that contain any transaction committed within 2 days and prunes the ones that only contain transactions older than 2 days.
 
+label:new[Introduced in Neo4j 5.9] +
+From Neo4j 5.9 onwards, you can optionally add a period-based restriction to the size of logs to keep.
+For example, `2 days 1G` prunes logical logs that only contain transactions older than 2 days or are larger than 1G.
+
 Other possible ways to configure the log retention policy are:
 
 * `db.tx_log.rotation.retention_policy=true|keep_all` -- keep transaction logs indefinitely.
@@ -83,7 +87,9 @@ To force a checkpoint, run the procedure xref:reference/procedures.adoc#procedur
 This option is not recommended in production Enterprise Edition environments, as xref:backup-restore/modes.adoc#differential-backup[differential backups] rely on the presence of the transaction logs since the last backup.
 ====
 
-* `<number><optional unit> <type>` where valid units are `k`, `M`, and `G`, and valid types are `files`, `size`, `txs`, `entries`, `hours`, and `days`.
+* `<number><optional unit> <type> <optional space restriction>` where valid units are `K`, `M`, and `G`, and valid types are `files`, `size`, `txs`, `entries`, `hours`, and `days`.
+Valid optional space restriction is a logical log space restriction like `1G`.
+For example, `2 days 1G` limits the logical log space on the disk to 1G at most 2 days per database.
 +
 .Types that can be used to control log retention
 [options="header",cols="1m,3a,2m"]
@@ -117,4 +123,8 @@ m| db.tx_log.rotation.retention_policy=10 hours
 | days
 | Keep logs that contain any transaction committed within the specified number of days from the current time.
 m| db.tx_log.rotation.retention_policy=30 days
+
+| days and size
+| Keep logs that contain any transaction committed within the specified number of days from the current time and within the allocated log space.
+m| db.tx_log.rotation.retention_policy=2 days 1G
 |===


### PR DESCRIPTION
Add more details on how to combine both temporal and size parameters for the Tx log retention.