### PR TITLE
Don't use `0x` prefix to reference the unicode code point

### DIFF
--- a/modules/ROOT/pages/tutorial/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tutorial/neo4j-admin-import.adoc
@@ -174,7 +174,7 @@ The details of a CSV file header format can be found at xref:tools/neo4j-admin/n
 The following CSV files have:
 
 * `--delimiter=";"`
-* `--array-delimiter="U+007C"` (`0x007C` is the Unicode code point for the character `|`)
+* `--array-delimiter="U+007C"` (`U+007C` is the Unicode code point for the character `|`)
 * `--quote="'"`
 
 .movies2.csv


### PR DESCRIPTION
This is to avoid confusion, since we *don't* support passing the delimiter with the `0x` prefix.

Cherry-picked from https://github.com/neo4j/docs-operations/pull/1575.