### PR TITLE
Remove the note that Neo4j supports SELinux by default (#1627)

### DIFF
--- a/modules/ROOT/pages/installation/linux/rpm.adoc
+++ b/modules/ROOT/pages/installation/linux/rpm.adoc
@@ -104,11 +104,6 @@ As in the following example:
 NEO4J_ACCEPT_LICENSE_AGREEMENT=yes yum install neo4j-enterprise-{neo4j-version-exact}
 ----
 
-[NOTE]
-====
-Neo4j supports Security-Enhanced Linux (SELinux) by default.
-====
-
 [[linux-rpm-suse]]
 == Install on SUSE
 


### PR DESCRIPTION
Cherry-picked from #1627 