### PR TITLE
remove the note about dropping the database

### DIFF
--- a/modules/ROOT/pages/backup-restore/restore-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-backup.adoc
@@ -154,8 +154,12 @@ bin/neo4j-admin database restore --from-path=/path/to/backups/neo4j-2023-05-05T1
 ----
 +
 The `--from-path=` argument must contain the path to the last backup of a chain, in this case, `neo4j-2023-06-29T14-51-33.backup`.
-If you want to restore several databases at once, you can specify a comma-separated list of paths to backup artifacts, remove the `<database>` parameter, and skip the `CREATE DATABASE` step.
-
++
+[TIP]
+====
+If you want to restore several databases at once, you must stop them first and then you can alter the command by specifying a comma-separated list of paths to backup artifacts, and remove the `<database>` parameter.
+You should also skip the `CREATE DATABASE` step afterward.
+====
 . Create the new database using `CREATE DATABASE` against the `system` database.
 +
 [source, cypher, role=nocopy noplay]
@@ -177,9 +181,14 @@ bin/neo4j-admin database restore --from-path=/path/to/mybackups/neo4j-2023-06-29
 ----
 +
 The `--from-path=` argument must contain the path to either a full or a differential backup artifact.
-If you want to restore several databases at once, you can specify a comma-separated list of paths to backup artifacts, remove the `<database>` parameter, and skip the `CREATE DATABASE` step. +
 The `--restore-until=` argument must contain a UTC date and time.
 The restore recovers all transactions that were committed before the provided date and time.
++
+[TIP]
+====
+If you want to restore several databases at once, you must stop them first and then you can alter the command by specifying a comma-separated list of paths to backup artifacts, and remove the `<database>` parameter.
+You should also skip the `CREATE DATABASE` step afterward.
+====
 +
 [NOTE]
 ====

--- a/modules/ROOT/pages/backup-restore/restore-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-backup.adoc
@@ -165,11 +165,6 @@ CREATE DATABASE mydatabase
 
 To restore data up to a specific date, you need to pass the backup artifact that contains the data up to that date.
 
-[NOTE]
-====
-Restoring data up to a specific date is only possible after you drop the existing database.
-====
-
 . Log in to the Neo4j using `cypher-shell`:
 +
 [source, shell,role=nocopy noplay]

--- a/modules/ROOT/pages/backup-restore/restore-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-backup.adoc
@@ -158,7 +158,7 @@ The `--from-path=` argument must contain the path to the last backup of a chain,
 [TIP]
 ====
 If you want to restore several databases at once, you must stop them first and then you can alter the command by specifying a comma-separated list of paths to backup artifacts, and remove the `<database>` parameter.
-You should also skip the `CREATE DATABASE` step afterward.
+You should also skip the `CREATE DATABASE` step afterward if you are replacing an existing database.
 ====
 . Create the new database using `CREATE DATABASE` against the `system` database.
 +
@@ -187,7 +187,7 @@ The restore recovers all transactions that were committed before the provided da
 [TIP]
 ====
 If you want to restore several databases at once, you must stop them first and then you can alter the command by specifying a comma-separated list of paths to backup artifacts, and remove the `<database>` parameter.
-You should also skip the `CREATE DATABASE` step afterward.
+You should also skip the `CREATE DATABASE` step afterward if you are replacing an existing database.
 ====
 +
 [NOTE]

--- a/modules/ROOT/pages/backup-restore/restore-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-backup.adoc
@@ -164,6 +164,7 @@ CREATE DATABASE mydatabase
 === Restore data up to a specific date
 
 To restore data up to a specific date, you need to pass the backup artifact that contains the data up to that date.
+If you want to replace an existing database, add the option `--overwrite-destination=true` to the restore command.
 
 . Log in to the Neo4j using `cypher-shell`:
 +
@@ -183,12 +184,6 @@ bin/cypher-shell -u neo4j -p password
 ----
 STOP DATABASE databasename;
 ----
-. Drop the database that requires the restore:
-+
-[source, cypher, role=nocopy noplay]
-----
-DROP DATABASE databasename;
-----
 +
 Do not exit the `cypher-shell` session.
 
@@ -196,7 +191,7 @@ Do not exit the `cypher-shell` session.
 +
 [source, shell,role=nocopy noplay]
 ----
-bin/neo4j-admin database restore --from-path=/path/to/mybackups/neo4j-2023-06-29T14-50-45.backup --restore-until="2023-06-29 13:50:45"
+bin/neo4j-admin database restore --from-path=/path/to/mybackups/neo4j-2023-06-29T14-50-45.backup --restore-until="2023-06-29 13:50:45" mydatabase
 ----
 +
 The `--from-path=` argument must contain the path to either a full or a differential backup artifact.
@@ -209,11 +204,11 @@ The restore recovers all transactions that were committed before the provided da
 If you know the transaction ID of the last transaction that was committed before the date you want to restore to, you can use the `--restore-until=` argument with the transaction ID instead of the date.
 For example, `--restore-until=123`.
 ====
