### PR TITLE
Use unicode on CSV file delimiters example

### DIFF
--- a/modules/ROOT/pages/tutorial/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tutorial/neo4j-admin-import.adoc
@@ -174,7 +174,7 @@ The details of a CSV file header format can be found at xref:tools/neo4j-admin/n
 The following CSV files have:
 
 * `--delimiter=";"`
-* `--array-delimiter="|"`
+* `--array-delimiter="U+007C"` (`0x007C` is the Unicode code point for the character `|`)
 * `--quote="'"`
 
 .movies2.csv
@@ -219,7 +219,7 @@ The call to `neo4j-admin database import` would look like this:
 .shell
 [source]
 ----
-bin/neo4j-admin database import full --delimiter=";" --array-delimiter="|" --quote="'" --nodes=import/movies2.csv --nodes=import/actors2.csv --relationships=import/roles2.csv neo4j
+bin/neo4j-admin database import full --delimiter=";" --array-delimiter="U+007C" --quote="'" --nodes=import/movies2.csv --nodes=import/actors2.csv --relationships=import/roles2.csv neo4j
 ----
 
 


### PR DESCRIPTION
Change the `--array-delimiter` example to be set using the code point for the character `|` (the same used before, so we don't need to change the CSV content).

This was based on a user feedback, that it was not clear from the examples that they could have used (and how they could have used) unicode code points to set the delimiter to arbitrary characters, including non-printable ones.

See https://github.com/neo4j/neo4j/issues/13445.