### PR TITLE
Explain how neo4j metric names are transformed in Prometheus (#1658)

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/expose.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/expose.adoc
@@ -116,3 +116,21 @@ If you can afford to send unencrypted metrics within the internal network, such 
 If you specify anything more permissive, such as `server.metrics.prometheus.endpoint=0.0.0.0:2004`, you should have a firewall rule to prevent any unauthorized access.
 Data in transit will still not be encrypted, so it should never go over any insecure networks.
 
+[TIP]
+====
+When Neo4j metrics are exposed via Prometheus, their names are transformed to comply with Prometheus naming conventions.
+
+The following general rules are applied:
+
+* Dots (.) are replaced with underscores (_), since Prometheus does not support dots in metric names.
+
+* Depending on the metric type, a postfix is added.
+
+Original Neo4j metric names can be found in Prometheus output, see lines starting with `# HELP`.
+
+For more information, see link:https://prometheus.io/docs/concepts/data_model[Prometheus Documentation].
+====
+
+
+
+

--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -25,6 +25,9 @@ The metrics fall into one of the following categories:
 * Counter -- shows an accumulated value.
 * Histogram -- shows the distribution of values.
 
+Neo4j supports several ways of exposing metrics.
+For more details, refer to the page xref:monitoring/metrics/expose.adoc[Expose metrics].
+
 [[metrics-global]]
 === Global metrics
 


### PR DESCRIPTION
Add a note/tip to remind users that Neo4j metric names exposed via Prometheus are modified to comply with the Prometheus naming conventions. However, I don't think we have to provide a detailed example here because Prometheus is a third-party resource, and its standards or rules may change. IMO, it's enough to emphasize that the Prometheus metrics format is different from ours and to give a link to the Prometheus documentation.

---------