### PR TITLE
Fix names of the global neo4j pool metrics

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -192,11 +192,11 @@ By default, database metrics include:
 [options="header",cols="<3m,<4"]
 |===
 |Name |Description
-|<prefix>.dbms.pool.<pool>.used_heap|Used or reserved heap memory in bytes. (gauge)
-|<prefix>.dbms.pool.<pool>.used_native|Used or reserved native memory in bytes. (gauge)
-|<prefix>.dbms.pool.<pool>.total_used|Sum total used heap and native memory in bytes. (gauge)
-|<prefix>.dbms.pool.<pool>.total_size|Sum total size of the capacity of the heap and/or native memory pool. (gauge)
-|<prefix>.dbms.pool.<pool>.free|Available unused memory in the pool, in bytes. (gauge)
+|<prefix>.pool.<pool>.used_heap|Used or reserved heap memory in bytes. (gauge)
+|<prefix>.pool.<pool>.used_native|Used or reserved native memory in bytes. (gauge)
+|<prefix>.pool.<pool>.total_used|Sum total used heap and native memory in bytes. (gauge)
+|<prefix>.pool.<pool>.total_size|Sum total size of the capacity of the heap and/or native memory pool. (gauge)
+|<prefix>.pool.<pool>.free|Available unused memory in the pool, in bytes. (gauge)
 |===
 
 [[db-page-cache-metrics]]


### PR DESCRIPTION
Update the names of the Global neo4j pool metrics according to the changes made
 in the [PR #22972](https://github.com/neo-technology/neo4j/pull/22972/files#diff-f46e38361d386712aec989c90ea850ce393856c5ccae5dabd6f9664f08a5631a)