### PR TITLE
Clarify a few details around Neo4j plugins

### DIFF
--- a/modules/ROOT/pages/configuration/index.adoc
+++ b/modules/ROOT/pages/configuration/index.adoc
@@ -10,6 +10,7 @@ The topics described are:
 * xref:configuration/ports.adoc[Ports] -- An overview of the ports relevant to a Neo4j installation.
 * xref:configuration/connectors.adoc[Configure network connectors] -- How to configure network connectors for Neo4j.
 * xref:configuration/set-initial-password.adoc[Set initial password] -- How to set an initial password.
+* xref:configuration/plugins.adoc[Configure Neo4j plugins] -- How to load plugins to a Neo4j deployment.  
 * xref:configuration/dynamic-settings.adoc[Update dynamic settings] -- How to configure certain Neo4j parameters while Neo4j is running.
 * xref:configuration/configuration-settings.adoc[Configuration settings] -- A complete reference of all configuration settings.
 

--- a/modules/ROOT/pages/configuration/plugins.adoc
+++ b/modules/ROOT/pages/configuration/plugins.adoc
@@ -33,7 +33,7 @@ The following plugins are supported:
 | 
 | https://neo4j.com/docs/apoc/current/[APOC user guide]
 
-| Bloom Enterprise footnote:You can also get basic access to Bloom via Graph Apps in Neo4j Desktop without a license key. See link:[Bloom documentation] for more details.
+| Bloom Enterprise footnote:[You can also get basic access to Bloom via Graph Apps in Neo4j Desktop without a license key. See link:{neo4j-docs-base-uri}/bloom-user-guide/current/bloom-installation/bloom-deployment-modes/[Bloom deployment modes] for more details.]
 | `bloom`
 | {check-mark}
 | link:{neo4j-docs-base-uri}/bloom-user-guide[Neo4j Bloom]
@@ -56,7 +56,7 @@ The following plugins are supported:
 | Graph Data Science
 | `graph-data-science`
 | 
-| link:{neo4j-docs-base-uri}/graph-data-science[Graph Data Science]
+| link:{neo4j-docs-base-uri}/graph-data-science/current/installation/#_installation_methods[Graph Data Science]
 
 | Graph Data Science Enterprise
 | `graph-data-science`

--- a/modules/ROOT/pages/configuration/plugins.adoc
+++ b/modules/ROOT/pages/configuration/plugins.adoc
@@ -2,15 +2,15 @@
 = Configure plugins
 :description: This page describes how to load plugins to a Neo4j deployment.
 
-Neo4j distributions come bundled with a range of pre-installed products, such as Graph Data Science library, Bloom, and Ops Manager, which can be used to extend the Neo4j capabilities.
-The JAR files for these products are located in the _product_ and _labs_ folders and can be installed as plugins.
+Neo4j distributions come bundled with a range of pre-installed products, such as Graph Data Science library or Bloom, which can be used to extend the Neo4j capabilities.
+The JAR files for these products are located in the _products_ and _labs_ folders and can be installed as plugins.
 
 If you want to use your own plugins, ensure that you add them to the designated _plugins_ directory.
 This directory serves as the central location where Neo4j looks for and loads the plugins at startup.
 
 [NOTE]
 ====
-Bloom and GDS Enterprise require a license activation key to become available to the user within Neo4j.
+Bloom Enterprise and GDS Enterprise require a license activation key to become available to the user within Neo4j.
 Reach out to your Neo4j account representative or request a representative to link:https://neo4j.com/contact-us/#sales-inquiry[contact you].
 ====
 
@@ -19,46 +19,46 @@ The following plugins are supported:
 .Supported Neo4j plugins
 [options="header",cols="d,m,b,a"]
 |===
-|Name |Key  | License required | Further information
+|Name |Key  | License activation key required | Further information
 
 | APOC Extended
 | `apoc-extended`
-| {cross-mark}
+| 
 | https://neo4j.com/labs/apoc/5/[APOC Extended user guide (Labs project)]
 
 | APOC
 | `apoc`
-| {cross-mark}
+| 
 | https://neo4j.com/docs/apoc/current/[APOC user guide]
 
