### PR TITLE
Update information on `db.transaction.timeout` (#1085)

### DIFF
--- a/modules/ROOT/pages/database-internals/transaction-management.adoc
+++ b/modules/ROOT/pages/database-internals/transaction-management.adoc
@@ -54,7 +54,10 @@ db.transaction.timeout=10s
 ====
 
 Configuring transaction timeout does not affect transactions executed with custom timeouts (e.g., via the Java API or Neo4j Drivers), as the custom timeout overrides the value set for `db.transaction.timeout`.
-Note that the timeout value can only be overridden to a value that is smaller than that configured by `db.transaction.timeout`.
+Note that the timeout value can only be overridden to a value smaller than that configured by `db.transaction.timeout`.
+
+label:new[Introduced in Neo4j 5.3]
+Starting from Neo4j 5.3, you can set the transaction timeout to any value, even larger than configured by `db.transaction.timeout`.
 
 
 == Manage transactions


### PR DESCRIPTION
Following the slack discussions and findings, I suggest the following amendments.
Do we have then to cherry-pick this PR to the branch 5.x to make it visible now?

---------