### PR TITLE
Update the description of `<prefix>.cluster.raft.message_processing_timer` (#1228)

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -399,7 +399,7 @@ The total number of queries executed remotely to a member of a different cluster
 |<prefix>.cluster.raft.raft_log_entry_prefetch_buffer.size|Raft Log Entry Prefetch buffer size. (gauge)
 |<prefix>.cluster.raft.raft_log_entry_prefetch_buffer.async_put|Raft Log Entry Prefetch buffer async puts. (gauge)
 |<prefix>.cluster.raft.raft_log_entry_prefetch_buffer.sync_put|Raft Log Entry Prefetch buffer sync puts. (gauge)
-|<prefix>.cluster.raft.message_processing_delay|The time the Raft message stays in the queue after being received and before being processed, i.e. append and commit to the store. The higher the value, the longer the messages wait to be processed. This metric is closely linked to disk write performance.
+|<prefix>.cluster.raft.message_processing_delay|Delay between Raft message receive and process.
 (gauge)
 |<prefix>.cluster.raft.message_processing_timer|Timer for Raft message processing. (counter, histogram)
 |<prefix>.cluster.raft.replication_new|The total number of Raft replication requests. It increases with write transactions (possibly internal) activity. (counter)


### PR DESCRIPTION

Update the metric's description according to the codebase