### PR TITLE
Clarify lock note again

### DIFF
--- a/modules/ROOT/pages/database-internals/locks-deadlocks.adoc
+++ b/modules/ROOT/pages/database-internals/locks-deadlocks.adoc
@@ -201,6 +201,11 @@ For these additional locks, no assumptions or guarantees can be made concerning 
 
 === Locks for dense nodes
 
+[NOTE]
+====
+This _Locks for dense nodes_ section describes the behavior of the `standard`, `aligned`, and `high-limit` store formats. The `block` format has a similar but not identical feature. 
+====
+
 A node is considered dense if it at any point has had 50 or more relationships (i.e. it will still be considered dense even if it comes to have less than 50 relationships at any point in the future).
 A node is considered sparse if it has never had more than 50 relationships.
 You can configure the relationship count threshold for when a node is considered dense by setting xref:configuration/configuration-settings.adoc#config_db.relationship_grouping_threshold[`db.relationship_grouping_threshold`] configuration parameter.
@@ -215,11 +220,6 @@ In other words, relationship modifications acquire coarse-grained shared node lo
 The locking is very similar for sparse and dense nodes.
 The biggest contention for sparse nodes is the update of the degree (i.e. number of relationships) for the node.
 Dense nodes store this data in a concurrent data structure, and so can avoid exclusive node locks in almost all cases for relationship modifications.
-
-[NOTE]
-====
-This section applies only to `standard`, `aligned`, and `high-limit` store formats.
-====
 
 [[transaction-management-lock-acquisition-timeout]]
 === Configure lock acquisition timeout


### PR DESCRIPTION
The reason I moved the Note, was because it wasn't clear which section the Note refers to.