### PR TITLE
clarifying that DBMS privileges do not get backed up (#1501)

### DIFF
--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -141,7 +141,14 @@ the size of the produced artifact will be approximately equal to the size of bac
 - `all` - include both `roles` and `users`.
 - `none` - does not include any metadata.
 [NOTE]
-`roles` and `users` that do not have database-related privileges are not included in the backup (e.g. those with only DBMS or no privileges). It is recommended to use `SHOW USERS` and `SHOW ROLES` to get the complete list of users and roles in these situations.
+====
+Privileges specific to the DBMS and not to the backed-up database are not included in the backup.
+For instance, `GRANT ROLE MANAGEMENT ON DBMS TO $role` will not be backed up.
+
+Accordingly, `roles` and `users` that do not have database-related privileges are not included in the backup (e.g. those with only DBMS or no privileges).
+
+It is recommended to use `SHOW USERS`, `SHOW ROLES`, and `SHOW ROLE $role PRIVILEGES AS COMMANDS` to get the complete list of users, roles and privileges in these situations.
+====
 |all
 
 |--inspect-path=<path>


### PR DESCRIPTION
DBMS-wide privileges do not get backed up when performing a database backup. This PR changes the docs entry of `neo4j-admin backup` to clarify this.

---------
Cherry-picked from #1501 