### PR TITLE
Update accessing-neo4j-ingress.adoc (#1551)

### DIFF
--- a/modules/ROOT/pages/kubernetes/accessing-neo4j-ingress.adoc
+++ b/modules/ROOT/pages/kubernetes/accessing-neo4j-ingress.adoc
@@ -233,7 +233,7 @@ kubectl apply -f /path/to/your/nginx-tcp.yaml
 +
 [source,shell]
 ----
-kubectl get scv -n ingress-nginx
+kubectl get svc -n ingress-nginx
 ----
 .. Open the Ingress controller service for editing:
 +


### PR DESCRIPTION
The following line has a typo scv instead of svc
kubectl get scv -n ingress-nginx
should be
kubectl get svc -n ingress-nginx
or
kubectl get service -n ingress-nginx