### PR TITLE
S3 URI support for admin database import and database load/dump

### DIFF
--- a/modules/ROOT/pages/backup-restore/aggregate.adoc
+++ b/modules/ROOT/pages/backup-restore/aggregate.adoc
@@ -68,7 +68,7 @@ Aggregates a chain of backup artifacts into a single artifact.
 |
 
 |--from-path=<path>
-|Accepts either a path to a single artifact file or, a folder containing backup artifacts.
+|Accepts either a path to a single artifact file or a folder containing backup artifacts.
 
 When a file is supplied, the _<database>_ parameter should be omitted.
 The option to supply a file is only available in Neo4j 5.2 and later.
@@ -94,6 +94,13 @@ Consult Neo4j support before use.
 |
 |===
 
+[NOTE]
+====
+As of Neo4j 5.19, the `--from-path=<path>` option can also load backup artifacts from AWS S3 URIs.
+Neo4j uses link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html[default AWS credentials] to access AWS S3 URIs. 
+==== 
+
+
 [[aggregate-backup-example]]
 == Examples
 
@@ -103,6 +110,12 @@ Consult Neo4j support before use.
 bin/neo4j-admin database aggregate-backup --from-path=/mnt/backups/ neo4j
 ----
 The command first looks inside the `/mnt/backups/` directory for a backup chain for the database `neo4j`. If found, it is then aggregated into a single backup artifact.
+
+.An example of how to perform aggregation of a set of backups located in a given folder for the `neo4j` database in an AWS S3 URI.
+[source,shell]
+----
+bin/neo4j-admin database aggregate-backup --from-path=s3://mnt/backups/ neo4j
+----
 
 .An example of how to perform aggregation of a set of backups identified using a given backup file for the `neo4j` database.
 [source,shell]

--- a/modules/ROOT/pages/backup-restore/offline-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/offline-backup.adoc
@@ -90,7 +90,6 @@ The `neo4j-admin database dump` command has the following options:
 
 |--to-path=<path>
 |Destination folder of a database dump.
-As of Neo4j 5.19, archives can also be dumped to S3 URIs. 
 |
 
 |--to-stdout
@@ -102,6 +101,11 @@ As of Neo4j 5.19, archives can also be dumped to S3 URIs.
 |
 |===
 
+[NOTE]
+====
+As of Neo4j 5.19, the `--to-path=<path>` option can also dump databases to AWS S3 URIs.
+Neo4j uses link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html[default AWS credentials] to access AWS S3 URIs. 
+====
 
 [[offline-backup-example]]
 == Example
@@ -115,6 +119,13 @@ bin/neo4j-admin database dump <database> --to-path=/full/path/to/dumps/
 ----
 
 The command creates a file called _<database>.dump_ where `<database>` is the database specified in the command.
+
+The following is an example of how to create a dump in an AWS S3 URI, as of Neo4j 5.19.
+
+[source, shell, role="nocopy"]
+----
+bin/neo4j-admin database dump <database> --to-path=s3://full/path/to/aws-s3-dumps/
+----
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/backup-restore/offline-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/offline-backup.adoc
@@ -44,7 +44,7 @@ neo4j-admin database dump [-h] [--expand-commands]
 Dump a database into a single-file archive.
 The archive can be used by the load command.
 `<to-path>` should be a directory (in which case a file called _<database>.dump_ will be created), or `--to-stdout` can be supplied to use standard output.
-If neither `--to-path` or `--to-stdout` is supplied `server.directories.dumps.root` setting will be used as a destination.
+If neither `--to-path` or `--to-stdout` is supplied `server.directories.dumps.root` setting will be used as a destination. 
 It is not possible to dump a database that is mounted in a running Neo4j server.
 
 === Parameters
@@ -90,6 +90,7 @@ The `neo4j-admin database dump` command has the following options:
 
 |--to-path=<path>
 |Destination folder of a database dump.
+As of Neo4j 5.19, archives can also be dumped to S3 URIs. 
 |
 
 |--to-stdout

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -176,6 +176,12 @@ If you want to force a full backup, use `FULL`.
 |
 |===
 
