### PR TITLE
Update configuration-settings.adoc

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -2449,7 +2449,7 @@ label:dynamic[Dynamic] label:changed[Value changed in 5.2]
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|Limit the amount of memory that all of the running transactions can consume, in bytes (or kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g'). Zero means 'unlimited'. 70% of the heap size limit.
+a|Limit the amount of memory that all of the running transactions can consume, in bytes (or kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g'). Zero means 'unlimited'. Defaults to 70% of the heap size limit.
 |Valid values
 a|A byte size (valid multipliers are `B`, `KiB`, `KB`, `K`, `kB`, `kb`, `k`, `MiB`, `MB`, `M`, `mB`, `mb`, `m`, `GiB`, `GB`, `G`, `gB`, `gb`, `g`, `TiB`, `TB`, `PiB`, `PB`, `EiB`, `EB`) that is minimum `10.00MiB` or is `0B`.
 |Default value


### PR DESCRIPTION
Fix the description of `dbms.memory.transaction.total.max`, where a "Defaults to" was missing compared to the in-code version.
Cherry-picked from #1445 