### PR TITLE
Remove the note that Neo4j supports SELinux by default (#1629)

### DIFF
--- a/modules/ROOT/pages/installation/linux/rpm.adoc
+++ b/modules/ROOT/pages/installation/linux/rpm.adoc
@@ -86,12 +86,6 @@ yum install neo4j-enterprise-{neo4j-version-exact}
 rpm -qa | grep neo
 ----
 
-[NOTE]
-====
-Neo4j supports Security-Enhanced Linux (SELinux), by default.
-====
-
-
 [[linux-rpm-install-noninteractive]]
 === Non-interactive installation of Neo4j Enterprise Edition
 


### PR DESCRIPTION
Cherry-picked from #1629 