### PR TITLE
Document SHOW DATABASES fields that can be NULL

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -36,7 +36,8 @@ A database may be described as read-only when using `ALTER DATABASE ... SET ACCE
 | databaseID
 | The database unique ID.
 
-A database must be 'online' or 'deallocating' for this value to be available. For other database states the value will be NULL.
+A database must be `online` or `deallocating` for this value to be available.
+For other database states the value will be `NULL`.
 | STRING
 
 | serverID
@@ -139,14 +140,15 @@ The value is a string formatted as:
 ----
 {storage engine}-{store format}-{major version}.{minor version}
 ----
-A database must be 'online' or 'deallocating' for this value to be available. For other database states the value will be NULL.
+A database must be `online` or `deallocating` for this value to be available.
+For other database states the value will be `NULL`.
 | STRING
 
 | lastCommittedTxn
 | The ID of the last transaction received.
 
-A database must be 'online' or 'deallocating' for this value to be available. For other database states
-the value will be NULL.
+A database must be `online` or `deallocating` for this value to be available.
+For other database states the value will be `NULL`.
 | INTEGER
 
 | replicationLag
@@ -154,8 +156,8 @@ the value will be NULL.
 Number of transactions the current database is behind compared to the database on the primary instance.
 The lag is expressed in negative integers. In standalone environments, the value is always `0`.
 
-A database must be 'online' or 'deallocating' for
-this value to be available. For other database states the value will be NULL.
+A database must be `online` or `deallocating` for this value to be available.
+For other database states the value will be `NULL`.
 | INTEGER
 
 |constituents

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -35,6 +35,8 @@ A database may be described as read-only when using `ALTER DATABASE ... SET ACCE
 
 | databaseID
 | The database unique ID.
+
+A database must be 'online' or 'deallocating' for this value to be available. For other database states the value will be NULL.
 | STRING
 
 | serverID
@@ -137,16 +139,23 @@ The value is a string formatted as:
 ----
 {storage engine}-{store format}-{major version}.{minor version}
 ----
+A database must be 'online' or 'deallocating' for this value to be available. For other database states the value will be NULL.
 | STRING
 
 | lastCommittedTxn
 | The ID of the last transaction received.
+
+A database must be 'online' or 'deallocating' for this value to be available. For other database states
+the value will be NULL.
 | INTEGER
 
 | replicationLag
 |
 Number of transactions the current database is behind compared to the database on the primary instance.
 The lag is expressed in negative integers. In standalone environments, the value is always `0`.
+
+A database must be 'online' or 'deallocating' for
+this value to be available. For other database states the value will be NULL.
 | INTEGER
 
 |constituents


### PR DESCRIPTION
Some of the fields in SHOW DATABASES will always be null for databases that are not running. Update the documentation to reflect this.