### PR TITLE
Update the default value of `db.tx_log.rotation.retention_policy` (#1239)

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -4653,7 +4653,7 @@ m|+++true+++
 [[config_db.tx_log.rotation.retention_policy]]
 === `db.tx_log.rotation.retention_policy`
 
-label:dynamic[Dynamic]
+label:dynamic[Dynamic] label:changed[Default value changed in 5.13]
 
 .db.tx_log.rotation.retention_policy
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
@@ -4662,16 +4662,18 @@ label:dynamic[Dynamic]
 a|Specify how long Neo4j should keep logical transaction logs to backup the database.
 For example, `10 days` prunes logical logs that only contain transactions older than 10 days.
 Alternatively, `100k txs` keeps the 100k latest transactions from each database and prunes any older transactions.
-From Neo4j 5.9 onwards, you can optionally add a period-based restriction to the size of logs to keep, for example, `2 days 1G` prunes logical logs that only contain transactions older than 2 days or are larger than 1G.
+From Neo4j 5.9 onwards, you can optionally add a period-based restriction to the size of logs to keep.
+For example, `2 days 1G` prunes logical logs that only contain transactions older than 2 days or are larger than 1G.
 |Valid values
 a|a string which matches the pattern, `^(true\|keep_all\|false\|keep_none\|(\\d+[KkMmGg]?( (files\|size\|txs\|entries\|hours( \\d+[KkMmGg]?)?\|days( \\d+[KkMmGg]?)?))))$`
 Must be `true` or `keep_all`, `false` or `keep_none`, or of format `<number><optional unit> <type> <optional space restriction>`.
 Valid units are `K`, `M`, and `G`.
 Valid types are `files`, `size`, `txs`, `entries`, `hours`, and `days`.
 Valid optional space restriction is a logical log space restriction like `1G`.
-For example, `1G size` limits logical log space on the disk to 1G per database, `200K txs` limits the number of transactions kept to 200 000 per database, and `2 days 1G` limits the logical log space on the disk to 1G at most 2 days per database.
+For example, `1G size` limits logical log space on the disk to 1G per database, `200K txs` limits the number of transactions kept to 200 000 per database, and `2 days 1G` limits the logical log space on the disk to 1G at most 2 days per database. +
+Starting from Neo4j 5.13, the default value is changed from `2 days` to `2 days 2G`.
 |Default value
-m|+++2 days+++
+m|+++2 days 2G+++
 |===
 
 [[config_db.tx_log.rotation.size]]

--- a/modules/ROOT/pages/database-internals/transaction-logs.adoc
+++ b/modules/ROOT/pages/database-internals/transaction-logs.adoc
@@ -59,11 +59,14 @@ Manually deleting transaction log files is not supported.
 You can control the number of transaction logs that Neo4j keeps to back up the database using the parameter xref:configuration/configuration-settings.adoc#config_db.tx_log.rotation.retention_policy[`db.tx_log.rotation.retention_policy`].
 This configuration setting is dynamic and can be changed at runtime.
 
-By default, it is set to `2 days`, which means Neo4j keeps logical logs that contain any transaction committed within 2 days and prunes the ones that only contain transactions older than 2 days.
+Up to Neo4j 5.12, the default value is set to `2 days`, which means Neo4j keeps logical logs that contain any transaction committed within 2 days and prunes the ones that only contain transactions older than 2 days.
 
 label:new[Introduced in Neo4j 5.9] +
 From Neo4j 5.9 onwards, you can optionally add a period-based restriction to the size of logs to keep.
 For example, `2 days 1G` prunes logical logs that only contain transactions older than 2 days or are larger than 1G.
+
+label:new[Introduced in Neo4j 5.13] +
+Starting from Neo4j 5.13, the default value is changed to `2 days 2G`, which means Neo4j keeps logical logs that contain any transaction committed within 2 days from the current time and within the allocated log space (2G).
 
 Other possible ways to configure the log retention policy are:
 


### PR DESCRIPTION


In Neo4j 5.13, the def.value of the config
`db.tx_log.rotation.retention_policy` was changed from `2 days` to `2 days 2G`. To reflect those changes, we have to update two pages in the Operations manual.

---------