### PR TITLE
Add Store Format link to `--format` parameter entry

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -175,6 +175,8 @@ Unicode character ID can be used if prepended by `\`.
 |--format=<format>
 |Name of database format.
 Imported database will be created of the specified format or use format from configuration if not specified.
+
+For an example, see the available link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-internals/store-formats[Store Formats].
 |
 
 |-h, --help

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -176,7 +176,7 @@ Unicode character ID can be used if prepended by `\`.
 |Name of database format.
 Imported database will be created of the specified format or use format from configuration if not specified.
 
-For an example, see the available link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-internals/store-formats[Store Formats].
+For an example, see the available xref:/database-internals/store-formats.adoc[Store Formats].
 |
 
 |-h, --help


### PR DESCRIPTION
Since we don't list anywhere the list of available store formats
(since these can change based on the version and edition of the DBMS),
we can point to our Store Formats documentation to allow users figure
out what are the options they could use there.