### PR TITLE
Add parallel runtime information

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -1595,6 +1595,30 @@ a|a double which is in the range `0.0` to `1.0`
 m|+++0.75+++
 |===
 
+
+[[config_server.cypher.parallel.worker_limit]]
+=== `server.cypher.parallel.worker_limit`
+
+label:enterprise-edition[Enterprise Edition]
+label:new[Introduced in 5.13]
+
+.server.cypher.parallel.worker_limit 
+[frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
+|===
+|Description
+a| Number of threads to allocate to Cypher worker threads for the parallel runtime.
+If set to a positive number, that number of workers will be started.
+If set to `0`, one worker will be started for every logical processor available to the Java Virtual Machine.
+
+If set to a negative number we will subtract the value from the number of logical processors available; for example, say Neo4j is running on a server with 16 available processors, using `server.cypher.parallel.worker_limit = -1` would then mean that 15 threads are available for the parallel runtime.
+
+|Valid values
+a| Integer
+
+|Default value
+m| 0
+|===
+
 == Database settings
 
 Database settings affect the behavior of a Neo4j database, for example, the file watcher service, the database format, the database store files, and the database timezone.

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -776,6 +776,12 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_awaitindexes]]
 .db.awaitIndexes()
@@ -794,6 +800,12 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_checkpoint]]
 .db.checkpoint() label:enterprise-edition[]
@@ -813,6 +825,12 @@ m|DBMS
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_clearquerycaches]]
 .db.clearQueryCaches() label:admin-only[]
@@ -1054,6 +1072,13 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
+
 
 [[procedure_db_labels]]
 .db.labels()
@@ -1071,6 +1096,13 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
+
 
 [[procedure_db_listlocks]]
 .db.listLocks() label:enterprise-edition[] label:admin-only[]
@@ -1086,6 +1118,13 @@ m|DBMS
 // | Default roles
 // m|admin
 |===
+
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 
 [[procedure_db_ping]]
@@ -1105,6 +1144,12 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_prepareforreplanning]]
 .db.prepareForReplanning() label:admin-only[]
@@ -1122,6 +1167,12 @@ m|READ
 // m|admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_propertykeys]]
 .db.propertyKeys()
@@ -1138,6 +1189,12 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_relationshiptypes]]
 .db.relationshipTypes()
@@ -1155,6 +1212,12 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_resampleindex]]
 .db.resampleIndex()
@@ -1173,6 +1236,12 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_resampleoutdatedindexes]]
 .db.resampleOutdatedIndexes()
@@ -1188,6 +1257,13 @@ m|READ
 // | Default roles
 // m|reader, editor, publisher, architect, admin
 |===
+
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 
 [[procedure_db_schema_nodetypeproperties]]
@@ -1205,6 +1281,12 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_schema_reltypeproperties]]
 .db.schema.relTypeProperties()
@@ -1221,6 +1303,12 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_schema_visualization]]
 .db.schema.visualization()
@@ -1240,6 +1328,12 @@ m|READ
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_db_stats_clear]]
 .db.stats.clear() label:admin-only[]
@@ -1367,6 +1461,13 @@ m|DBMS
 // | Default roles
 // m|admin
 |===
+
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_dbms_cluster_setAutomaticallyEnableFreeServers]]
 .dbms.cluster.setAutomaticallyEnableFreeServers() label:enterprise-edition[] label:admin-only[]
@@ -1634,6 +1735,13 @@ m|DBMS
 // m|reader, editor, publisher, architect, admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
+
 [[procedure_dbms_listcapabilities]]
 .dbms.listCapabilities()
 [cols="<15s,<85"]
@@ -1703,6 +1811,13 @@ m|DBMS
 // | Default roles
 // m|reader, editor, publisher, architect, admin
 |===
+
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_dbms_quarantineDatabase]]
 .dbms.quarantineDatabase() label:enterprise-edition[] label:admin-only[]
@@ -1806,6 +1921,13 @@ m|DBMS
 // m|admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
+
 
 [[procedure_dbms_scheduler_groups]]
 .dbms.scheduler.groups() label:enterprise-edition[] label:admin-only[]
@@ -1822,6 +1944,12 @@ m|DBMS
 // m|admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_dbms_scheduler_jobs]]
 .dbms.scheduler.jobs() label:enterprise-edition[] label:admin-only[]
@@ -1837,6 +1965,13 @@ m|DBMS
 // | Default roles
 // m|admin
 |===
+
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_dbms_security_clearauthcache]]
 .dbms.security.clearAuthCache() label:enterprise-edition[] label:admin-only[]
@@ -1914,6 +2049,12 @@ m|WRITE
 // m|admin
 |===
 
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_dbms_upgradestatus]]
 .dbms.upgradeStatus() label:admin-only[] label:deprecated[Deprecated in 5.9]
@@ -1929,6 +2070,13 @@ m|READ
 // | Default roles
 // m|admin
 |===
+
+[NOTE]
+====
+This procedure is not considered safe to run from multiple threads.
+It is therefore not supported by the parallel runtime (introduced in Neo4j 5.13).
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+====
 
 [[procedure_tx_getmetadata]]
 .tx.getMetaData()


### PR DESCRIPTION
The parallel runtime introduced a new config setting. For testing purposes, I have taken the description from the mono repo verbatim (https://github.com/neo-technology/neo4j/pull/22275/files#diff-22e5a6968aee5ed485e16da8650e784a16dbd787005216bb719d3dc44aa2b43a)

There are also a number of procedures that are not considered thread-safe to run on the parallel runtime. This PR adds a note for the relevant procedures. Note that the link to the Cypher Manual will not work yet as the we have yet to merge the parallel runtime PR in that repo.