### PR TITLE
Add `WAIT` examples to START/STOP sections and syntax tables to the Cypher adm commands

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/alter-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/alter-databases.adoc
@@ -3,7 +3,7 @@
 [[administration-databases-alter-database]]
 = Alter databases
 
-Standard databases can be modified using the command `ALTER DATABASE`.
+You can modify standard databases using the Cypher command `ALTER DATABASE`.
 
 == Syntax
 
@@ -41,8 +41,9 @@ There can be multiple `SET OPTION` or `REMOVE OPTION` clauses for different opti
 == Alter database access mode
 
 By default, a database has read-write access mode on creation.
-The database can be limited to read-only mode on creation using the configuration parameters `dbms.databases.default_to_read_only`, `dbms.databases.read_only`, and `dbms.database.writable`.
+The database can be limited to read-only mode on creation using the configuration settings `server.databases.default_to_read_only`, `server.databases.read_only`, and `server.database.writable`.
 For details, see the section on xref::database-administration/standard-databases/configuration-parameters.adoc#[Configuration parameters].
+
 A database that was created with read-write access mode can be changed to read-only.
 To change it to read-only, you can use the `ALTER DATABASE` command with the sub-clause `SET ACCESS READ ONLY`.
 Subsequently, the database access mode can be switched back to read-write using the sub-clause `SET ACCESS READ WRITE`.
@@ -60,15 +61,15 @@ Modifying access mode is only available to standard databases and not composite 
 
 === Alter database access mode to read-only
 
-.Query
+To modify the database access mode, use the following command where `customers` is the database name:
+
 [source, cypher]
 ----
 ALTER DATABASE customers SET ACCESS READ ONLY
 ----
 
-The database access mode can be seen in the `access` output column of the command `SHOW DATABASES`.
+The database access mode can be seen in the `access` output column of the command `SHOW DATABASES`:
 
-.Query
 [source, cypher]
 ----
 SHOW DATABASES yield name, access
@@ -90,9 +91,8 @@ SHOW DATABASES yield name, access
 === Alter database access using `IF EXISTS`
 
 `ALTER DATABASE` commands are optionally idempotent, with the default behavior to fail with an error if the database does not exist.
-Appending `IF EXISTS` to the command ensures that no error is returned and nothing happens should the database not exist.
+Appending `IF EXISTS` to the command ensures that no error is returned and nothing happens if the database does not exist.
 
-.Query
 [source, cypher]
 ----
 ALTER DATABASE nonExisting IF EXISTS
@@ -105,7 +105,7 @@ In a cluster environment, you can use the `ALTER DATABASE` command to change the
 For more information, see xref::clustering/databases.adoc#alter-topology[Managing databases in a cluster].
 
 [[alter-database-options]]
-== Alter database options
+== `ALTER DATABASE` options
 
 The `ALTER DATABASE` command can be used to set or remove specific options for a database.
 
@@ -118,7 +118,7 @@ The `ALTER DATABASE` command can be used to set or remove specific options for a
 | txLogEnrichment
 | FULL\|DIFF\|NONE
 | Defines the level of enrichment applied to transaction logs for Change Data Capture (CDC) purposes.
-For details about enrichment mode, see link:{neo4j-docs-base-uri}/cdc/{page-version}/getting-started/enrichment-mode[Change Data Capture Manual -> Getting Started -> Enrichment mode].
+For details about enrichment mode, see link:{neo4j-docs-base-uri}/cdc/{page-version}/get-started/self-managed/#set-enrichment-mode/[Change Data Capture Manual -> Set the enrichment mode].
 |===
 
 [NOTE]
