### PR TITLE
Fix names of the Bolt driver metrics (#1385)

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -92,10 +92,18 @@ By default, database metrics include:
 |<prefix>.bolt.response_success|(unsupported feature) When `internal.server.bolt.response_metrics` is enabled, number of `encounteredsuccess` responses. (counter)
 |<prefix>.bolt.response_ignored|(unsupported feature) When `internal.server.bolt.response_metrics` is enabled, number of `encounteredignored` responses (counter)
 |<prefix>.bolt.response_failed|(unsupported feature) When `internal.server.bolt.response_metrics` is enabled, number of `encounteredinstances` of a given error code. (counter)
-|<prefix>.bolt_driver.managed_transaction_function_calls|The total number of managed transaction function calls. (counter)
-|<prefix>.bolt_driver.unmanaged_transaction_calls|The total number of un-managed transaction function calls. (counter)
-|<prefix>.bolt_driver.implicit_transaction_calls|The total number of implicit transaction function calls. (counter)
-|<prefix>.bolt_driver.execute_calls|The total number of driver-level execute function calls. (counter)
+|===
+
+[[bolt-driver-metrics]]
+.Bolt Driver metrics label:new[Introduced in 5.13]
+
+[options="header",cols="<3m,<4"]
+|===
+|Name |Description
+|<prefix>.dbms.bolt_driver.api.managed_transaction_function_calls|The total number of managed transaction function calls. (counter)
+|<prefix>.dbms.bolt_driver.api.unmanaged_transaction_calls|The total number of unmanaged transaction function calls. (counter)
+|<prefix>.dbms.bolt_driver.api.implicit_transaction_calls|The total number of implicit transaction function calls. (counter)
+|<prefix>.dbms.bolt_driver.api.execute_calls|The total number of driver-level execute function calls. (counter)
 |===
 
 [[checkpointing-metrics]]


### PR DESCRIPTION
Separate Bolt driver metrics from the Bolt metrics. Fix names of the Bolt driver metrics according to the codebase. For details, see https://github.com/neo-technology/neo4j/pull/22339. These metrics were added as a new metric class.

---------