### PR TITLE
Label db state metrics with 5.7 (#1381)

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -165,7 +165,7 @@ By default, database metrics include:
 |===
 
 [[db-state-count-metrics]]
-.Database state count metrics
+.Database state count metrics label:new[Introduced in 5.7]
 
 [options="header",cols="<3m,<4"]
 |===


### PR DESCRIPTION
As it was decided to tag all new additions with the corresponding labels in the 5.x series, we have to label `database state metrics` with `Introduced in 5.7`.
See PR #636