### PR TITLE
fix lxref instead of xref in immutable privileges tutorial

### DIFF
--- a/modules/ROOT/pages/tutorial/tutorial-immutable-privileges.adoc
+++ b/modules/ROOT/pages/tutorial/tutorial-immutable-privileges.adoc
@@ -4,9 +4,9 @@
 :description: This tutorial describes methods for administering immutable privileges.
 
 This tutorial describes how to administer immutable privileges, which are useful assets for restricting the actions of users who themselves are able to administer privileges.
-They offer a way to prevent such users from simply removing any restrictions by using their lxref:authentication-authorization/dbms-administration.adoc#access-control-dbms-administration-privilege-management[privilege management] privileges.
+They offer a way to prevent such users from simply removing any restrictions by using their xref:authentication-authorization/dbms-administration.adoc#access-control-dbms-administration-privilege-management[privilege management] privileges.
 
-In other words, having  lxref:authentication-authorization/dbms-administration.adoc#access-control-dbms-administration-privilege-management[privilege management] privileges is not sufficient to add or remove immutable privileges.
+In other words, having  xref:authentication-authorization/dbms-administration.adoc#access-control-dbms-administration-privilege-management[privilege management] privileges is not sufficient to add or remove immutable privileges.
 The only way immutable privileges can be added or removed is when auth is disabled.
 
 [CAUTION]


### PR DESCRIPTION
I was reading the immutable privileges tutorial at https://neo4j.com/docs/operations-manual/current/tutorial/tutorial-immutable-privileges/ and noticed two typos, `lxref` instead of `xref`, this PR fixes it.

<img width="356" alt="Screenshot 2024-01-21 at 09 57 50" src="https://github.com/neo4j/docs-operations/assets/1222009/448a0eec-fcec-4296-8e6e-2f3ad257de07">
