### PR TITLE
Fix neo4j-admin server validate-config example

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/validate-config.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/validate-config.adoc
@@ -38,10 +38,10 @@ The `neo4j-admin server validate-config` command has the following options:
 
 == Example
 
-.Invoke `neo4j-admin validate-config`
+.Invoke `neo4j-admin server validate-config`
 [source, shell]
 ----
-bin/neo4j-admin validate-config
+bin/neo4j-admin server validate-config
 ----
 
 .Example output


### PR DESCRIPTION
As written the example throws the following error with 5.14 @ [Validate Config](https://neo4j.com/docs/operations-manual/5/tools/neo4j-admin/validate-config/):

```
./bin/neo4j-admin validate-config
Unmatched argument at index 0: 'validate-config'
Did you mean: neo4j-admin server validate-config or neo4j-admin server migrate-configuration or neo4j-admin database migrate?
```