### PR TITLE
Add a note about Idp connectivity

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
@@ -152,7 +152,9 @@ dbms.security.authentication_providers=oidc-newsso,oidc-oldsso,native
 dbms.security.authorization_providers=oidc-newsso,oidc-oldsso,native
 ----
 ======
-. Check Connectivity. Neo4j will need to connect to the identity provider to discover settings and fetch public keys to verify tokens. Check firewall settings, security controls and if necessary logs, to ensure that the Neo4j server is able to connect to the identity provider using https.
+. Check connectivity.
+Neo4j needs to connect to the identity provider to discover settings and fetch public keys to verify tokens.
+Check firewall settings, security controls, and, if necessary, logs to ensure that the Neo4j server is able to connect to the identity provider using HTTPS.
 If a proxy is required, this can be https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/doc-files/net-properties.html#Proxies[configured] in the Java virtual machine using the configuration setting xref:configuration/configuration-settings.adoc#config_server.jvm.additional[server.jvm.additional].
 Proxies that require credentials are not supported.
 

--- a/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
@@ -152,7 +152,7 @@ dbms.security.authentication_providers=oidc-newsso,oidc-oldsso,native
 dbms.security.authorization_providers=oidc-newsso,oidc-oldsso,native
 ----
 ======
-. Check Connectivity. Neo4j will need to connect to the identity provider to discover settings and fetch public keys to verify tokens. Check firewall settings and security controls to ensure that the Neo4j server is able to connect to the identity provider using https.
+. Check Connectivity. Neo4j will need to connect to the identity provider to discover settings and fetch public keys to verify tokens. Check firewall settings, security controls and if necessary logs, to ensure that the Neo4j server is able to connect to the identity provider using https.
 If a proxy is required, this can be https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/doc-files/net-properties.html#Proxies[configured] in the Java virtual machine using the configuration setting xref:configuration/configuration-settings.adoc#config_server.jvm.additional[server.jvm.additional].
 Proxies that require credentials are not supported.
 

--- a/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
@@ -154,7 +154,7 @@ dbms.security.authorization_providers=oidc-newsso,oidc-oldsso,native
 ======
 . Check connectivity.
 Neo4j needs to connect to the identity provider to discover settings and fetch public keys to verify tokens.
-Check firewall settings, security controls, and, if necessary, logs to ensure that the Neo4j server is able to connect to the identity provider using HTTPS.
+Check firewall settings and security controls, and, if necessary, logs to ensure that the Neo4j server is able to connect to the identity provider using HTTPS.
 If a proxy is required, this can be https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/doc-files/net-properties.html#Proxies[configured] in the Java virtual machine using the configuration setting xref:configuration/configuration-settings.adoc#config_server.jvm.additional[server.jvm.additional].
 Proxies that require credentials are not supported.
 

--- a/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
@@ -152,6 +152,9 @@ dbms.security.authentication_providers=oidc-newsso,oidc-oldsso,native
 dbms.security.authorization_providers=oidc-newsso,oidc-oldsso,native
 ----
 ======
+. Check Connectivity. Neo4j will need to connect to the identity provider to discover settings and fetch public keys to verify tokens. Check firewall settings and security controls to ensure that the Neo4j server is able to connect to the identity provider using https.
+If a proxy is required, this can be https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/doc-files/net-properties.html#Proxies[configured] in the Java virtual machine using the configuration setting xref:configuration/configuration-settings.adoc#config_server.jvm.additional[server.jvm.additional].
+Proxies that require credentials are not supported.
 
 [[auth-sso-map-idp-roles]]
 == Map the Identity Provider Groups to the Neo4j Roles


### PR DESCRIPTION
Add a note to ensure the Neo4j server is able to connect to the identity provider, as this is required for operation.