### PR TITLE
Update accessing-neo4j-ingress.adoc

### DIFF
--- a/modules/ROOT/pages/kubernetes/accessing-neo4j-ingress.adoc
+++ b/modules/ROOT/pages/kubernetes/accessing-neo4j-ingress.adoc
@@ -177,7 +177,9 @@ Alternatively, if you want to access Neo4j on port `:80`, leave `tls.enabled` wi
 [source, yaml]
 ----
 reverseProxy:
-    image: neo4j/helm-charts-reverse-proxy:5.12.0
+    #Use image only when need a specific version or using your internal artifactory.
+    #Otherwise let it default to what is in the values.yaml
+    #image: neo4j/helm-charts-reverse-proxy:5.12.0
     serviceName: "standalone-admin"
     ingress:
         enabled: true


### PR DESCRIPTION
The example incorrectly includes an old release - the version is not needed as the image value in values.yaml should be the default