### PR TITLE
Remove azp checking from docs in line with OIDC spec update

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
@@ -84,11 +84,6 @@ This will be checked against the `iss` claim in the token.
 | true
 | The expected value for the `aud` claim.
 
-| xref:configuration/configuration-settings.adoc#config_dbms.security.oidc.-provider-.client_id[dbms.security.oidc.<provider>.client_id]
-|
-| true
-|  The `client_id` of this client as issued by the provider.
-
 | xref:configuration/configuration-settings.adoc#config_dbms.security.oidc.-provider-.params[dbms.security.oidc.<provider>.params]
 |
 | true
@@ -241,13 +236,6 @@ Provide the expected value for the audience(`aud`) claim:
 [source, properties]
 ----
 dbms.security.oidc.mysso.claims.audience=myaudience
-----
-In some situations there may be multiple values for the `aud` claim.
-In this situation, the id_token should contain an authorized party(`azp`) claim containing the client id, which is configured as follows:
-+
-[source, properties]
-----
-dbms.security.oidc.mysso.claims.client_id=myclientid
 ----
 
 . Configure claims.

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -4453,17 +4453,17 @@ m|+++sub+++
 |===
 
 
-[role=label--enterprise-edition label--dynamic]
+[role=label--enterprise-edition label--dynamic label--deprecated]
 [[config_dbms.security.oidc.-provider-.client_id]]
 === `dbms.security.oidc.<provider>.client_id`
 
-// label:enterprise-edition[Enterprise Edition] label:dynamic[Dynamic]
+// label:enterprise-edition[Enterprise Edition] label:dynamic[Dynamic] label:deprecated[Deprecated]
 
 .dbms.security.oidc.<provider>.client_id
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|Client id needed if token contains multiple Audience (aud) claims.
+a|Client id. Not used. This value was previously used to validate the `azp` claim in the id_token, but this validation has been removed in line with updates to the OIDC specification.
 |Valid values
 a|A string.
 |===


### PR DESCRIPTION
We removed the `azp` claim check. Update the documentation to reflect this.