### PR TITLE
Add a tip about needing server and client usage in intra-cluster TLS …

### DIFF
--- a/modules/ROOT/pages/clustering/setup/encryption.adoc
+++ b/modules/ROOT/pages/clustering/setup/encryption.adoc
@@ -39,6 +39,25 @@ The generation of xref:security/ssl-framework.adoc#term-ssl-cryptographic-object
 It generally requires having a PKI with a xref:security/ssl-framework.adoc#term-ssl-certificate-authority[Certificate Authority (CA)] within the organization and they should be able to advise here.
 Note that the information in this manual relating to the PKI is mainly for illustrative purposes.
 
+[TIP]
+====
+If setting up intra-cluster encryption as part of a cluster configuration, ensure that the certificates used on the cluster endpoint support server and client usage.
+This is because when connecting between the Neo4j servers for clustering, each server uses its own certificate to authenticate as a client on the connection to another server.
+
+This could be verified from within the certificate details:
+
+----
+openssl x509 -in public.crt -noout -text
+----
+We should see that the X509v3 Extended Key Usage section shows both the usages listed:
+
+----
+X509v3 Extended Key Usage:
+    TLS Web Server Authentication, TLS Web Client Authentication
+----
+====
+
+
 When the certificates and private keys are obtained they can be installed on each of the servers.
 Each server has a certificate of its own, signed by a CA, and the corresponding private key.
 The certificate of the CA is installed into the `trusted` directory, and any certificate signed by the CA is thus trusted.

--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -100,6 +100,24 @@ If the same certificates are used across all instances of the cluster, make sure
 Multi-host and wildcard certificates are also supported.
 ====
 
+[TIP]
+====
+If setting up intra-cluster encryption as part of a cluster configuration, ensure that the certificates used on the cluster endpoint support server and client usage.
+This is because when connecting between the Neo4j servers for clustering, each server uses its own certificate to authenticate as a client on the connection to another server.
+
+This could be verified from within the certificate details:
+
+----
+openssl x509 -in public.crt -noout -text
+----
+We should see that the X509v3 Extended Key Usage section shows both the usages listed:
+
+----
+X509v3 Extended Key Usage:
+    TLS Web Server Authentication, TLS Web Client Authentication
+----
+====
+
 ==== Transformations
 
 Neo4j requires all SSL certificates to be in the `PEM` format.


### PR DESCRIPTION
…certificates (#1688)

Servers act as both servers and clients, and will complain if they only have one of the modes