-| Bloom
+| Bloom Enterprise
 | `bloom`
 | {check-mark}
 | link:{neo4j-docs-base-uri}/bloom-user-guide[Neo4j Bloom]
 
-| GenAI
+| GenAI (footnote:[The GenAI plugin is available in Neo4j **Enterprise** Edition only.])
 | `genai`
-| {cross-mark}
+|
 | link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/genai-integrations/[Cypher Manual -> GenAI integrations].
 
 | GraphQL
 | `graphql`
-| {cross-mark}
+| 
 | link:{neo4j-docs-base-uri}/graphql/current/[Neo4j GraphQL Library]
 
 | Graph Algorithms
 | `graph-algorithms`
-| {cross-mark}
+| 
 | link:{neo4j-docs-base-uri}/graph-data-science[The Neo4j Graph Data Science Library Manual]
 
-| Graph Data Science
+| Graph Data Science Enterprise
 | `graph-data-science`
-| {cross-mark}
+| {check-mark}
 | link:{neo4j-docs-base-uri}/graph-data-science[Graph Data Science]
 
 | Neo Semantics
 | `n10s`
-| {cross-mark}
+| 
 | https://neo4j.com/labs/nsmtx-rdf/[Neo Semantics]
 |===
 
@@ -74,7 +74,7 @@ For more information on using plugins in a different Neo4j setup, see:
 Here are the steps to enable the plugins:
 
 . Move or copy the plugins (_.jar files_) from _<NEO4J_HOME>/products_ and _<NEO4J_HOME>/labs_ to the _<NEO4J_HOME>/plugins_ directory.
-See the table in xref:configuration/file-locations.adoc[File locations] for more information.
+See tables in xref:configuration/file-locations.adoc[Default file locations] for more information.
 
 . Add the following lines in _<NEO4J_HOME>/conf/neo4j.conf_:
 +
@@ -102,7 +102,7 @@ See the table in xref:configuration/file-locations.adoc[File locations] for more
 ----
 . Install the plugins.
 +
-Refer to link:https://neo4j.com/docs/bloom-user-guide/current/bloom-installation/[Bloom documentation], link:https://neo4j.com/docs/graph-data-science/current/installation/[GDS documentation], and  https://neo4j.com/docs/ops-manager/current[Neo4j Ops Manager documentation] for more details on how to install them.
+Refer to link:https://neo4j.com/docs/bloom-user-guide/current/bloom-installation/[Bloom documentation], link:https://neo4j.com/docs/graph-data-science/current/installation/[GDS documentation] for more details on how to install them.
 
 [NOTE]
 ====
@@ -110,3 +110,4 @@ All installed plugins will automatically be loaded every time Neo4j is started.
 Because of that, the number of plugins may impact the startup time.
 Install only the necessary plugins to avoid performance issues.
 ====
+

--- a/modules/ROOT/pages/configuration/plugins.adoc
+++ b/modules/ROOT/pages/configuration/plugins.adoc
@@ -2,7 +2,7 @@
 = Configure plugins
 :description: This page describes how to load plugins to a Neo4j deployment.
 
-Neo4j Enterprise Edition comes bundled with a range of pre-installed products, such as Graph Data Science library or Bloom, which can be used to extend the Neo4j capabilities.
+Neo4j Enterprise Edition comes bundled with a range of pre-installed products, such as Graph Data Science library and Bloom, which can be used to extend the Neo4j capabilities.
 The JAR files for these products are located in the _products_ folder and can be installed as plugins.
 
 Neo4j Community Edition comes with the APOC plugin only in the _labs_ directory.
@@ -12,7 +12,7 @@ This directory serves as the central location where Neo4j looks for and loads th
 
 [NOTE]
 ====
-Bloom Enterprise and GDS Enterprise require a license activation key to become available to the user within Neo4j.
+Bloom Enterprise and GDS Enterprise require a license activation key.
 Reach out to your Neo4j account representative or request a representative to link:https://neo4j.com/contact-us/#sales-inquiry[contact you].
 ====
 
