### PR TITLE
Label db state metrics with 5.7

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -165,14 +165,14 @@ By default, database metrics include:
 |===
 
 [[db-state-count-metrics]]
-.Database state count metrics
+.Database state count metrics label:new[Introduced in 5.7]
 
 [options="header",cols="<3m,<4"]
 |===
 |Name |Description
-|<prefix>.db.state.count.hosted|label:new[Introduced in 5.7]Databases hosted on this server. Databases in states `started`, `store copying`, or `draining` are considered hosted. (gauge)
-|<prefix>.db.state.count.failed|label:new[Introduced in 5.7]Databases in a failed state on this server. (gauge)
-|<prefix>.db.state.count.desired_started|label:new[Introduced in 5.7]Databases that desire to be started on this server. (gauge)
+|<prefix>.db.state.count.hosted|Databases hosted on this server. Databases in states `started`, `store copying`, or `draining` are considered hosted. (gauge)
+|<prefix>.db.state.count.failed|Databases in a failed state on this server. (gauge)
+|<prefix>.db.state.count.desired_started|Databases that desire to be started on this server. (gauge)
 |===
 
 [[db-data-metrics]]

--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -170,9 +170,9 @@ By default, database metrics include:
 [options="header",cols="<3m,<4"]
 |===
 |Name |Description
-|<prefix>.db.state.count.hosted|Databases hosted on this server. Databases in states `started`, `store copying`, or `draining` are considered hosted. (gauge)
-|<prefix>.db.state.count.failed|Databases in a failed state on this server. (gauge)
-|<prefix>.db.state.count.desired_started|Databases that desire to be started on this server. (gauge)
+|<prefix>.db.state.count.hosted|label:new[Introduced in 5.7]Databases hosted on this server. Databases in states `started`, `store copying`, or `draining` are considered hosted. (gauge)
+|<prefix>.db.state.count.failed|label:new[Introduced in 5.7]Databases in a failed state on this server. (gauge)
+|<prefix>.db.state.count.desired_started|label:new[Introduced in 5.7]Databases that desire to be started on this server. (gauge)
 |===
 
 [[db-data-metrics]]


### PR DESCRIPTION
As it was decided to tag all new additions with the corresponding labels in the 5.x series, we have to label `database state metrics` with `Introduced in 5.7`.
See PR #636 