### PR TITLE
Cherrypick into 5.x: Add Store Format link to `--format` parameter entry

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -175,6 +175,8 @@ Unicode character ID can be used if prepended by `\`.
 |--format=<format>
 |Name of database format.
 Imported database will be created of the specified format or use format from configuration if not specified.
+
+For an example, see the available xref:/database-internals/store-formats.adoc[Store Formats].
 |
 
 |-h, --help


### PR DESCRIPTION
Since we don't list anywhere the list of available store formats (since these can change based on the version and edition of the DBMS), we can point to our Store Formats documentation to allow users figure out what are the options they could use there.

This is a cherry pick of #1486.