### PR TITLE
Adding new page alias after several broken links in different guides

### DIFF
--- a/modules/ROOT/pages/database-administration/index.adoc
+++ b/modules/ROOT/pages/database-administration/index.adoc
@@ -1,5 +1,5 @@
 :description: This page gives an introduction to database administration using Neo4j.
-:page-aliases: manage-databases/introduction.adoc, manage-databases/index.adoc
+:page-aliases: manage-databases/introduction.adoc, manage-databases/index.adoc, manage-databases/introduction.adoc#manage-databases-default
 [database-administration]
 = Database administration
 


### PR DESCRIPTION
Even though we have the `manage-databases/introduction.adoc` page alias, in several guides (Go, JavaScript, Bloom etc) the link `manage-databases/introduction.adoc#manage-databases-default` is being used instead and the `page-aliases` component doesn't seem to map that. We could change the link in every guide it appears or use this PR to add a new alias to fix the 404 error. 