### PR TITLE
adding clarification to `neo4j-admin backup` command description

### DIFF
--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -128,11 +128,14 @@ With a single `*` as a value, you can back up all the databases of the DBMS.
 |
 
 |--include-metadata=none\|all\|users\|roles
-|Include metadata in file. Can't be used for backing system database.
-- roles - commands to create the roles and privileges (for both database and graph) that affect the use of the database
-- users - commands to create the users that can use the database and their role assignments
-- all - include roles and users
-- none - don't include any metadata
+|Include metadata in file. Can't be used for backing up the system database.
+
+- `roles` - include commands to create the roles and privileges (for both database and graph) that affect the use of the database
+- `users` - include commands to create the users that can use the database and their role assignments
+- `all` - include `roles` and `users` detailed above
+- `none` - don't include any metadata
+[NOTE]
+`roles` and `users` which don't have any database-related privileges are not included in the backup (e.g. those with only DBMS privileges or no privileges at all). It is recommended to use `SHOW USERS` and `SHOW ROLES` to get the full list of users and roles in these situations.
 |all
 
 |--inspect-path=<path>


### PR DESCRIPTION
This PR contains an expanded description of the --include-metadata option of the neo4j-admin backup command which clarifies that users and roles who don't have any db-relevant privileges will not get backed up.