@@ -126,9 +126,8 @@ For details about enrichment mode, see link:{neo4j-docs-base-uri}/cdc/{page-vers
 There are no available `OPTIONS` values for composite databases.
 ====
 
-=== Alter the options set for a database
+=== Modify the options set for a database
 
-.Query
 [source, cypher]
 ----
 ALTER DATABASE `movies`
@@ -137,7 +136,6 @@ SET OPTION txLogEnrichment 'FULL'
 
 The database set options can be seen in the `options` output column of the command `SHOW DATABASES`.
 
-.Query
 [source, cypher]
 ----
 SHOW DATABASES yield name, options
@@ -157,7 +155,6 @@ SHOW DATABASES yield name, options
 
 === Remove the options set for a database
 
-.Query
 [source, cypher]
 ----
 ALTER DATABASE `movies`
@@ -166,7 +163,6 @@ REMOVE OPTION txLogEnrichment
 
 The `REMOVE OPTION` clause removes the specified option from the database using the `ALTER DATABASE` command.
 
-.Query
 [source, cypher]
 ----
 SHOW DATABASES YIELD name, options

--- a/modules/ROOT/pages/database-administration/standard-databases/alter-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/alter-databases.adoc
@@ -2,7 +2,40 @@
 [role=enterprise-edition not-on-aura]
 [[administration-databases-alter-database]]
 = Alter databases
+
 Standard databases can be modified using the command `ALTER DATABASE`.
+
+== Syntax
+
+[options="header", width="100%", cols="1m,5a"]
+|===
+| Command | Syntax
+
+| ALTER DATABASE
+|
+[source, syntax, role="noheader"]
+----
+ALTER DATABASE name [IF EXISTS]
+{
+SET ACCESS {READ ONLY \| READ WRITE} \|
+SET TOPOLOGY n PRIMAR{Y\|IES} [m SECONDAR{Y\|IES}] \|
+SET OPTION option value
+}
+[WAIT [n [SEC[OND[S]]]]\|NOWAIT]
+----
+
+[source, syntax]
+----
+ALTER DATABASE name [IF EXISTS]
+REMOVE OPTION option
+[WAIT [n [SEC[OND[S]]]]\|NOWAIT]
+----
+
+[NOTE]
+====
+There can be multiple `SET OPTION` or `REMOVE OPTION` clauses for different option keys.
+====
+|===
 
 [[manage-databases-alter]]
 == Alter database access mode

--- a/modules/ROOT/pages/database-administration/standard-databases/configuration-parameters.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/configuration-parameters.adoc
@@ -60,7 +60,7 @@ This set can contain also not yet existing databases, but not the `system` datab
 
 [NOTE]
 ====
-Regardless of settings of `server.databases.default_to_read_only`, `server.databases.read_only` and `dbms.databases.writable` the `system` database will never be read-only and will always accept write queries.
+Regardless of settings of `server.databases.default_to_read_only`, `server.databases.read_only` and `server.databases.writable` the `system` database will never be read-only and will always accept write queries.
 ====
 
 [NOTE]
@@ -75,7 +75,7 @@ Example configuration:
 server.databases.read_only=["foo", "bar"]
 ----
 
-| xref:configuration/dynamic-settings.adoc#config_dbms.databases.writable[`dbms.databases.writable`]
+| xref:configuration/configuration-settings.adoc#config_server.databases.writable[`server.databases.writable`]
 a|
 List of database names for which to accept write queries.
 This set can contain also not yet existing databases. +
@@ -85,13 +85,13 @@ If a database name is present in both sets, the database will be read-only and p
 [[config-param-note-3]]
 [TIP]
 ====
-If most of your databases would read-only with a few exceptions, it can be easier to set `config_server.databases.default_to_read_only` to `true`, and then put the names of the non read-only databases into `dbms.databases.writeable`.
+If most of your databases would read-only with a few exceptions, it can be easier to set `server.databases.default_to_read_only` to `true`, and then put the names of the non read-only databases into `server.databases.writable`.
 ====
 
 Example configuration:
 [source, example, role="noheader"]
 ----
-dbms.databases.writable=["foo", "bar"]
+server.databases.writable=["foo", "bar"]
 ----
 |===
 

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -84,12 +84,12 @@ Defines which server is used for seeding the data of the created database.
 The server ID can be found in the `serverId` column after running `SHOW SERVERS`.
 
 | `seedURI`
-| URI to a backup or a dump from an existing database
+| URI to a backup or a dump from an existing database.
 |
 Defines an identical seed from an external source which will be used to seed all servers.
 
 | `seedConfig`
-| comma-separated list of configuration values
+| Comma-separated list of configuration values.
 |
 Defines additional configuration specified by comma-separated `name=value` pairs that might be required by certain seed providers.
 
@@ -119,7 +119,7 @@ More details about seeding options can be found in xref::clustering/databases.ad
 ====
 
 
-=== Usage examples
+=== Examples
 
 .Create a database
 ======
@@ -130,7 +130,7 @@ More details about seeding options can be found in xref::clustering/databases.ad
 CREATE DATABASE customers
 ----
 
-When a database is created, it shows up in the listing provided by the command `SHOW DATABASES`:
+When you create a database, it shows up in the listing provided by the command `SHOW DATABASES`:
 
 .Query
 [source, cypher]
@@ -172,8 +172,8 @@ CREATE DATABASE slow WAIT 5 SECONDS
 +-------------------------------------------------------+
 ----
 
-The `success` column provides an aggregate status of whether or not the command is considered successful and thus every row will have the same value.
-This column is to determine, for example in a script, whether or not the command has been completed successfully without timing out.
+The `success` column provides an aggregate status of whether or not the command is considered successful.
+Thus, every row has the same value, determined on a successful completion without a timeout.
 ======
 
 
@@ -183,7 +183,7 @@ This column is to determine, for example in a script, whether or not the command
 The `CREATE DATABASE` command is optionally idempotent, with the default behavior to fail with an error if the database already exists.
 There are two ways to circumvent this behavior.
 
-First, appending `IF NOT EXISTS` to the command ensures that no error is returned and nothing happens should the database already exist.
+First, appending `IF NOT EXISTS` to the command ensures that no error is returned and that nothing happens if the database already exists.
 
 .Query
 [source, cypher]
@@ -191,7 +191,7 @@ First, appending `IF NOT EXISTS` to the command ensures that no error is returne
 CREATE DATABASE customers IF NOT EXISTS
 ----
 
-Second, adding `OR REPLACE` to the command results in any existing database being deleted and a new one being created.
+Second, adding `OR REPLACE` to the command deletes any existing database and creates a new one.
 
 .Query
 [source, cypher]
@@ -237,7 +237,7 @@ START DATABASE name [WAIT [n [SEC[OND[S]]]]\|NOWAIT]
 
 |===
 
-=== Usage examples
+=== Examples
 
 .Start a database
 ======
@@ -247,7 +247,7 @@ START DATABASE name [WAIT [n [SEC[OND[S]]]]\|NOWAIT]
 START DATABASE customers
 ----
 
-The status of the started database can be seen using the command `SHOW DATABASE name`.
+You can see the status of the started database by running the command `SHOW DATABASE name`.
 
 .Query
 [source, cypher]
@@ -296,7 +296,7 @@ STOP DATABASE name [WAIT [n [SEC[OND[S]]]]\|NOWAIT]
 
 |===
 
-=== Usage examples
+=== Examples
 
 .Stop a database
 ======

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -18,7 +18,7 @@ For more information, see link:{neo4j-docs-base-uri}/upgrade-migration-guide/upg
 [[create-neo4j-database]]
 == Create databases
 
-You can create a database using the Cypher command xref:database-administration/syntax.adoc#administration-syntax-database-management[`CREATE DATABASE`].
+You can create a database using the Cypher command `CREATE DATABASE`.
 
 [NOTE]
 ====
@@ -121,10 +121,10 @@ More details about seeding options can be found in xref::clustering/databases.ad
 
 === Examples
 
-.Create a database
-======
+==== Create a database
 
-.Query
+To create a database named `customers`, use the command `CREATE DATABASE` followed by the name of this database.
+
 [source, cypher]
 ----
 CREATE DATABASE customers
@@ -132,7 +132,6 @@ CREATE DATABASE customers
 
 When you create a database, it shows up in the listing provided by the command `SHOW DATABASES`:
 
-.Query
 [source, cypher]
 ----
 SHOW DATABASES YIELD name
@@ -150,13 +149,12 @@ SHOW DATABASES YIELD name
 | "system"    |
 +-------------+
 ----
-======
 
 
-.Create a database with xref:database-administration/standard-databases/wait-options.adoc[`WAIT`]
-======
+==== Create a database with xref:database-administration/standard-databases/wait-options.adoc[`WAIT`]
 
-.Query
+Sub-clause `WAIT` allows you to specify a time limit in which the command must complete and return. 
+
 [source, cypher]
 ----
 CREATE DATABASE slow WAIT 5 SECONDS
@@ -174,18 +172,15 @@ CREATE DATABASE slow WAIT 5 SECONDS
 
 The `success` column provides an aggregate status of whether or not the command is considered successful.
 Thus, every row has the same value, determined on a successful completion without a timeout.
-======
 
 
-.Create databases with `IF NOT EXISTS` or `OR REPLACE`
-======
+==== Create databases with `IF NOT EXISTS` or `OR REPLACE`
 
 The `CREATE DATABASE` command is optionally idempotent, with the default behavior to fail with an error if the database already exists.
 There are two ways to circumvent this behavior.
 
 First, appending `IF NOT EXISTS` to the command ensures that no error is returned and that nothing happens if the database already exists.
 
-.Query
 [source, cypher]
 ----
 CREATE DATABASE customers IF NOT EXISTS
@@ -193,7 +188,6 @@ CREATE DATABASE customers IF NOT EXISTS
 
 Second, adding `OR REPLACE` to the command deletes any existing database and creates a new one.
 
-.Query
 [source, cypher]
 ----
 CREATE OR REPLACE DATABASE customers
@@ -207,8 +201,6 @@ The behavior of `IF NOT EXISTS` and `OR REPLACE` apply to both standard and comp
 ====
 The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used together.
 ====
-
-======
 
 
 [[manage-databases-start]]
@@ -239,9 +231,12 @@ START DATABASE name [WAIT [n [SEC[OND[S]]]]\|NOWAIT]
 
 === Examples
 
-.Start a database
-======
-.Query
+==== Start a database
+
+Starting a database is a straightforward operation.
+Suppose you have a database named `customers`.
+To start it, use the following command:
+
 [source, cypher]
 ----
 START DATABASE customers
@@ -249,7 +244,6 @@ START DATABASE customers
 
 You can see the status of the started database by running the command `SHOW DATABASE name`.
 
-.Query
 [source, cypher]
 ----
 SHOW DATABASE customers YIELD name, requestedStatus, currentStatus
@@ -264,17 +258,17 @@ SHOW DATABASE customers YIELD name, requestedStatus, currentStatus
 | "customers" | "online"        | "online"      |
 +-----------------------------------------------+
 ----
-======
 
-.Start a database with xref:database-administration/standard-databases/wait-options.adoc[`WAIT`]
-======
-.Query
+
+==== Start a database with xref:database-administration/standard-databases/wait-options.adoc[`WAIT`]
+
+You can start your database using `WAIT` sub-clause to ensure that the command waits for a specified amount of time until the database is started. 
+
 [source, cypher]
 ----
 START DATABASE customers WAIT 5 SECONDS
 ----
 
-======
 
 [[manage-databases-stop]]
 == Stop databases
@@ -298,9 +292,10 @@ STOP DATABASE name [WAIT [n [SEC[OND[S]]]]\|NOWAIT]
 
 === Examples
 
-.Stop a database
-======
-.Query
+==== Stop a database
+
+To stop a database, use the following command:
+
 [source, cypher]
 ----
 STOP DATABASE customers
@@ -311,9 +306,8 @@ STOP DATABASE customers
 Both standard databases and composite databases can be stopped using this command.
 ====
 
-The status of the stopped database can be seen using the command `SHOW DATABASE name`.
+The status of the stopped database can be seen using the command `SHOW DATABASE name`:
 
-.Query
 [source, cypher]
 ----
 SHOW DATABASE customers YIELD name, requestedStatus, currentStatus
@@ -328,16 +322,15 @@ SHOW DATABASE customers YIELD name, requestedStatus, currentStatus
 | "customers" | "offline"       | "offline"     |
 +-----------------------------------------------+
 ----
-======
 
-.Stop a database with xref:database-administration/standard-databases/wait-options.adoc[`WAIT`]
-======
-.Query
+==== Stop a database with xref:database-administration/standard-databases/wait-options.adoc[`WAIT`]
+
+You can also stop your database using the `WAIT` sub-clause, which allows you to specify the amount of time that the system should wait for the database to stop.
+
 [source, cypher]
 ----
 STOP DATABASE customers WAIT 10 SECONDS
 ----
-======
 
 
 [NOTE]

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -27,72 +27,42 @@ Having dots (`.`) in the database names is not recommended.
 This is due to the difficulty of determining if a dot is part of the database name or a delimiter for a database alias in a composite database.
 ====
 
-.Query
-[source, cypher]
-----
-CREATE DATABASE customers
-----
-
 In Neo4j, the default store format for all new databases is `aligned`.
 If you want to change it, you can set a new value for the xref:configuration/configuration-settings.adoc#config_db.format[`db.format`] configuration in the _neo4j.conf_ file. +
 Alternatively, you can set the store format of new databases using the `CREATE DATABASE databasename OPTIONS {storeFormat: 'the-new-format'}` command. 
 However, if the store is seeded with `seedURI` or `existingDataSeedInstance`, or if the command is being used to mount pre-existing store files already present on the disk, they will use their current store format without any alterations.
+
 See xref:database-internals/store-formats.adoc[Store formats], for more details about available database store formats in Neo4j.
 
-When a database is created, it shows up in the listing provided by the command `SHOW DATABASES`:
+=== Syntax
 
-.Query
-[source, cypher]
-----
-SHOW DATABASES YIELD name
-----
+[options="header", width="100%", cols="1m,5a"]
+|===
+| Command | Syntax
 
-.Result
-[role="queryresult",options="header,footer",cols="1*<m"]
+| CREATE DATABASE
+|
+[source, syntax, role="noheader"]
 ----
-+-------------+
-| name        |
-+-------------+
-| "customers" |
-| "movies"    |
-| "neo4j"     |
-| "system"    |
-+-------------+
+CREATE DATABASE name [IF NOT EXISTS]
+[TOPOLOGY n PRIMAR{Y\|IES} [m SECONDAR{Y\|IES}]]
+[OPTIONS "{" option: value[, ...] "}"]
+[WAIT [n [SEC[OND[S]]]]\|NOWAIT]
 ----
 
-[[manage-databases-existing]]
-=== Use `IF NOT EXISTS` or `OR REPLACE` when creating databases
-
-The `CREATE DATABASE` command is optionally idempotent, with the default behavior to fail with an error if the database already exists.
-There are two ways to circumvent this behavior.
-
-First, appending `IF NOT EXISTS` to the command ensures that no error is returned and nothing happens should the database already exist.
-
-.Query
-[source, cypher]
+[source, syntax, role="noheader"]
 ----
-CREATE DATABASE customers IF NOT EXISTS
+CREATE OR REPLACE DATABASE name
+[TOPOLOGY n PRIMAR{Y\|IES} [m SECONDAR{Y\|IES}]]
+[OPTIONS "{" option: value[, ...] "}"]
+[WAIT [n [SEC[OND[S]]]]\|NOWAIT]
 ----
 
-Second, adding `OR REPLACE` to the command results in any existing database being deleted and a new one being created.
+|===
 
-.Query
-[source, cypher]
-----
-CREATE OR REPLACE DATABASE customers
-----
-
-This is equivalent to running `DROP DATABASE customers IF EXISTS` followed by `CREATE DATABASE customers`.
-
-The behavior of `IF NOT EXISTS` and `OR REPLACE` apply to both standard and composite databases (e.g. a composite database may replace a standard database or another composite database).
-
-[NOTE]
-====
-The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used together.
-====
 
 [[manage-databases-create-database-options]]
-=== Create database options
+=== Options
 
 The `CREATE DATABASE` command can have a map of options, e.g. `OPTIONS {key: 'value'}`.
 
@@ -114,12 +84,12 @@ Defines which server is used for seeding the data of the created database.
 The server ID can be found in the `serverId` column after running `SHOW SERVERS`.
 
 | `seedURI`
-| URI to a backup or a dump from an existing database.
+| URI to a backup or a dump from an existing database
 |
 Defines an identical seed from an external source which will be used to seed all servers.
 
 | `seedConfig`
-| comma-separated list of configuration values.
+| comma-separated list of configuration values
 |
 Defines additional configuration specified by comma-separated `name=value` pairs that might be required by certain seed providers.
 
@@ -149,21 +119,133 @@ More details about seeding options can be found in xref::clustering/databases.ad
 ====
 
 
+=== Usage examples
+
+.Create a database
+======
+
+.Query
+[source, cypher]
+----
+CREATE DATABASE customers
+----
+
+When a database is created, it shows up in the listing provided by the command `SHOW DATABASES`:
+
+.Query
+[source, cypher]
+----
+SHOW DATABASES YIELD name
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+----
++-------------+
+| name        |
++-------------+
+| "customers" |
+| "movies"    |
+| "neo4j"     |
+| "system"    |
++-------------+
+----
+======
+
+
+.Create a database with xref:database-administration/standard-databases/wait-options.adoc[`WAIT`]
+======
+
+.Query
+[source, cypher]
+----
+CREATE DATABASE slow WAIT 5 SECONDS
+----
+
+.Result
+[role="queryresult"]
+----
++-------------------------------------------------------+
+| address          | state      | message     | success |
++-------------------------------------------------------+
+| "localhost:7687" | "CaughtUp" | "caught up" | TRUE    |
++-------------------------------------------------------+
+----
+
+The `success` column provides an aggregate status of whether or not the command is considered successful and thus every row will have the same value.
+This column is to determine, for example in a script, whether or not the command has been completed successfully without timing out.
+======
+
+
+.Create databases with `IF NOT EXISTS` or `OR REPLACE`
+======
+
+The `CREATE DATABASE` command is optionally idempotent, with the default behavior to fail with an error if the database already exists.
+There are two ways to circumvent this behavior.
+
+First, appending `IF NOT EXISTS` to the command ensures that no error is returned and nothing happens should the database already exist.
+
+.Query
+[source, cypher]
+----
+CREATE DATABASE customers IF NOT EXISTS
+----
+
+Second, adding `OR REPLACE` to the command results in any existing database being deleted and a new one being created.
+
+.Query
+[source, cypher]
+----
+CREATE OR REPLACE DATABASE customers
+----
+
+This is equivalent to running `DROP DATABASE customers IF EXISTS` followed by `CREATE DATABASE customers`.
+
+The behavior of `IF NOT EXISTS` and `OR REPLACE` apply to both standard and composite databases (e.g. a composite database may replace a standard database or another composite database).
+
+[NOTE]
+====
+The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used together.
+====
+
+======
+
+
 [[manage-databases-start]]
 == Start databases
 
 Databases can be started using the command `START DATABASE`.
 
+[NOTE]
+====
+Both standard databases and composite databases can be started using this command.
+====
+
+
+=== Syntax
+
+[options="header", width="100%", cols="1m,5a"]
+|===
+| Command | Syntax
+
+| START DATABASE
+|
+[source, syntax, role="noheader"]
+----
+START DATABASE name [WAIT [n [SEC[OND[S]]]]\|NOWAIT]
+----
+
+|===
+
+=== Usage examples
+
+.Start a database
+======
 .Query
 [source, cypher]
 ----
 START DATABASE customers
 ----
-
-[NOTE]
-====
-Both standard databases and composite databases can be started using this command.
-====
 
 The status of the started database can be seen using the command `SHOW DATABASE name`.
 
@@ -182,12 +264,42 @@ SHOW DATABASE customers YIELD name, requestedStatus, currentStatus
 | "customers" | "online"        | "online"      |
 +-----------------------------------------------+
 ----
+======
+
+.Start a database with xref:database-administration/standard-databases/wait-options.adoc[`WAIT`]
+======
+.Query
+[source, cypher]
+----
+START DATABASE customers WAIT 5 SECONDS
+----
+
+======
 
 [[manage-databases-stop]]
 == Stop databases
 
 Databases can be stopped using the command `STOP DATABASE`.
 
+=== Syntax
+
+[options="header", width="100%", cols="1m,5a"]
+|===
+| Command | Syntax
+
+| STOP DATABASE
+|
+[source, syntax, role="noheader"]
+----
+STOP DATABASE name [WAIT [n [SEC[OND[S]]]]\|NOWAIT]
+----
+
+|===
+
+=== Usage examples
+
+.Stop a database
+======
 .Query
 [source, cypher]
 ----
@@ -216,6 +328,17 @@ SHOW DATABASE customers YIELD name, requestedStatus, currentStatus
 | "customers" | "offline"       | "offline"     |
 +-----------------------------------------------+
 ----
+======
+
+.Stop a database with xref:database-administration/standard-databases/wait-options.adoc[`WAIT`]
+======
+.Query
+[source, cypher]
+----
+STOP DATABASE customers WAIT 10 SECONDS
+----
+======
+
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/database-administration/standard-databases/delete-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/delete-databases.adoc
@@ -6,6 +6,26 @@
 Databases can be deleted by using the command `DROP DATABASE`.
 Note that all database aliases must be dropped before dropping a database.
 
+[[drop-database-syntax]]
+== Syntax
+
+[options="header", width="100%", cols="1m,5a"]
+|===
+| Command | Syntax
+
+| DROP DATABASE
+|
+[source, syntax, role="noheader"]
+----
+DROP [COMPOSITE] DATABASE name [IF EXISTS] [{DUMP\|DESTROY} [DATA]] [WAIT [n [SEC[OND[S]]]]\|NOWAIT]
+----
+
+|===
+
+== Usage examples
+
+.Example
+======
 .Query
 [source, cypher]
 ----
@@ -16,10 +36,13 @@ DROP DATABASE customers
 ====
 Both standard databases and composite databases can be deleted using this command.
 ====
+======
 
 The `DROP DATABASE` command removes a database entirely.
 Therefore, it no longer shows up in the listing provided by the command `SHOW DATABASES`.
 
+.Example
+======
 .Query
 [source, cypher]
 ----
@@ -37,9 +60,10 @@ SHOW DATABASES YIELD name
 | "system"            |
 +---------------------+
 ----
+======
 
 [[delete-databases-existing]]
-== Use `IF EXISTS` when deleting databases
+=== Use `IF EXISTS` when deleting databases
 
 The `DROP DATABASE` command is optionally idempotent, with the default behavior to fail with an error if the database does not exist.
 Appending `IF EXISTS` to the command ensures that no error is returned and nothing happens should the database not exist.
@@ -53,7 +77,7 @@ DROP DATABASE customers IF EXISTS
 ----
 
 [[manage-databases-dump]]
-== Use `DUMP DATA` or `DESTROY DATA` when deleting databases
+=== Use `DUMP DATA` or `DESTROY DATA` when deleting databases
 
 You can request that a dump of the store files is produced first, and stored in the path configured using the `dbms.directories.dumps.root` setting (by default `<neo4j-home>/data/dumps`).
 This can be achieved by appending `DUMP DATA` to the command (or `DESTROY DATA` to explicitly request the default behavior).
@@ -73,6 +97,9 @@ DROP ALIAS `motion pictures` FOR DATABASE;
 DROP DATABASE movies DUMP DATA
 ----
 
+
+.Combine `IF EXISTS` and  `DUMP DATA`/ `DESTROY DATA`
+======
 The options `IF EXISTS` and  `DUMP DATA`/ `DESTROY DATA` can also be combined.
 An example could look like this:
 
@@ -81,3 +108,6 @@ An example could look like this:
 ----
 DROP DATABASE customers IF EXISTS DUMP DATA
 ----
+======
+
+

--- a/modules/ROOT/pages/database-administration/standard-databases/delete-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/delete-databases.adoc
@@ -24,7 +24,7 @@ DROP [COMPOSITE] DATABASE name [IF EXISTS] [{DUMP\|DESTROY} [DATA]] [WAIT [n [SE
 
 == Usage examples
 
-.Example
+.Delete a database
 ======
 .Query
 [source, cypher]
@@ -36,13 +36,10 @@ DROP DATABASE customers
 ====
 Both standard databases and composite databases can be deleted using this command.
 ====
-======
 
 The `DROP DATABASE` command removes a database entirely.
 Therefore, it no longer shows up in the listing provided by the command `SHOW DATABASES`.
 
-.Example
-======
 .Query
 [source, cypher]
 ----

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -31,7 +31,7 @@ YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
 
 == `SHOW DATABASES` output
 
-Depending on whether you want to show, you can list:
+Depending on what you want to see, you can list:
 
 * All databases.
 * A particular database.

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -1,8 +1,37 @@
 :description: how to list databases in Neo4j, use SHOW DATABASES command, see all available databases, databases states. How to filter listed databases in Neo4j.
 [[manage-databases-list]]
-= Listing databases
+= List databases
 
-There are four different commands for listing databases, depending on whether you want to show:
+You can list your databases using the Cypher command `SHOW DATABASES`.
+
+== Syntax
+
+[options="header", width="100%", cols="1m,5a"]
+|===
+| Command | Syntax
+
+| SHOW DATABASE
+|
+[source, syntax, role="noheader"]
+----
+SHOW { DATABASE[S] name \| DATABASE[S] \| DEFAULT DATABASE \| HOME DATABASE }
+[WHERE expression]
+----
+
+[source, syntax, role="noheader"]
+----
+SHOW { DATABASE[S] name \| DATABASE[S] \| DEFAULT DATABASE \| HOME DATABASE }
+YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
+[WHERE expression]
+[RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+
+|===
+
+
+== `SHOW DATABASES` output
+
+Depending on whether you want to show, you can list:
 
 * All databases.
 * A particular database.

--- a/modules/ROOT/pages/database-administration/standard-databases/wait-options.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/wait-options.adoc
@@ -25,24 +25,3 @@ A command with a `WAIT` clause may be interrupted whilst it is waiting to comple
 In this event, the command will continue to execute in the background and will not be aborted.
 ====
 
-.Create a database with `WAIT`
-======
-.Query
-[source, cypher]
-----
-CREATE DATABASE slow WAIT 5 SECONDS
-----
-
-.Result
-[role="queryresult"]
-----
-+-------------------------------------------------------+
-| address          | state      | message     | success |
-+-------------------------------------------------------+
-| "localhost:7687" | "CaughtUp" | "caught up" | TRUE    |
-+-------------------------------------------------------+
-----
-
-The `success` column provides an aggregate status of whether or not the command is considered successful and thus every row will have the same value.
-This column is to determine, for example in a script, whether or not the command has been completed successfully without timing out.
-======


### PR DESCRIPTION
This is a big PR and I think it would be better to merge it after 5.20 release.

- Syntax tables were added to the modified pages
- Pages were restructured in line with the neo4j-admin commands section
- Usage examples were aligned 