### PR TITLE
clarifying that DBMS privileges do not get backed up

### DIFF
--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -141,7 +141,13 @@ the size of the produced artifact will be approximately equal to the size of bac
 - `all` - include both `roles` and `users`.
 - `none` - does not include any metadata.
 [NOTE]
-`roles` and `users` that do not have database-related privileges are not included in the backup (e.g. those with only DBMS or no privileges). It is recommended to use `SHOW USERS` and `SHOW ROLES` to get the complete list of users and roles in these situations.
+====
+Privileges which only pertain to the DBMS (rather than the database being backed up), are not included in the backup. For example, `GRANT ROLE MANAGEMENT ON DBMS TO $role` would not be backed up.
+
+Accordingly, `roles` and `users` that do not have database-related privileges are not included in the backup (e.g. those with only DBMS or no privileges).
+
+It is recommended to use `SHOW USERS`, `SHOW ROLES` and `SHOW ROLE $role PRIVILEGES` to get the complete list of users, roles and privileges in these situations.
+====
 |all
 
 |--inspect-path=<path>

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -147,7 +147,7 @@ For instance, `GRANT ROLE MANAGEMENT ON DBMS TO $role` will not be backed up.
 
 Accordingly, `roles` and `users` that do not have database-related privileges are not included in the backup (e.g. those with only DBMS or no privileges).
 
-It is recommended to use `SHOW USERS`, `SHOW ROLES` and `SHOW ROLE $role PRIVILEGES` to get the complete list of users, roles and privileges in these situations.
+It is recommended to use `SHOW USERS`, `SHOW ROLES`, and `SHOW ROLE $role PRIVILEGES` to get the complete list of users, roles and privileges in these situations.
 ====
 |all
 

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -142,12 +142,12 @@ the size of the produced artifact will be approximately equal to the size of bac
 - `none` - does not include any metadata.
 [NOTE]
 ====
-Privileges specific to the DBMS and not to the backed-up database are not included in the backup. 
+Privileges specific to the DBMS and not to the backed-up database are not included in the backup.
 For instance, `GRANT ROLE MANAGEMENT ON DBMS TO $role` will not be backed up.
 
 Accordingly, `roles` and `users` that do not have database-related privileges are not included in the backup (e.g. those with only DBMS or no privileges).
 
-It is recommended to use `SHOW USERS`, `SHOW ROLES`, and `SHOW ROLE $role PRIVILEGES` to get the complete list of users, roles and privileges in these situations.
+It is recommended to use `SHOW USERS`, `SHOW ROLES`, and `SHOW ROLE $role PRIVILEGES AS COMMANDS` to get the complete list of users, roles and privileges in these situations.
 ====
 |all
 

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -142,7 +142,8 @@ the size of the produced artifact will be approximately equal to the size of bac
 - `none` - does not include any metadata.
 [NOTE]
 ====
-Privileges which only pertain to the DBMS (rather than the database being backed up), are not included in the backup. For example, `GRANT ROLE MANAGEMENT ON DBMS TO $role` would not be backed up.
+Privileges specific to the DBMS and not to the backed-up database are not included in the backup. 
+For instance, `GRANT ROLE MANAGEMENT ON DBMS TO $role` will not be backed up.
 
 Accordingly, `roles` and `users` that do not have database-related privileges are not included in the backup (e.g. those with only DBMS or no privileges).
 


### PR DESCRIPTION
DBMS-wide privileges do not get backed up when performing a database backup. This PR changes the docs entry of `neo4j-admin backup` to clarify this.