### PR TITLE
Correct max label id (#1176)

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-store-info.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-store-info.adoc
@@ -202,7 +202,7 @@ The store formats are:
 | `2^36` (68 719 476 736)
 
 | Labels
-| `2^32` (4 294 967 296)
+| `2^31` (2 147 483 648)
 
 | Relationship types
 | `2^16` (65 536)
@@ -262,7 +262,7 @@ The store formats are:
 | `2^36` (68 719 476 736)
 
 | Labels
-| `2^32` (4 294 967 296)
+| `2^31` (2 147 483 648)
 
 | Relationship types
 | `2^16` (65 536)
@@ -342,7 +342,7 @@ The store formats are:
 | `2^50` (1 Quadrillion)
 
 | Labels
-| `2^32` (4 294 967 296)
+| `2^31` (2 147 483 648)
 
 | Relationship types
 | `2^24` (16 777 216)


### PR DESCRIPTION
2^32 labels has never actually been supported,
anything over 2^31 would fail with an integer overflow.

Cherry-picked from #1176 