### PR TITLE
Add the metric `<prefix.>store.size.available_reserved`

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -321,6 +321,7 @@ label:deprecated[Deprecated in 5.15]
 |Name |Description
 |<prefix>.store.size.total|The total size of the database and transaction logs, in bytes. The total size of the database helps determine how much cache page is required. It also helps compare the total disk space used by the data store and how much is available. (gauge)
 |<prefix>.store.size.database|The size of the database, in bytes. The total size of the database helps determine how much cache page is required. It also helps compare the total disk space used by the data store and how much is available. (gauge)
+|<prefix>.store.size.available_reserved|An estimate of reserved but available space in the database, in bytes. At least this much space is potentially reusable when writing new data. (gauge)
 |===
 
 [[db-tx-log-metrics]]

--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -321,7 +321,7 @@ label:deprecated[Deprecated in 5.15]
 |Name |Description
 |<prefix>.store.size.total|The total size of the database and transaction logs, in bytes. The total size of the database helps determine how much cache page is required. It also helps compare the total disk space used by the data store and how much is available. (gauge)
 |<prefix>.store.size.database|The size of the database, in bytes. The total size of the database helps determine how much cache page is required. It also helps compare the total disk space used by the data store and how much is available. (gauge)
-|<prefix>.store.size.available_reserved|An estimate of reserved but available space in the database, in bytes. At least this much space is potentially reusable when writing new data. (gauge)
+|<prefix>.store.size.available_reserved|label:new[Introduced in 5.21]An estimate of reserved but available space in the database, in bytes. At least this much space is potentially reusable when writing new data. (gauge)
 |===
 
 [[db-tx-log-metrics]]


### PR DESCRIPTION
I suppose this change is related to the [PR#25468](https://github.com/neo-technology/neo4j/pull/25468).
Should we add the label 'Introduced in 5.21'? 