-. Using `cypher-shell`, recreate the database that you dropped using `CREATE DATABASE` against the `system` database, for example:
+. Unless you are replacing an existing database, create the new database using `CREATE DATABASE` against the `system` database:
 +
 [source, cypher, role=nocopy noplay]
 ----
-CREATE DATABASE databasename;
+CREATE DATABASE mydatabase;
 ----
 
 === Restore a database backup in a cluster

--- a/modules/ROOT/pages/backup-restore/restore-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-backup.adoc
@@ -20,7 +20,7 @@ For more information, see xref:database-administration/standard-databases/manage
 [NOTE]
 ====
 When restoring a backup chain, the transaction log contained in the differential backup artifacts must first be replayed.
-This recovery operation is resource intensive and can be decoupled from the restore operation by using the xref:backup-restore/aggregate.adoc[aggregate] command.
+This recovery operation is resource-intensive and can be decoupled from the restore operation by using the xref:backup-restore/aggregate.adoc[aggregate] command.
 ====
 
 [[restore-backup-syntax]]
@@ -143,8 +143,10 @@ That means, if you restore `neo4j-2023-06-29T14-50-45.backup`, your database wil
 
 === Restore a database backup
 
-. Restore a database backup by running the following command.
-If you want to replace an existing database, add the option `--overwrite-destination=true` to the restore command.
+This example assumes that you want to restore your data in a new database, called `mydatabase`.
+If you want to replace an existing database, you need to stop it first, and add the option `--overwrite-destination=true` to the restore command.
+
+. Restore a database backup by running the following command:
 +
 [source, shell,role=nocopy noplay]
 ----
@@ -152,9 +154,9 @@ bin/neo4j-admin database restore --from-path=/path/to/backups/neo4j-2023-05-05T1
 ----
 +
 The `--from-path=` argument must contain the path to the last backup of a chain, in this case, `neo4j-2023-06-29T14-51-33.backup`.
-If you want to restore several databases at once, you can specify a comma-separated list of paths to backup artifacts.
+If you want to restore several databases at once, you can specify a comma-separated list of paths to backup artifacts, remove the `<database>` parameter, and skip the `CREATE DATABASE` step.
 
-. Unless you are replacing an existing database, create the new database using `CREATE DATABASE` against the `system` database.
+. Create the new database using `CREATE DATABASE` against the `system` database.
 +
 [source, cypher, role=nocopy noplay]
 ----
@@ -163,31 +165,11 @@ CREATE DATABASE mydatabase
 
 === Restore data up to a specific date
 
-To restore data up to a specific date, you need to pass the backup artifact that contains the data up to that date.
-If you want to replace an existing database, add the option `--overwrite-destination=true` to the restore command.
+To restore data up to a specific date, you need to pass the backup artifact that contains the data up to that date. +
+This example assumes that you want to restore your data in a new database, called `mydatabase`.
+If you want to replace an existing database, you need to stop it first, and add the option `--overwrite-destination=true` to the restore command.
 
-. Log in to the Neo4j using `cypher-shell`:
-+
-[source, shell,role=nocopy noplay]
-----
-bin/cypher-shell -u neo4j -p password
-----
-. Change the active database to `system`:
-+
-[source, shell,role=nocopy noplay]
-----
-:use system;
-----
-. Stop the database that requires the restore:
-+
-[source, cypher, role=nocopy noplay]
-----
-STOP DATABASE databasename;
-----
-+
-Do not exit the `cypher-shell` session.
-
-.  In a different `shell` terminal, restore from the backup that contains the data up to the desired date.
+. Restore from the backup that contains the data up to the desired date.
 +
 [source, shell,role=nocopy noplay]
 ----
@@ -195,7 +177,7 @@ bin/neo4j-admin database restore --from-path=/path/to/mybackups/neo4j-2023-06-29
 ----
 +
 The `--from-path=` argument must contain the path to either a full or a differential backup artifact.
-If you want to restore several databases at once, you can specify a comma-separated list of paths to backup artifacts.
+If you want to restore several databases at once, you can specify a comma-separated list of paths to backup artifacts, remove the `<database>` parameter, and skip the `CREATE DATABASE` step. +
 The `--restore-until=` argument must contain a UTC date and time.
 The restore recovers all transactions that were committed before the provided date and time.
 +
@@ -204,7 +186,7 @@ The restore recovers all transactions that were committed before the provided da
 If you know the transaction ID of the last transaction that was committed before the date you want to restore to, you can use the `--restore-until=` argument with the transaction ID instead of the date.
 For example, `--restore-until=123`.
 ====
-. Unless you are replacing an existing database, create the new database using `CREATE DATABASE` against the `system` database:
+. Create the new database using `CREATE DATABASE` against the `system` database:
 +
 [source, cypher, role=nocopy noplay]
 ----


### PR DESCRIPTION
I removed the note but left the step 4. Do you think I should add the same step to the section **Restore a database backup**?
