### PR TITLE
Add a metric for block format

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -133,6 +133,7 @@ By default, database metrics include:
 |Name |Description
 |<prefix>.neo4j.count.relationship|The total number of relationships in the database. (gauge)
 |<prefix>.neo4j.count.node|The total number of nodes in the database. A rough metric of how big your graph is. And if you are running a bulk insert operation you can see this tick up. (gauge)
+|<prefix>.neo4j.count.relationship_types|label:new[Introduced in 5.15] The total number of internally generated IDs for the different relationship types stored in the database. These IDs do not reflect changes in the actual data. Informational, not an indication of any issue. (gauge)
 |===
 
 [[db-neo4j-pool-metrics]]
@@ -180,10 +181,10 @@ By default, database metrics include:
 [options="header",cols="<3m,<4"]
 |===
 |Name |Description
-|<prefix>.ids_in_use.relationship_type|The total number of internally generated IDs for the different relationship types stored in the database. These IDs do not reflect changes in the actual data. Informational, not an indication of any issue. (gauge)
-|<prefix>.ids_in_use.property|The total number of internally generated IDs for the different property names stored in the database. These IDs do not reflect changes in the actual data. Informational, not an indication of any issue. (gauge)
-|<prefix>.ids_in_use.relationship|The total number of internally generated reusable IDs for the relationships stored in the database. These IDs do not reflect changes in the actual data. If you want to have a rough metric of how big your graph is, use `<prefix>.neo4j.count.relationship` instead. (gauge)
-|<prefix>.ids_in_use.node|The total number of internally generated reusable IDs for the nodes stored in the database. These IDs do not reflect changes in the actual data. If you want to have a rough metric of how big your graph is, use `<prefix>.neo4j.count.node` instead. (gauge)
+|<prefix>.ids_in_use.relationship_type|label:deprecated[Deprecated in 5.15]The total number of internally generated IDs for the different relationship types stored in the database. These IDs do not reflect changes in the actual data. Informational, not an indication of any issue. (gauge)
+|<prefix>.ids_in_use.property|label:deprecated[Deprecated in 5.15]The total number of internally generated IDs for the different property names stored in the database. These IDs do not reflect changes in the actual data. Informational, not an indication of any issue. (gauge)
+|<prefix>.ids_in_use.relationship|label:deprecated[Deprecated in 5.15]The total number of internally generated reusable IDs for the relationships stored in the database. These IDs do not reflect changes in the actual data. If you want to have a rough metric of how big your graph is, use `<prefix>.neo4j.count.relationship` instead. (gauge)
+|<prefix>.ids_in_use.node|label:deprecated[Deprecated in 5.15]The total number of internally generated reusable IDs for the nodes stored in the database. These IDs do not reflect changes in the actual data. If you want to have a rough metric of how big your graph is, use `<prefix>.neo4j.count.node` instead. (gauge)
 |===
 
 [[global-neo4j-pools-metrics]]


### PR DESCRIPTION
According to the [PR#22820](https://github.com/neo-technology/neo4j/pull/22820), we have to update information about metrics: add a new one and label deprecated metrics.
A new metric is `<prefix>.neo4j.count.relationship_types`.