### PR TITLE
updated mentions of ubi8 docker images to ubi9

### DIFF
--- a/modules/ROOT/pages/docker/introduction.adoc
+++ b/modules/ROOT/pages/docker/introduction.adoc
@@ -35,7 +35,7 @@ ____
 
 === Base operating system
 
-The Neo4j image is available with either `debian:bullseye-slim` or `redhat/ubi8-minimal:latest` as the base image.
+The Neo4j image is available with either `debian:bullseye-slim` or `redhat/ubi9-minimal:latest` as the base image.
 The default is `debian:bullseye-slim`.
 
 [TIP]
@@ -44,7 +44,7 @@ If you are unsure which base image to use or have no preference, just use the de
 ====
 
 
-To specify which base image to use, the image tags optionally have a `-bullseye` or `-ubi8` suffix.
+To specify which base image to use, the image tags optionally have a `-bullseye` or `-ubi9` suffix.
 
 For example:
 
@@ -52,8 +52,8 @@ For example:
 ----
 neo4j:{neo4j-version-exact}-bullseye            # debian 11 community
 neo4j:{neo4j-version-exact}-enterprise-bullseye # debian 11 enterprise
-neo4j:{neo4j-version-exact}-ubi8              # redhat UBI8 community
-neo4j:{neo4j-version-exact}-enterprise-ubi8   # redhat UBI8 enterprise
+neo4j:{neo4j-version-exact}-ubi9              # redhat UBI9 community
+neo4j:{neo4j-version-exact}-enterprise-ubi9   # redhat UBI9 enterprise
 neo4j:{neo4j-version-exact}                   # debian 11 community
 neo4j:{neo4j-version-exact}-enterprise        # debian 11 enterprise
 ----
@@ -68,8 +68,8 @@ neo4j:{neo4j-version-exact}-enterprise        # debian 11 enterprise
 | `-bullseye`
 | `debian:bullseye-slim`
 
-| `-ubi8`
-| `redhat/ubi8-minimal:latest`
+| `-ubi9`
+| `redhat/ubi9-minimal:latest`
 
 | _unspecified_
 | `debian:bullseye-slim`
@@ -78,7 +78,7 @@ neo4j:{neo4j-version-exact}-enterprise        # debian 11 enterprise
 
 [NOTE]
 ====
-The Red Hat variant images are only available from 5.10.0 and onwards.
+The Red Hat UBI9 variant images are only available from 5.17.0 and onwards.
 For earlier Neo4j versions, do not specify a base image.
 ====
 


### PR DESCRIPTION
In 5.17.0 we will start deprecating ubi8 images in favour of ubi9 ones. This updates the documentation so that we aren't telling users to start the deprecated images.

This should only be merged into the public documentation after the 5.17 release though, otherwise the docker commands won't work. I'm not sure what needs doing to ensure it doesn't get published early?