### PR TITLE
Adding clarification that sub-admin roles should not be able to change their own privileges

### DIFF
--- a/modules/ROOT/pages/tutorial/access-control.adoc
+++ b/modules/ROOT/pages/tutorial/access-control.adoc
@@ -224,10 +224,14 @@ Then you need to *deny* the two specific actions this role is not supposed to pe
 * Read any patients' social security number (`SSN`).
 * Submit medical diagnoses.
 
+As well as the ability for the `itadmin` to amend their own privileges.
+
 [source, cypher, role=systemcmd]
 ----
 DENY READ {ssn} ON GRAPH healthcare NODES Patient TO itadmin;
 DENY CREATE ON GRAPH healthcare RELATIONSHIPS DIAGNOSIS TO itadmin;
+DENY ROLE MANAGEMENT ON DBMS TO itadmin;
+DENY PRIVILEGE MANAGEMENT ON DBMS TO itadmin;
 ----
 
 The complete set of privileges available to users assigned the `itadmin` role can be viewed using the following command:
@@ -254,6 +258,8 @@ SHOW ROLE itadmin PRIVILEGES AS COMMANDS;
 | "GRANT LOAD ON ALL DATA TO `itadmin`"                                   |
 | "DENY READ {ssn} ON GRAPH `healthcare` NODE Patient TO `itadmin`"       |
 | "DENY CREATE ON GRAPH `healthcare` RELATIONSHIP DIAGNOSIS TO `itadmin`" |
+| "DENY ROLE MANAGEMENT ON DBMS TO `itadmin`"                             |
+| "DENY PRIVILEGE MANAGEMENT ON DBMS TO `itadmin`"                        |
 +-------------------------------------------------------------------------+
 ----
 


### PR DESCRIPTION
This was noticed in a recent internal pentest of RBAC.

We need to clarify that it is necessary to explicitly deny the ability to change your own privileges if you copy the admin role (otherwise the new role is essentially unconstrained).