### PR TITLE
Docker - ref-settings.adoc: NEO4J_dbms_security_ldap_host typo error 

### DIFF
--- a/modules/ROOT/pages/docker/ref-settings.adoc
+++ b/modules/ROOT/pages/docker/ref-settings.adoc
@@ -494,7 +494,7 @@ For more information on the configuration descriptions, valid values, and defaul
 | `+NEO4J_dbms_security__ldap_connection__timeout+`
 
 | `dbms.security.ldap.host`
-| `+NEO4J_dbms_security__ldap__host+`
+| `+NEO4J_dbms_security_ldap_host+`
 
 | `dbms.security.ldap.read_timeout`
 | `+NEO4J_dbms_security__ldap_read__timeout+`


### PR DESCRIPTION
Cherry-picked from #1166 