### PR TITLE
Update scaling.adoc

### DIFF
--- a/modules/ROOT/pages/kubernetes/operations/scaling.adoc
+++ b/modules/ROOT/pages/kubernetes/operations/scaling.adoc
@@ -27,7 +27,7 @@ neo4j:
 # Neo4j Configuration (yaml format)
 config:
   server.memory.heap.initial_size: "2G"
-  server.memory.heap.initial_size: "2G"
+  server.memory.heap.max_size: "2G"
   server.memory.pagecache.size: "500m"
 ----
 
@@ -46,7 +46,7 @@ neo4j:
 # Neo4j Configuration (yaml format)
 config:
   server.memory.heap.initial_size: "2G"
-  server.memory.heap.initial_size: "2G"
+  server.memory.heap.max_size: "2G"
   server.memory.pagecache.size: "1G"
 ----
 +


### PR DESCRIPTION
JVM Heap initial memory set twice. That's probably a mistake, should be max_size in the later config lines.