@@ -81,7 +81,7 @@ For more information on using plugins in a different Neo4j setup, see:
 Here are the steps to enable the plugins:
 
 . Move or copy the plugins (_.jar files_) from _<NEO4J_HOME>/products_ and _<NEO4J_HOME>/labs_ to the _<NEO4J_HOME>/plugins_ directory.
-See tables in xref:configuration/file-locations.adoc[Default file locations] for more information.
+See xref:configuration/file-locations.adoc[Default file locations] for more information.
 
 . Add the following lines in _<NEO4J_HOME>/conf/neo4j.conf_:
 +

--- a/modules/ROOT/pages/configuration/plugins.adoc
+++ b/modules/ROOT/pages/configuration/plugins.adoc
@@ -38,7 +38,7 @@ The following plugins are supported:
 | {check-mark}
 | link:{neo4j-docs-base-uri}/bloom-user-guide[Neo4j Bloom]
 
-| GenAI footnote:[The GenAI plugin is only available in Neo4j **Enterprise** Edition from 5.17.]
+| GenAI footnote:[The GenAI plugin is only available in Neo4j **Enterprise** Edition starting from Neo4j 5.17.]
 | `genai`
 |
 | link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/genai-integrations/[Cypher Manual -> GenAI integrations].

--- a/modules/ROOT/pages/configuration/plugins.adoc
+++ b/modules/ROOT/pages/configuration/plugins.adoc
@@ -2,8 +2,10 @@
 = Configure plugins
 :description: This page describes how to load plugins to a Neo4j deployment.
 
-Neo4j distributions come bundled with a range of pre-installed products, such as Graph Data Science library or Bloom, which can be used to extend the Neo4j capabilities.
-The JAR files for these products are located in the _products_ and _labs_ folders and can be installed as plugins.
+Neo4j Enterprise Edition comes bundled with a range of pre-installed products, such as Graph Data Science library or Bloom, which can be used to extend the Neo4j capabilities.
+The JAR files for these products are located in the _products_ folder and can be installed as plugins.
+
+Neo4j Community Edition comes with the APOC plugin only in the _labs_ directory.
 
 If you want to use your own plugins, ensure that you add them to the designated _plugins_ directory.
 This directory serves as the central location where Neo4j looks for and loads the plugins at startup.
@@ -31,12 +33,12 @@ The following plugins are supported:
 | 
 | https://neo4j.com/docs/apoc/current/[APOC user guide]
 
-| Bloom Enterprise
+| Bloom Enterprise footnote:You can also get basic access to Bloom via Graph Apps in Neo4j Desktop without a license key. See link:[Bloom documentation] for more details.
 | `bloom`
 | {check-mark}
 | link:{neo4j-docs-base-uri}/bloom-user-guide[Neo4j Bloom]
 
-| GenAI (footnote:[The GenAI plugin is available in Neo4j **Enterprise** Edition only.])
+| GenAI footnote:[The GenAI plugin is only available in Neo4j **Enterprise** Edition from 5.17.]
 | `genai`
 |
 | link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/genai-integrations/[Cypher Manual -> GenAI integrations].
@@ -49,12 +51,17 @@ The following plugins are supported:
 | Graph Algorithms
 | `graph-algorithms`
 | 
-| link:{neo4j-docs-base-uri}/graph-data-science[The Neo4j Graph Data Science Library Manual]
+| link:{neo4j-docs-base-uri}/graph-data-science/current/installation/installation-enterprise-edition/[The Neo4j Graph Data Science Library Manual]
+
+| Graph Data Science
+| `graph-data-science`
+| 
+| link:{neo4j-docs-base-uri}/graph-data-science[Graph Data Science]
 
 | Graph Data Science Enterprise
 | `graph-data-science`
 | {check-mark}
-| link:{neo4j-docs-base-uri}/graph-data-science[Graph Data Science]
+| link:{neo4j-docs-base-uri}/graph-data-science[GDS Enterprise Edition]
 
 | Neo Semantics
 | `n10s`


### PR DESCRIPTION
Add a footnote that GenAI plugin is available in EE only
Remove mentioning about the Ops Manager, as it doesn't run as a plugin but as a separate product
Mention the Configure plugins page in the intro page to the section
Clarify that Bloom Enterprise and GDS Enterprise require license key