### PR TITLE
Change "Starting the service automatically on system start" section and add code

### DIFF
--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -282,8 +282,7 @@ For operating systems that are not using `systemd`, some package-specific option
 [[debian-service-start-automatically]]
 == Starting the service automatically on system start
 
-On Debian-based distributions, users will need to run the following command to ensure that Neo4j starts automatically at boot time:
-
+On Debian-based distributions, run the following command to ensure that Neo4j starts automatically at boot time:
 [source, shell]
 ----
 sudo systemctl enable neo4j

--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -282,7 +282,12 @@ For operating systems that are not using `systemd`, some package-specific option
 [[debian-service-start-automatically]]
 == Starting the service automatically on system start
 
-On Debian-based distributions, Neo4j is enabled to start automatically on system boot by default.
+On Debian-based distributions, users will need to run the following command to ensure that Neo4j starts automatically at boot time:
+
+[source, shell]
+----
+sudo systemctl enable neo4j
+----
 
 [NOTE]
 ====


### PR DESCRIPTION
Instead of saying "On Debian-based distributions, Neo4j is enabled to start automatically on system boot by default" It should say "On Debian-based distributions, users will need to run the following command to ensure that Neo4j starts automatically at boot time.:" with the code example 

sudo systemctl enable neo4j