+[NOTE]
+====
+As of Neo4j 5.19, the `--to-path=<path>` option can also create backups in AWS S3 URIs.
+Neo4j uses link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html[default AWS credentials] to access AWS S3 URIs. 
+==== 
+
 [[backup-command-exit-codes]]
 === Exit codes
 
@@ -331,6 +337,16 @@ By default, the type is automatically determined based on the existing backups.
 [source, shell,role=nocopy noplay]
 ----
 bin/neo4j-admin database backup --to-path=/path/to/backups/neo4j neo4j
+----
+====
+
+.Perform a backup to an AWS S3 URI
+====
+The following is an example of how to create a database backup in an AWS S3 URI, as of Neo4j 5.19.
+
+[source, shell,role=nocopy noplay]
+----
+bin/neo4j-admin database backup --to-path=s3://path/to/backups/neo4j neo4j
 ----
 ====
 

--- a/modules/ROOT/pages/backup-restore/planning.adoc
+++ b/modules/ROOT/pages/backup-restore/planning.adoc
@@ -74,7 +74,7 @@ When using `neo4j-admin database backup` in a cluster, it is recommended to back
 ====
 * `neo4j-admin database dump/load` –- used for performing offline dump and load operations.
 The database to be dumped must be in **offline** mode.
-The dump command can only be invoked from the server command line and is suitable for environments, where downtime is not a factor.
+The dump command can only be invoked from the server command line and is suitable for environments where downtime is not a factor.
 The command produces an archive file that follows the format _<databasename><timestamp>.dump_.
 * `neo4j-admin database copy` –- used for copying an offline database or backup.
 This command can be used for cleaning up database inconsistencies and reclaiming unused space.

--- a/modules/ROOT/pages/backup-restore/restore-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-backup.adoc
@@ -115,6 +115,12 @@ Usage of this option is only allowed if the `--from-path` parameter points to ex
 |
 |===
 
+[NOTE]
+====
+As of Neo4j 5.19, the `--from-path=<path>` option can also load backups from AWS S3 URIs.
+Neo4j uses link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html[default AWS credentials] to access AWS S3 URIs. 
+==== 
+
 [[restore-backup-example]]
 == Examples
 
@@ -158,6 +164,13 @@ bin/neo4j-admin database restore --from-path=/path/to/backups/neo4j-2023-05-05T1
 ----
 +
 The `--from-path=` argument must contain the path to the last backup of a chain, in this case, `neo4j-2023-06-29T14-51-33.backup`.
++
+As of Neo4j 5.19, `from-path=<path>` can alternatively load an AWS S3 URI:
++
+[source, shell,role=nocopy noplay]
+----
+bin/neo4j-admin database restore --from-path=s3:///path/to/backups/neo4j-2023-05-05T11-26-38.backup mydatabase
+----
 +
 [TIP]
 ====

--- a/modules/ROOT/pages/backup-restore/restore-dump.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-dump.adoc
@@ -76,7 +76,6 @@ Can contain `*` and `?` for globbing.
 
 |--from-path=<path>
 |Path to a directory containing archive(s) created with the dump command.
-As of Neo4j 5.19, archives can also be loaded from S3 URIs.  
 |
 
 |--from-stdin
@@ -99,6 +98,12 @@ As of Neo4j 5.19, archives can also be loaded from S3 URIs.
 |Enable verbose output.
 |===
 
+[NOTE]
+====
+As of Neo4j 5.19, the `--from-path=<path>` option can also load databases from AWS S3 URIs.
+Neo4j uses link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html[default AWS credentials] to access AWS S3 URIs. 
+====
+
 [[restore-dump-example]]
 == Example
 
