### PR TITLE
Rename Neo4j connectors to network connectors to differentiate them from Kafka, Spark, etc. (#1301)

### DIFF
--- a/modules/ROOT/pages/configuration/connectors.adoc
+++ b/modules/ROOT/pages/configuration/connectors.adoc
@@ -1,34 +1,33 @@
-:description: How to configure connectors (Bolt, HTTP, and HTTPS) for Neo4j.
+:description: How to configure network connectors (Bolt, HTTP, and HTTPS) for Neo4j.
 [[connectors]]
-= Configure connectors
+= Configure network connectors
 
-Neo4j provides support for Bolt, HTTP, and HTTPS protocols using connectors.
-Connectors are configured in the _neo4j.conf_ file.
+Neo4j provides support for Bolt, HTTP, and HTTPS protocols using network connectors.
+Network connectors are configured in the _neo4j.conf_ file.
 
 [[connectors-available-connectors]]
-== Available connectors
+== Available network connectors
 
-The table below lists the available Neo4j connectors:
+The table below lists the available network connectors in Neo4j:
 
-.Neo4j connectors and port number
+.Neo4j network connectors and port number
 [options="header"]
 |===
-| Connector name  | Protocol | Default port number
+| Network connector name  | Protocol | Default port number
 | `server.bolt`   | Bolt     | `7687`
 | `server.http`   | HTTP     | `7474`
 | `server.https`  | HTTPS    | `7473`
 |===
 
-When configuring the HTTPS or Bolt connector, see also xref:security/ssl-framework.adoc[SSL framework] for details on how to work with SSL certificates.
+When configuring the HTTPS or Bolt connectors, see also xref:security/ssl-framework.adoc[SSL framework] for details on how to work with SSL certificates.
 
 
 [[connectors-configuration-options]]
 == Configuration options
 
-The connectors are configured by settings on the format `server.<connector-name>.<setting-suffix>>`.
-The available suffixes are described in the table below:
+The network connectors are configured by settings in the format `server.<network-connector-name>.<setting-suffix>>`.
 
-.Configuration option suffixes for connectors
+.Configuration option suffixes for network connectors
 [options="header",cols="15,25,60,60"]
 |===
 | Option name
@@ -43,17 +42,17 @@ The available suffixes are described in the table below:
   When disabled, Neo4j does not listen for incoming connections on the relevant port.
 
 | `listen_address`
-| `127.0.0.1:<connector-default-port>`
+| `127.0.0.1:<network-connector-default-port>`
 | `xref:configuration/configuration-settings.adoc#config_server.bolt.listen_address[server.bolt.listen_address]`, `xref:configuration/configuration-settings.adoc#config_server.https.listen_address[server.https.listen_address]`, `xref:configuration/configuration-settings.adoc#config_server.http.listen_address[server.http.listen_address]`
 | This setting specifies how Neo4j listens for incoming connections.
 It consists of two parts; an IP address (e.g. 127.0.0.1 or 0.0.0.0) and a port number (e.g. 7687), and is expressed in the format `<ip-address>:<port-number>`.
 See below for an example of usage.
 
 | `advertised_address`
-| `localhost:<connector-default-port>`
+| `localhost:<network-connector-default-port>`
 | `xref:configuration/configuration-settings.adoc#config_server.bolt.advertised_address[server.bolt.advertised_address]`, `xref:configuration/configuration-settings.adoc#config_server.https.advertised_address[server.https.advertised_address]`, `xref:configuration/configuration-settings.adoc#config_server.http.advertised_address[server.http.advertised_address]`
-| This setting specifies the address that clients should use for this connector.
-This is useful in a cluster as it allows each server to correctly advertise addresses of the other servers in the cluster.
+| This setting specifies the address that clients should use for this network connector.
+This is useful in a cluster as it allows each server to correctly advertise the addresses of the other servers in the cluster.
 The advertised address consists of two parts; an address (fully qualified domain name, hostname, or IP address) and a port number (e.g. 7687), and is expressed in the format `<address>:<port-number>`.
 See below for an example of usage.
 
@@ -61,7 +60,7 @@ See below for an example of usage.
 | `DISABLED`
 | `xref:configuration/configuration-settings.adoc#config_server.bolt.tls_level[server.bolt.tls_level]`
 | This setting is only applicable to the Bolt connector.
-It allows the connector to accept encrypted and/or unencrypted connections.
+It allows the Bolt connector to accept encrypted and/or unencrypted connections.
 The default value is `DISABLED`, where only unencrypted client connections are to be accepted by this connector, and all encrypted connections will be rejected.
 
 Other values are `REQUIRED` and `OPTIONAL`.
@@ -79,8 +78,8 @@ server.bolt.listen_address=0.0.0.0:7000
 
 .Specify `advertised_address` for the Bolt connector
 ====
-If routing traffic via a proxy, or if port mappings are in use, it is possible to specify `advertised_address` for each connector individually.
-For example, if port 7687 on the Neo4j Server is mapped from port 9000 on the external network, specify the `advertised_address` for the Bolt connector:
+If routing traffic via a proxy, or if port mappings are in use, it is possible to specify `advertised_address` for each network connector individually.
+For example, if port `7687` on the Neo4j server is mapped from port `9000` on the external network, specify the `advertised_address` for the Bolt connector:
 ----
 server.bolt.advertised_address=<server-name>:9000
 ----
@@ -90,17 +89,17 @@ server.bolt.advertised_address=<server-name>:9000
 [[connectors-options-for-bolt-thread-pooling]]
 == Options for Bolt thread pooling
 
-See xref:performance/bolt-thread-pool-configuration.adoc[Bolt thread pool configuration] to learn more about Bolt thread pooling and how to configure it on the connector level.
+See xref:performance/bolt-thread-pool-configuration.adoc[Bolt thread pool configuration] to learn more about Bolt thread pooling and how to configure it on the network connector level.
 
 [[connectors-defaults-for-addresses]]
 == Defaults for addresses
 
-It is possible to specify defaults for the configuration options with `listen_address` and `advertised_address` suffixes, as described below.
-Setting a default value will apply to all the connectors, unless specifically configured for a certain connector.
+It is possible to specify defaults for the configuration options with `listen_address` and `advertised_address` suffixes.
+Setting a default value applies to all network connectors unless specifically configured for a certain connector.
 
 
 `xref:configuration/configuration-settings.adoc#config_server.default_listen_address[server.default_listen_address]`::
-This configuration option defines a default IP address of the settings with the `listen_address` suffix for all connectors.
+This configuration option defines a default IP address of the settings with the `listen_address` suffix for all network connectors.
 If the IP address part of the `listen_address` is not specified, it is inherited from the shared setting `server.default_listen_address`.
 +
 .Specify `listen_address` for the Bolt connector
@@ -120,7 +119,7 @@ server.bolt.listen_address=:7000
 ====
 
 `xref:configuration/configuration-settings.adoc#config_server.default_advertised_address[server.default_advertised_address]`::
-This configuration option defines a default address of the settings with the `advertised_address` suffix for all connectors.
+This configuration option defines a default address of the settings with the `advertised_address` suffix for all network connectors.
 If the address part of the `advertised_address` is not specified, it is inherited from the shared setting `server.default_advertised_address`.
 +
 .Specify `advertised_address` for the Bolt connector
@@ -144,7 +143,7 @@ server.bolt.advertised_address=:9000
 [WARNING]
 ====
 The default address settings can only accept the hostname or IP address portion of the full socket address.
-Port numbers are protocol-specific, and can only be added by the protocol-specific connector configuration.
+Port numbers are protocol-specific, and can only be added by the protocol-specific network connector configuration.
 
 For example, if you configure the default address value to be `example.com:9999`, Neo4j will fail to start and you will get an error in xref:configuration/file-locations.adoc[_neo4j.log_].
 ====


### PR DESCRIPTION
Cherry-picked from #1301 