### PR TITLE
Tag deallocated state with version (#1336)

### DIFF
--- a/modules/ROOT/pages/clustering/servers.adoc
+++ b/modules/ROOT/pages/clustering/servers.adoc
@@ -14,7 +14,7 @@ A server can exist in five different states within the DBMS:
 * Free
 * Enabled
 * Deallocating
-* Deallocated
+* Deallocated label:new[Introduced in 5.15]
 * Cordoned
 * Dropped
 
@@ -85,7 +85,7 @@ When a server is no longer needed, it cannot be removed from the cluster while i
 The command `DEALLOCATE DATABASE[S] FROM SERVER[S] _server_[,...]` is used to transition servers to the _Deallocating_ state, reallocating all their hosted databases to other servers in the cluster.
 Additionally, servers which are deallocating will not have any further databases allocated to them.
 
-=== Deallocated state
+=== Deallocated state label:new[Introduced in 5.15]
 
 When a server is in the deallocated state it no longer hosts any databases any databases besides system and can be removed from the cluster.
 Additionally, deallocated servers cannot have any further databases allocated to them.


### PR DESCRIPTION
The operations manual refers to the `Deallocated` state as it was always available. Actually it is a rather new invention, so it is worth pointing out that to the reader.