@@ -111,6 +116,13 @@ If you are not replacing an existing database, you must create the database (usi
 [source,shell, role="nocopy"]
 ----
 ./neo4j-admin database load --from-path=/full-path/data/dumps <database> --overwrite-destination=true
+----
+
+The following is an example of how to load the dump from an AWS S3 URI, as of Neo4j 5.19.
+
+[source,shell, role="nocopy"]
+----
+./neo4j-admin database load --from-path=full/path/to/aws-s3-dumps/ <database> --overwrite-destination=true
 ----
 
 [TIP]

--- a/modules/ROOT/pages/backup-restore/restore-dump.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-dump.adoc
@@ -76,6 +76,7 @@ Can contain `*` and `?` for globbing.
 
 |--from-path=<path>
 |Path to a directory containing archive(s) created with the dump command.
+As of Neo4j 5.19, archives can also be loaded from S3 URIs.  
 |
 
 |--from-stdin

--- a/modules/ROOT/pages/backup-restore/restore-dump.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-dump.adoc
@@ -122,7 +122,7 @@ The following is an example of how to load the dump from an AWS S3 URI, as of Ne
 
 [source,shell, role="nocopy"]
 ----
-./neo4j-admin database load --from-path=full/path/to/aws-s3-dumps/ <database> --overwrite-destination=true
+./neo4j-admin database load --from-path=s3://full/path/to/aws-s3-dumps/ <database> --overwrite-destination=true
 ----
 
 [TIP]

--- a/modules/ROOT/pages/tools/neo4j-admin/consistency-checker.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/consistency-checker.adoc
@@ -122,6 +122,13 @@ Value can be plain numbers, like `10000000` or e.g. `20G` for 20 gigabytes, or e
 |<from-path>
 |===
 
+[NOTE]
+====
+As of Neo4j 5.19, the `--from-path=<path>` option can also check artifacts in AWS S3 URIs.
+Neo4j uses link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html[default AWS credentials] to access AWS S3 URIs. 
+==== 
+
+
 == Output
 
 If the consistency checker does not find errors, it exits cleanly and does not produce a report.

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -236,6 +236,7 @@ Therefore, use it with care, especially with large imports.
 * The first line must contain the header.
 * Multiple data sources like these can be specified in one import, where each data source has its own header.
 * Files can also be specified using regular expressions.
+* As of Neo4j 5.19, files can also be located in S3 URIs.
 
 For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |
@@ -270,6 +271,7 @@ The value can be a plain number or a byte units string, e.g. `128k`, `1m`.
 * The first line must contain the header.
 * Multiple data sources like these can be specified in one import, where each data source has its own header.
 * Files can also be specified using regular expressions.
+* As of Neo4j 5.19, files can also be located in S3 URIs.
 
 For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -236,7 +236,6 @@ Therefore, use it with care, especially with large imports.
 * The first line must contain the header.
 * Multiple data sources like these can be specified in one import, where each data source has its own header.
 * Files can also be specified using regular expressions.
-* As of Neo4j 5.19, files can also be located in S3 URIs.
 
 For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |
@@ -271,7 +270,6 @@ The value can be a plain number or a byte units string, e.g. `128k`, `1m`.
 * The first line must contain the header.
 * Multiple data sources like these can be specified in one import, where each data source has its own header.
 * Files can also be specified using regular expressions.
-* As of Neo4j 5.19, files can also be located in S3 URIs.
 
 For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |
@@ -383,6 +381,13 @@ For example, `mydatabase --nodes 0-nodes.csv`.
 For example, `nodes 0-nodes.csv -- mydatabase`.
 ====
 
+[NOTE]
+.Importing from AWS S3 URIs
+====
+As of Neo4j 5.19, the `--nodes` and `--relationships` options can also import files from AWS S3 URIs.
+Neo4j uses link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html[default AWS credentials] to access AWS S3 URIs. 
+====
+
 
 [[import-tool-examples]]
 === Examples
@@ -435,6 +440,16 @@ For example:
 [source, shell, role=noplay]
 ----
 neo4j_home$ bin/neo4j-admin database import full --nodes import/node_header.csv,'import/node_data_\d{1,5}.csv' databasename
+----
+====
+
+.Importing files from AWS S3 URIs
+====
+The following is an example of how to import files from AWS S3 URIs, as of Neo4j 5.19.
+
+[source, shell, role=noplay]
+----
+neo4j_home$ bin/neo4j-admin database import full --nodes s3://my-bucket/data/nodes.csv --relationships s3://my-bucket/data/relationships.csv newdb
 ----
 ====
 


### PR DESCRIPTION
Added the 5.19 version info to the table texts. We could use version labels in suitable places instead.