### PR TITLE
Adding new limited allocation procedures

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -112,7 +112,7 @@ By default, a newly created database has both read and write access.
 To relieve the load of a specific server(s), you can use one of the following procedures to deallocate databases causing the pressure from the server(s):
 
 * xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServer[`dbms.cluster.deallocateDatabaseFromServer("server-name", "database-name")`]
-* xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServers[`dbms.cluster.deallocateDatabaseFromServers(["server-name1", "server-name2"], "database-name")`]
+* xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServers[`dbms.cluster.deallocateDatabaseFromServers(["server-name1", "server-name2"\], "database-name")`]
 * xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateNumberOfDatabases[`dbms.cluster.deallocateNumberOfDatabases("server-name", number)`]
 
 [NOTE]

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -102,9 +102,49 @@ ALTER DATABASE foo SET ACCESS {READ ONLY | READ WRITE}
 
 By default, a newly created database has both read and write access.
 
+[[deallocatedatabase]]
+== Deallocate database
+
+There can be situations when we would like to get a specific database off a certain server.
+For example, take the scenario that we have an overloaded `server1` containing small databases `foo, bar` and a very large database `baz`.
+At the same time we have other servers which are not as overloaded.
+
+Now we can add a deallocate `baz` off `server1` to relieve pressure off `server1`. To do this
+
+.Deallocating a database from a server
+[source, cypher]
+----
+neo4j@system> CALL dbms.cluster.deallocateDatabase("server1", "baz");
+----
+
+[NOTE]
+====
+The `dbms.cluster.deallocateDatabase()` procedure is only available starting in 5.22.
+====
+
+[[reallocatedatabase]]
+== Reallocate database
+
+Imagine if we added three new servers and want to get large database `baz` off all the old servers and onto the new servers.
+We can now do this by reallocating `baz` away to relieve pressure from the old servers.
+Note that this is different from `deallocateDatabase` as no specific server is chosen, the cluster will pick all the servers containing `baz`.
+Other databases will not be affected.
+
+.Reallocating a database to new servers
+[source, cypher]
+----
+neo4j@system> CALL dbms.cluster.reallocateDatabase("baz");
+----
+
+[NOTE]
+====
+The `dbms.cluster.reallocateDatabase()` procedure is only available starting in 5.22.
+====
+
+
 == Reallocate databases
 
-If there is a need to rebalance database allocation across the cluster, for example if new servers have been added, use the `REALLOCATE DATABASE[S]`.
+If there is a need to rebalance all the database allocation across the cluster, for example if new servers have been added, use the `REALLOCATE DATABASE[S]`.
 This command can be used with `DRYRUN` to preview the new allocation of databases.
 
 [NOTE]

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -102,7 +102,7 @@ ALTER DATABASE foo SET ACCESS {READ ONLY | READ WRITE}
 
 By default, a newly created database has both read and write access.
 
-[role=label--new-5.22]
+[role=label--new-5.23]
 [[deallocatedatabase]]
 == Deallocate database
 
@@ -114,10 +114,36 @@ To relieve pressure off `server1`, you can deallocate `baz` off `server1` by run
 .Deallocating a database from a server
 [source, cypher]
 ----
-neo4j@system> CALL dbms.cluster.deallocateDatabase("server1", "baz");
+// With dry run
+neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServer("server1", "baz", true);
+
+// Without dry run
+neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServer("server1", "baz");
+
 ----
 
-[role=label--new-5.22]
+.Deallocating a database from multiple servers
+[source, cypher]
+----
+// With dry run
+neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServers(["server1", "server2"], "baz", true);
+
+// Without dry run
+neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServers(["server1", "server2"], "baz");
+
+----
+
+.Deallocating three databases from a server
+[source, cypher]
+----
+// With dry run
+neo4j@system> CALL dbms.cluster.deallocateNumberOfDatabases("server1", 3, true);
+
+// Without dry run
+neo4j@system> CALL dbms.cluster.deallocateNumberOfDatabases("server1", 3);
+----
+
+[role=label--new-5.23]
 [[reallocatedatabase]]
 == Reallocate a single database
 
@@ -127,10 +153,24 @@ Instead, the cluster offloads the specified database from all servers containing
 Other databases are not affected.
 For example, let's say you add three new servers and want to move the large database `baz` from all the old servers to the new servers.
 
-.Reallocating a database to new servers
+.Reallocating one database to new servers
 [source, cypher]
 ----
+// With dry run
+neo4j@system> CALL dbms.cluster.reallocateDatabase("baz", true);
+
+// Without dry run
 neo4j@system> CALL dbms.cluster.reallocateDatabase("baz");
+----
+
+.Reallocating a number of databases to new servers
+[source, cypher]
+----
+// With dry run
+neo4j@system> CALL dbms.cluster.reallocateNumberOfDatabases(3, true);
+
+// Without dry run
+neo4j@system> CALL dbms.cluster.reallocateNumberOfDatabases(3);
 ----
 
 == Reallocating databases

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -115,6 +115,11 @@ To relieve the load of a specific server(s), you can use one of the following pr
 * xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServers[`dbms.cluster.deallocateDatabaseFromServers(["server-name1", "server-name2"], "database-name")`]
 * xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateNumberOfDatabases[`dbms.cluster.deallocateNumberOfDatabases("server-name", number)`]
 
+[NOTE]
+====
+You must have the `SERVER MANAGEMENT` privilege to execute these procedures.
+====
+
 For example, `server01` hosts two small databases, `foo` and `bar`, and one very large database `baz`, while other servers contain fewer or smaller databases, and `server01` is under pressure.
 
 You can use one of the following approaches to deallocate `baz` from `server01` or to deallocate a number of databases from `server01`:
@@ -163,6 +168,11 @@ To rebalance all database allocations across the cluster, for example, because y
 
 You can use the procedure xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase()`] to offload a specific database from all servers containing it onto new servers or xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[dbms.cluster.reallocateNumberOfDatabases] to rebalance all database allocations across the cluster and relieve overloaded servers.
 These procedures do not require a server name and can be executed with or without a dry run.
+
+[NOTE]
+====
+You must have the `SERVER MANAGEMENT` privilege to execute these procedures.
+====
 
 For example, you add three new servers and want to move a very large database, `baz`, from all the servers containing it to the new servers.
 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -117,10 +117,6 @@ To relieve pressure off `server1`, you can deallocate `baz` off `server1` by run
 neo4j@system> CALL dbms.cluster.deallocateDatabase("server1", "baz");
 ----
 
-[NOTE]
-====
-The `dbms.cluster.deallocateDatabase()` procedure is only available starting in 5.22.
-====
 [role=label--new-5.22]
 [[reallocatedatabase]]
 == Reallocate a single database
@@ -137,13 +133,7 @@ For example, let's say you add three new servers and want to move the large data
 neo4j@system> CALL dbms.cluster.reallocateDatabase("baz");
 ----
 
-[NOTE]
-====
-The `dbms.cluster.reallocateDatabase()` procedure is only available starting in 5.22.
-====
-
-
-== Reallocate databases
+== Reallocating databases
 
 To rebalance all database allocations across the cluster, for example, because you added new servers, use the Cypher command `REALLOCATE DATABASE[S]`.
 This command can be used with `DRYRUN` to preview the new allocation of databases.

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -102,14 +102,14 @@ ALTER DATABASE foo SET ACCESS {READ ONLY | READ WRITE}
 
 By default, a newly created database has both read and write access.
 
+[role=label--new-5.22]
 [[deallocatedatabase]]
 == Deallocate database
 
-There can be situations when we would like to get a specific database off a certain server.
-For example, take the scenario that we have an overloaded `server1` containing small databases `foo, bar` and a very large database `baz`.
-At the same time we have other servers which are not as overloaded.
+To relieve the load of a particular server, you can use the procedure `dbms.cluster.deallocateDatabase("server-name", "database-name") to deallocate the database causing the pressure.
+For example, `server1` contains the small databases' foo' and `bar` and the very large database `baz`, while other servers contain fewer or smaller databases.
 
-Now we can add a deallocate `baz` off `server1` to relieve pressure off `server1`. To do this
+To relieve pressure off `server1`, you can deallocate `baz` off `server1` by running:
 
 .Deallocating a database from a server
 [source, cypher]
@@ -121,14 +121,15 @@ neo4j@system> CALL dbms.cluster.deallocateDatabase("server1", "baz");
 ====
 The `dbms.cluster.deallocateDatabase()` procedure is only available starting in 5.22.
 ====
-
+[role=label--new-5.22]
 [[reallocatedatabase]]
-== Reallocate database
+== Reallocate a single database
 
-Imagine if we added three new servers and want to get large database `baz` off all the old servers and onto the new servers.
-We can now do this by reallocating `baz` away to relieve pressure from the old servers.
-Note that this is different from `deallocateDatabase` as no specific server is chosen, the cluster will pick all the servers containing `baz`.
-Other databases will not be affected.
+To relieve the overloaded servers after adding new servers, you can use the procedure `dbms.cluster.reallocateDatabase()` to offload the database, causing it onto the new servers.
+It is different from `deallocateDatabase` as no specific server is chosen.
+Instead, the cluster offloads the specified database from all servers containing it.
+Other databases are not affected.
+For example, let's say you add three new servers and want to move the large database `baz` from all the old servers to the new servers.
 
 .Reallocating a database to new servers
 [source, cypher]
@@ -144,7 +145,7 @@ The `dbms.cluster.reallocateDatabase()` procedure is only available starting in 
 
 == Reallocate databases
 
-If there is a need to rebalance all the database allocation across the cluster, for example if new servers have been added, use the `REALLOCATE DATABASE[S]`.
+To rebalance all database allocations across the cluster, for example, because you added new servers, use the Cypher command `REALLOCATE DATABASE[S]`.
 This command can be used with `DRYRUN` to preview the new allocation of databases.
 
 [NOTE]

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -112,7 +112,7 @@ By default, a newly created database has both read and write access.
 To relieve the load of a specific server(s), you can use one of the following procedures to deallocate databases causing the pressure from the server(s):
 
 * xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServer[`dbms.cluster.deallocateDatabaseFromServer("server-name", "database-name")`]
-* xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServers[`dbms.cluster.deallocateDatabaseFromServers(["server-name1", "server-name2"\], "database-name")`]
+* xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServers[`dbms.cluster.deallocateDatabaseFromServers(git["server-name1", "server-name2"\], "database-name")`]
 * xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateNumberOfDatabases[`dbms.cluster.deallocateNumberOfDatabases("server-name", number)`]
 
 [NOTE]

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -8,6 +8,7 @@ The number of both primary and secondary servers to host a database can be set w
 The command `CREATE DATABASE` can be used to specify the initial topology and `ALTER DATABASE` can be used to change the topology once the database is created.
 If a database is no longer needed, the command `DROP DATABASE` deletes the database from the cluster.
 
+[[create-database]]
 == `CREATE DATABASE`
 
 The command to create a database in a cluster is not significantly different from the command to create a database in a non-clustered environment (see xref:database-administration/standard-databases/create-databases.adoc[Create, start, and stop databases] for more information on database management on single servers).
@@ -35,12 +36,13 @@ However, over time, or after several `CREATE DATABASE` commands have been issued
 At this point you can run `REALLOCATE DATABASES` to make the cluster re-balance databases across all servers that are part of the cluster.
 ====
 
-[[alter-topology]]
+[[alter-database]]
 == `ALTER DATABASE`
 
 To alter the topology of or read/write access to a database after it has been created, use the command `ALTER DATABASE`.
 
-=== Alter topology
+[[alter-topology]]
+=== Alter database topology
 
 To change the topology of the database `foo` from the previous example, the command can look like this:
 
@@ -91,7 +93,8 @@ ALTER DATABASE nonExisting IF EXISTS SET TOPOLOGY 1 PRIMARY 0 SECONDARY
 // * `OPTIMAL_DISC_USAGE`
 // * `ALL`
 
-=== Alter access
+[[alter-access]]
+=== Alter database access
 
 To alter the access to the database `foo`, the syntax looks like this:
 
@@ -103,22 +106,27 @@ ALTER DATABASE foo SET ACCESS {READ ONLY | READ WRITE}
 By default, a newly created database has both read and write access.
 
 [role=label--new-5.23]
-[[deallocatedatabase]]
-== Deallocate database
+[[deallocate-databases]]
+== Deallocate databases
 
-To relieve the load of a particular server, you can use the procedure `dbms.cluster.deallocateDatabase("server-name", "database-name") to deallocate the database causing the pressure.
-For example, `server1` contains the small databases' foo' and `bar` and the very large database `baz`, while other servers contain fewer or smaller databases.
+To relieve the load of a specific server(s), you can use one of the following procedures to deallocate databases causing the pressure from the server(s):
 
-To relieve pressure off `server1`, you can deallocate `baz` off `server1` by running:
+* xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServer[`dbms.cluster.deallocateDatabaseFromServer("server-name", "database-name")`]
+* xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServers[`dbms.cluster.deallocateDatabaseFromServers(["server-name1", "server-name2"], "database-name")`]
+* xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateNumberOfDatabases[`dbms.cluster.deallocateNumberOfDatabases("server-name", number)`]
+
+For example, `server01` hosts two small databases, `foo` and `bar`, and one very large database `baz`, while other servers contain fewer or smaller databases, and `server01` is under pressure.
+
+You can use one of the following approaches to deallocate `baz` from `server01` or to deallocate a number of databases from `server01`:
 
 .Deallocating a database from a server
 [source, cypher]
 ----
 // With dry run
-neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServer("server1", "baz", true);
+neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServer("server01", "baz", true);
 
 // Without dry run
-neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServer("server1", "baz");
+neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServer("server01", "baz");
 
 ----
 
@@ -126,10 +134,10 @@ neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServer("server1", "baz");
 [source, cypher]
 ----
 // With dry run
-neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServers(["server1", "server2"], "baz", true);
+neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServers(["server01", "server02"], "baz", true);
 
 // Without dry run
-neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServers(["server1", "server2"], "baz");
+neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServers(["server01", "server02"], "baz");
 
 ----
 
@@ -137,23 +145,28 @@ neo4j@system> CALL dbms.cluster.deallocateDatabaseFromServers(["server1", "serve
 [source, cypher]
 ----
 // With dry run
-neo4j@system> CALL dbms.cluster.deallocateNumberOfDatabases("server1", 3, true);
+neo4j@system> CALL dbms.cluster.deallocateNumberOfDatabases("server01", 3, true);
 
 // Without dry run
-neo4j@system> CALL dbms.cluster.deallocateNumberOfDatabases("server1", 3);
+neo4j@system> CALL dbms.cluster.deallocateNumberOfDatabases("server01", 3);
 ----
 
+
+[[reallocate-databases]]
+== Reallocate databases
+
+To rebalance all database allocations across the cluster, for example, because you added new servers, use either procedures or Cypher commands to reallocate databases onto the new servers.
+
 [role=label--new-5.23]
-[[reallocatedatabase]]
-== Reallocate a single database
+[[reallocate-databases-procedure]]
+=== Reallocate databases using a procedure
 
-To relieve the overloaded servers after adding new servers, you can use the procedure `dbms.cluster.reallocateDatabase()` to offload the database, causing it onto the new servers.
-It is different from `deallocateDatabase` as no specific server is chosen.
-Instead, the cluster offloads the specified database from all servers containing it.
-Other databases are not affected.
-For example, let's say you add three new servers and want to move the large database `baz` from all the old servers to the new servers.
+You can use the procedure xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase()`] to offload a specific database from all servers containing it onto new servers or xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[dbms.cluster.reallocateNumberOfDatabases] to rebalance all database allocations across the cluster and relieve overloaded servers.
+These procedures do not require a server name and can be executed with or without a dry run.
 
-.Reallocating one database to new servers
+For example, you add three new servers and want to move a very large database, `baz`, from all the servers containing it to the new servers.
+
+.Reallocate one database to new servers
 [source, cypher]
 ----
 // With dry run
@@ -173,14 +186,15 @@ neo4j@system> CALL dbms.cluster.reallocateNumberOfDatabases(3, true);
 neo4j@system> CALL dbms.cluster.reallocateNumberOfDatabases(3);
 ----
 
-== Reallocating databases
+[[reallocate-databases-cypher]]
+=== Reallocate databases using a Cypher command
 
-To rebalance all database allocations across the cluster, for example, because you added new servers, use the Cypher command `REALLOCATE DATABASE[S]`.
-This command can be used with `DRYRUN` to preview the new allocation of databases.
+You can use the Cypher command `REALLOCATE DATABASES` to rebalance all database allocations across the cluster and relieve overloaded servers.
+This command can also be used with `DRYRUN` to preview the new allocation of databases.
 
 [NOTE]
 ====
-`DRYRUN` is introduced in Neo4j 5.2 and thus does not work in previous versions.
+`DRYRUN` is available from Neo4j 5.2 and later.
 ====
 
 [source,cypher]

--- a/modules/ROOT/pages/database-administration/standard-databases/errors.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/errors.adoc
@@ -256,3 +256,36 @@ You can remove it only by running the xref:reference/procedures.adoc#procedure_d
 The one exception to this rule is for the built-in `system` database.
 Any quarantine for that database is removed automatically after instance restart.
 ====
+
+
+[[overloaded]]
+== Overloaded servers
+
+There can be situations when we would like to relieve an overloaded server to moving some of the databases hosted on it.
+In order to to this, we have limited deallocation commands such as `dbms.cluster.deallocateNumberOfDatabases()` which can
+move some databases off a certain server to other servers which do not have as much load.
+
+.Deallocating three databases from a server
+[source, cypher]
+----
+neo4j@system> CALL dbms.cluster.deallocateNumberOfDatabases("server1", 3);
+----
+
+[NOTE]
+====
+The `dbms.cluster.deallocateNumberOfDatabases()` procedure is only available starting in 5.22.
+====
+
+Alternatively, imagine if we added three new servers and want to reallocate a limited number of databases around the servers to rebalance.
+We can now do this by calling `dbms.cluster.reallocateNumberOfDatabases()`
+
+.Reallocating three databases around the cluster
+[source, cypher]
+----
+neo4j@system> CALL dbms.cluster.reallocateNumberOfDatabases(3);
+----
+
+[NOTE]
+====
+The `dbms.cluster.reallocateNumberOfDatabases()` procedure is only available starting in 5.22.
+====

--- a/modules/ROOT/pages/database-administration/standard-databases/errors.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/errors.adoc
@@ -256,36 +256,3 @@ You can remove it only by running the xref:reference/procedures.adoc#procedure_d
 The one exception to this rule is for the built-in `system` database.
 Any quarantine for that database is removed automatically after instance restart.
 ====
-
-
-[[overloaded]]
-== Overloaded servers
-
-There can be situations when we would like to relieve an overloaded server to moving some of the databases hosted on it.
-In order to to this, we have limited deallocation commands such as `dbms.cluster.deallocateNumberOfDatabases()` which can
-move some databases off a certain server to other servers which do not have as much load.
-
-.Deallocating three databases from a server
-[source, cypher]
-----
-neo4j@system> CALL dbms.cluster.deallocateNumberOfDatabases("server1", 3);
-----
-
-[NOTE]
-====
-The `dbms.cluster.deallocateNumberOfDatabases()` procedure is only available starting in 5.22.
-====
-
-Alternatively, imagine if we added three new servers and want to reallocate a limited number of databases around the servers to rebalance.
-We can now do this by calling `dbms.cluster.reallocateNumberOfDatabases()`
-
-.Reallocating three databases around the cluster
-[source, cypher]
-----
-neo4j@system> CALL dbms.cluster.reallocateNumberOfDatabases(3);
-----
-
-[NOTE]
-====
-The `dbms.cluster.reallocateNumberOfDatabases()` procedure is only available starting in 5.22.
-====

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -1859,15 +1859,15 @@ m|WRITE
 a|xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE SERVER`]
 |===
 
-[[procedure_dbms_cluster_deallocateDatabase]]
+[[procedure_dbms_cluster_deallocateDatabaseFromServer]]
 [role=label--enterprise-edition label--admin-only]
-.dbms.cluster.deallocateDatabase()
+.dbms.cluster.deallocateDatabaseFromServer()
 [cols="<15s,<85"]
 |===
 | Description
 a| Deallocate a specific user database on a specific server.
 | Signature
-m| dbms.cluster.deallocateDatabase(server :: STRING, database :: STRING)
+m| dbms.cluster.deallocateDatabaseFromServer(server :: STRING, database :: STRING)
 | Mode
 m|WRITE
 |===

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -1892,7 +1892,7 @@ m|WRITE
 [cols="<15s,<85"]
 |===
 | Description
-a| Deallocate a number of user databases from a specific server. The databases to be deallocated are selected randomly.
+a| Deallocate a number of user databases from a specific server.
 | Signature
 m| dbms.cluster.deallocateNumberOfDatabases(server :: STRING, number :: INTEGER)
 | Mode

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -1972,7 +1972,7 @@ This procedure requires the `SERVER MANAGEMENT` privilege.
 | Description
 a| Reallocate a specified number of user databases.
 | Signature
-m| dbms.cluster.reallocateNumberOfDatabases(number :: INTEGER, dryrun = false :: BOOLEAN) :: (database :: STRING, fromServerName :: STRING, fromServerId :: STRING, toServerName :: STRING, toServerId :: STRING, mode :: STRING)"
+m| dbms.cluster.reallocateNumberOfDatabases(number :: INTEGER, dryrun = false :: BOOLEAN) :: (database :: STRING, fromServerName :: STRING, fromServerId :: STRING, toServerName :: STRING, toServerId :: STRING, mode :: STRING)
 | Mode
 m|WRITE
 |===

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -1898,7 +1898,7 @@ m|DBMS
 | Description
 a| Compare the states of Discovery service V1 and Discovery service V2.
 | Signature
-m| dbms.cluster.showParallelDiscoveryState() :: (mode :: STRING, stateComparison :: STRING)
+m| dbms.cluster.showParallelDiscoveryState() :: (mode :: STRING, stateComparison :: STRING, v1ServerCount :: STRING, v2ServerCount :: STRING)
 | Mode
 m|DBMS
 |===

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -409,6 +409,11 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING, resourceType ::
 | label:yes[]
 | label:admin-only[] label:not-aura[Not available on Aura]
 
+| xref:reference/procedures.adoc#procedure_dbms_setDatabaseAllocator[`dbms.setDatabaseAllocator()`]
+| label:no[]
+| label:yes[]
+| label:admin-only[] label:deprecated-in-5.23[Deprecated in 5.23]
+
 | xref:reference/procedures.adoc#procedure_dbms_setDefaultAllocationNumbers[`dbms.setDefaultAllocationNumbers()`]
 | label:no[]
 | label:yes[]

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -1859,6 +1859,46 @@ m|WRITE
 a|xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE SERVER`]
 |===
 
+[NOTE]
+====
+Before Neo4j 5.23, the procedure dbms.cluster.uncordonServer() can be run only by users with `Admin` privileges.
+Since Neo4j 5.23, it can be run with the `SERVER MANAGEMENT` privilege.
+It will still run with the `Admin` privilege, but that should be considered deprecated.
+====
+
+[[procedure_dbms_cluster_switchdiscoveryserviceversion]]
+[role=label--enterprise-edition label--admin-only label--new-5.22]
+.dbms.cluster.switchDiscoveryServiceVersion()
+[cols="<15s,<85"]
+|===
+| Description
+a| Allows you to select which discovery service should be started.
+Possible values are:
+
+* `V1_ONLY` -- it runs only discovery service v1.
+* `V1_OVER_V2` -- it runs both Discovery Service V1 and Discovery Service V2, where V1 is the main service and V2 runs in the background.
+* `V2_OVER_V1` -- it runs both Discovery Service V1 and Discovery Service V2, where V2 is the main service and V1 runs in the background.
+* `V2_ONLY` -- it runs only discovery service v2.
+| Signature
+m| dbms.cluster.switchDiscoveryServiceVersion(mode :: STRING)
+| Mode
+m|DBMS
+|===
+
+[[procedure_dbms_cluster_showparalleldiscoverystate]]
+[role=label--enterprise-edition label--admin-only label--new-5.22]
+.dbms.cluster.showParallelDiscoveryState()
+[cols="<15s,<85"]
+|===
+| Description
+a| Compare the states of Discovery service V1 and Discovery service V2.
+| Signature
+m| dbms.cluster.showParallelDiscoveryState() :: (mode :: STRING, stateComparison :: STRING)
+| Mode
+m|DBMS
+|===
+
+
 [[procedure_dbms_cluster_deallocateDatabaseFromServer]]
 [role=label--enterprise-edition label--admin-only]
 .dbms.cluster.deallocateDatabaseFromServer()

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -293,6 +293,31 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING, resourceType ::
 | label:yes[]
 | label:admin-only[] label:new[Introduced in 5.22]
 
+| xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabase[`dbms.cluster.deallocateDatabase()`]
+| label:no[]
+| label:yes[]
+| label:admin-only[]
+
+| xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServers[`dbms.cluster.deallocateDatabaseFromServers()`]
+| label:no[]
+| label:yes[]
+| label:admin-only[]
+
+| xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateNumberOfDatabases[`dbms.cluster.deallocateNumberOfDatabases()`]
+| label:no[]
+| label:yes[]
+| label:admin-only[]
+
+| xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase()`]
+| label:no[]
+| label:yes[]
+| label:admin-only[]
+
+| xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[`dbms.cluster.reallocateNumberOfDatabases()`]
+| label:no[]
+| label:yes[]
+| label:admin-only[]
+
 | xref:reference/procedures.adoc#procedure_dbms_components[`dbms.components()`]
 | label:yes[]
 | label:yes[]
@@ -1834,44 +1859,74 @@ m|WRITE
 a|xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE SERVER`]
 |===
 
-[NOTE]
-====
-Before Neo4j 5.23, the procedure `dbms.cluster.uncordonServer()` can be run only by users with `Admin` privileges.
-Since Neo4j 5.23, it can be run with the `SERVER MANAGEMENT` privilege.
-It will still run with the `Admin` privilege, but that should be considered deprecated.
-====
-
-[[procedure_dbms_cluster_switchdiscoveryserviceversion]]
-[role=label--enterprise-edition label--admin-only label--new-5.22]
-.dbms.cluster.switchDiscoveryServiceVersion()
+[[procedure_dbms_cluster_deallocateDatabase]]
+[role=label--enterprise-edition label--admin-only]
+.dbms.cluster.deallocateDatabase()
 [cols="<15s,<85"]
 |===
 | Description
-a| Allows you to select which discovery service should be started.
-Possible values are:
-
-* `V1_ONLY` -- it runs only discovery service v1.
-* `V1_OVER_V2` -- it runs both Discovery Service V1 and Discovery Service V2, where V1 is the main service and V2 runs in the background.
-* `V2_OVER_V1` -- it runs both Discovery Service V1 and Discovery Service V2, where V2 is the main service and V1 runs in the background.
-* `V2_ONLY` -- it runs only discovery service v2.
+a| Deallocate a specific user database on a specific server.
 | Signature
-m| dbms.cluster.switchDiscoveryServiceVersion(mode :: STRING)
+m| dbms.cluster.deallocateDatabase(server :: STRING, database :: STRING)
 | Mode
-m|DBMS
+m|WRITE
 |===
 
-[[procedure_dbms_cluster_showparalleldiscoverystate]]
-[role=label--enterprise-edition label--admin-only label--new-5.22]
-.dbms.cluster.showParallelDiscoveryState()
+
+[[procedure_dbms_cluster_deallocateDatabaseFromServers]]
+[role=label--enterprise-edition label--admin-only]
+.dbms.cluster.deallocateDatabaseFromServers()
 [cols="<15s,<85"]
 |===
 | Description
-a| Compare the states of Discovery service V1 and Discovery service V2.
+a| Deallocate a specific user database on a list of servers.
 | Signature
-m| dbms.cluster.showParallelDiscoveryState() :: (mode :: STRING, stateComparison :: STRING)
+m| dbms.cluster.deallocateDatabaseFromServers(servers :: LIST<STRING>, database :: STRING)
 | Mode
-m|DBMS
+m|WRITE
 |===
+
+[[procedure_dbms_cluster_deallocateNumberOfDatabases]]
+[role=label--enterprise-edition label--admin-only]
+.dbms.cluster.deallocateNumberOfDatabases()
+[cols="<15s,<85"]
+|===
+| Description
+a| Deallocate a number of user databases from a specific server. The databases to be deallocated are selected randomly.
+| Signature
+m| dbms.cluster.deallocateNumberOfDatabases(server :: STRING, number :: INTEGER)
+| Mode
+m|WRITE
+|===
+
+
+[[procedure_dbms_cluster_reallocateDatabase]]
+[role=label--enterprise-edition label--admin-only]
+.dbms.cluster.reallocateDatabase()
+[cols="<15s,<85"]
+|===
+| Description
+a| Reallocate a specific database.
+| Signature
+m| dbms.cluster.reallocateDatabase(database :: STRING)
+| Mode
+m|WRITE
+|===
+
+
+[[procedure_dbms_cluster_reallocateNumberOfDatabases]]
+[role=label--enterprise-edition label--admin-only]
+.dbms.cluster.reallocateNumberOfDatabases()
+[cols="<15s,<85"]
+|===
+| Description
+a| Reallocate a specified number of user databases.
+| Signature
+m| dbms.cluster.reallocateNumberOfDatabases(number :: INTEGER)
+| Mode
+m|WRITE
+|===
+
 
 [[procedure_dbms_components]]
 .dbms.components()

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -296,27 +296,27 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING, resourceType ::
 | xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServer[`dbms.cluster.deallocateDatabaseFromServer()`]
 | label:no[]
 | label:yes[]
-| label:new[Introduced in 5.23]
+| label:new[Introduced in 5.23] label:server-management[`SERVER MANAGEMENT` privilege only]
 
 | xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServers[`dbms.cluster.deallocateDatabaseFromServers()`]
 | label:no[]
 | label:yes[]
-| label:new[Introduced in 5.23]
+| label:new[Introduced in 5.23] label:server-management[`SERVER MANAGEMENT` privilege only]
 
 | xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateNumberOfDatabases[`dbms.cluster.deallocateNumberOfDatabases()`]
 | label:no[]
 | label:yes[]
-| label:new[Introduced in 5.23]
+| label:new[Introduced in 5.23] label:server-management[`SERVER MANAGEMENT` privilege only]
 
 | xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase()`]
 | label:no[]
 | label:yes[]
-| label:new[Introduced in 5.23]
+| label:new[Introduced in 5.23] label:server-management[`SERVER MANAGEMENT` privilege only]
 
 | xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[`dbms.cluster.reallocateNumberOfDatabases()`]
 | label:no[]
 | label:yes[]
-| label:new[Introduced in 5.23]
+| label:new[Introduced in 5.23] label:server-management[`SERVER MANAGEMENT` privilege only]
 
 | xref:reference/procedures.adoc#procedure_dbms_components[`dbms.components()`]
 | label:yes[]
@@ -1911,6 +1911,7 @@ m| dbms.cluster.deallocateDatabaseFromServer(server :: STRING, database :: STRIN
 m|WRITE
 |===
 
+This procedure requires the `SERVER MANAGEMENT` privilege.
 
 [[procedure_dbms_cluster_deallocateDatabaseFromServers]]
 [role=label--enterprise-edition label--new-5.23]
@@ -1925,6 +1926,8 @@ m| dbms.cluster.deallocateDatabaseFromServers(servers :: LIST<STRING>, database 
 m|WRITE
 |===
 
+This procedure requires the `SERVER MANAGEMENT` privilege.
+
 [[procedure_dbms_cluster_deallocateNumberOfDatabases]]
 [role=label--enterprise-edition label--new-5.23]
 .dbms.cluster.deallocateNumberOfDatabases()
@@ -1938,6 +1941,7 @@ m| dbms.cluster.deallocateNumberOfDatabases(server :: STRING, number :: INTEGER,
 m|WRITE
 |===
 
+This procedure requires the `SERVER MANAGEMENT` privilege.
 
 [[procedure_dbms_cluster_reallocateDatabase]]
 [role=label--enterprise-edition label--new-5.23]
@@ -1951,6 +1955,8 @@ m| dbms.cluster.reallocateDatabase(database :: STRING, dryrun = false :: BOOLEAN
 | Mode
 m|WRITE
 |===
+
+This procedure requires the `SERVER MANAGEMENT` privilege.
 
 
 [[procedure_dbms_cluster_reallocateNumberOfDatabases]]
@@ -1966,6 +1972,7 @@ m| dbms.cluster.reallocateNumberOfDatabases(number :: INTEGER, dryrun = false ::
 m|WRITE
 |===
 
+This procedure requires the `SERVER MANAGEMENT` privilege.
 
 [[procedure_dbms_components]]
 .dbms.components()

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -1865,9 +1865,9 @@ a|xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE SERVER`]
 [cols="<15s,<85"]
 |===
 | Description
-a| Deallocate a specific user database on a specific server.
+a| Deallocate a specific user database from a specific server.
 | Signature
-m| dbms.cluster.deallocateDatabaseFromServer(server :: STRING, database :: STRING)
+m| dbms.cluster.deallocateDatabaseFromServer(server :: STRING, database :: STRING, dryrun = false :: BOOLEAN) :: (database :: STRING, fromServerName :: STRING, fromServerId :: STRING, toServerName :: STRING, toServerId :: STRING, mode :: STRING)
 | Mode
 m|WRITE
 |===
@@ -1879,9 +1879,9 @@ m|WRITE
 [cols="<15s,<85"]
 |===
 | Description
-a| Deallocate a specific user database on a list of servers.
+a| Deallocate a specific user database from a list of servers.
 | Signature
-m| dbms.cluster.deallocateDatabaseFromServers(servers :: LIST<STRING>, database :: STRING)
+m| dbms.cluster.deallocateDatabaseFromServers(servers :: LIST<STRING>, database :: STRING, dryrun = false :: BOOLEAN) :: (database :: STRING, fromServerName :: STRING, fromServerId :: STRING, toServerName :: STRING, toServerId :: STRING, mode :: STRING)
 | Mode
 m|WRITE
 |===
@@ -1894,7 +1894,7 @@ m|WRITE
 | Description
 a| Deallocate a number of user databases from a specific server.
 | Signature
-m| dbms.cluster.deallocateNumberOfDatabases(server :: STRING, number :: INTEGER)
+m| dbms.cluster.deallocateNumberOfDatabases(server :: STRING, number :: INTEGER, dryrun = false :: BOOLEAN) :: (database :: STRING, fromServerName :: STRING, fromServerId :: STRING, toServerName :: STRING, toServerId :: STRING, mode :: STRING)
 | Mode
 m|WRITE
 |===
@@ -1908,7 +1908,7 @@ m|WRITE
 | Description
 a| Reallocate a specific database.
 | Signature
-m| dbms.cluster.reallocateDatabase(database :: STRING)
+m| dbms.cluster.reallocateDatabase(database :: STRING, dryrun = false :: BOOLEAN) :: (database :: STRING, fromServerName :: STRING, fromServerId :: STRING, toServerName :: STRING, toServerId :: STRING, mode :: STRING)
 | Mode
 m|WRITE
 |===
@@ -1922,7 +1922,7 @@ m|WRITE
 | Description
 a| Reallocate a specified number of user databases.
 | Signature
-m| dbms.cluster.reallocateNumberOfDatabases(number :: INTEGER)
+m| dbms.cluster.reallocateNumberOfDatabases(number :: INTEGER, dryrun = false :: BOOLEAN) :: (database :: STRING, fromServerName :: STRING, fromServerId :: STRING, toServerName :: STRING, toServerId :: STRING, mode :: STRING)"
 | Mode
 m|WRITE
 |===

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -286,37 +286,37 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING, resourceType ::
 | xref:reference/procedures.adoc#procedure_dbms_cluster_switchdiscoveryserviceversion[`dbms.cluster.switchDiscoveryServiceVersion()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[] label:new[Introduced in 5.22]
+| label:new[Introduced in 5.22] label:admin-only[]
 
 | xref:reference/procedures.adoc#procedure_dbms_cluster_showparalleldiscoverystate[`dbms.cluster.showParallelDiscoveryState()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[] label:new[Introduced in 5.22]
+| label:new[Introduced in 5.22] label:admin-only[]
 
-| xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabase[`dbms.cluster.deallocateDatabase()`]
+| xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServer[`dbms.cluster.deallocateDatabaseFromServer()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[]
+| label:new[Introduced in 5.23]
 
 | xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServers[`dbms.cluster.deallocateDatabaseFromServers()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[]
+| label:new[Introduced in 5.23]
 
 | xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateNumberOfDatabases[`dbms.cluster.deallocateNumberOfDatabases()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[]
+| label:new[Introduced in 5.23]
 
 | xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[]
+| label:new[Introduced in 5.23]
 
 | xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[`dbms.cluster.reallocateNumberOfDatabases()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[]
+| label:new[Introduced in 5.23]
 
 | xref:reference/procedures.adoc#procedure_dbms_components[`dbms.components()`]
 | label:yes[]
@@ -1861,13 +1861,13 @@ a|xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE SERVER`]
 
 [NOTE]
 ====
-Before Neo4j 5.23, the procedure dbms.cluster.uncordonServer() can be run only by users with `Admin` privileges.
+Before Neo4j 5.23, the procedure `dbms.cluster.uncordonServer()` can be run only by users with `Admin` privileges.
 Since Neo4j 5.23, it can be run with the `SERVER MANAGEMENT` privilege.
 It will still run with the `Admin` privilege, but that should be considered deprecated.
 ====
 
 [[procedure_dbms_cluster_switchdiscoveryserviceversion]]
-[role=label--enterprise-edition label--admin-only label--new-5.22]
+[role=label--enterprise-edition label--new-5.22 label--admin-only]
 .dbms.cluster.switchDiscoveryServiceVersion()
 [cols="<15s,<85"]
 |===
@@ -1886,7 +1886,7 @@ m|DBMS
 |===
 
 [[procedure_dbms_cluster_showparalleldiscoverystate]]
-[role=label--enterprise-edition label--admin-only label--new-5.22]
+[role=label--enterprise-edition label--new-5.22 label--admin-only ]
 .dbms.cluster.showParallelDiscoveryState()
 [cols="<15s,<85"]
 |===
@@ -1898,9 +1898,8 @@ m| dbms.cluster.showParallelDiscoveryState() :: (mode :: STRING, stateComparison
 m|DBMS
 |===
 
-
 [[procedure_dbms_cluster_deallocateDatabaseFromServer]]
-[role=label--enterprise-edition label--admin-only]
+[role=label--enterprise-edition label--new-5.23]
 .dbms.cluster.deallocateDatabaseFromServer()
 [cols="<15s,<85"]
 |===
@@ -1914,7 +1913,7 @@ m|WRITE
 
 
 [[procedure_dbms_cluster_deallocateDatabaseFromServers]]
-[role=label--enterprise-edition label--admin-only]
+[role=label--enterprise-edition label--new-5.23]
 .dbms.cluster.deallocateDatabaseFromServers()
 [cols="<15s,<85"]
 |===
@@ -1927,7 +1926,7 @@ m|WRITE
 |===
 
 [[procedure_dbms_cluster_deallocateNumberOfDatabases]]
-[role=label--enterprise-edition label--admin-only]
+[role=label--enterprise-edition label--new-5.23]
 .dbms.cluster.deallocateNumberOfDatabases()
 [cols="<15s,<85"]
 |===
@@ -1941,7 +1940,7 @@ m|WRITE
 
 
 [[procedure_dbms_cluster_reallocateDatabase]]
-[role=label--enterprise-edition label--admin-only]
+[role=label--enterprise-edition label--new-5.23]
 .dbms.cluster.reallocateDatabase()
 [cols="<15s,<85"]
 |===
@@ -1955,7 +1954,7 @@ m|WRITE
 
 
 [[procedure_dbms_cluster_reallocateNumberOfDatabases]]
-[role=label--enterprise-edition label--admin-only]
+[role=label--enterprise-edition label--new-5.23]
 .dbms.cluster.reallocateNumberOfDatabases()
 [cols="<15s,<85"]
 |===

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -2192,7 +2192,7 @@ m|DBMS
 
 
 [[procedure_dbms_setDatabaseAllocator]]
-[role=label--enterprise-edition label--admin-only]
+[role=label--enterprise-edition label--admin-only label--deprecated-5.23]
 .dbms.setDatabaseAllocator()
 [cols="<15s,<85"]
 |===

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -412,7 +412,7 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING, resourceType ::
 | xref:reference/procedures.adoc#procedure_dbms_setDatabaseAllocator[`dbms.setDatabaseAllocator()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[] label:deprecated-in-5.23[Deprecated in 5.23]
+| label:admin-only[]
 
 | xref:reference/procedures.adoc#procedure_dbms_setDefaultAllocationNumbers[`dbms.setDefaultAllocationNumbers()`]
 | label:no[]
@@ -2192,7 +2192,7 @@ m|DBMS
 
 
 [[procedure_dbms_setDatabaseAllocator]]
-[role=label--enterprise-edition label--admin-only label--deprecated-5.23]
+[role=label--enterprise-edition label--admin-only]
 .dbms.setDatabaseAllocator()
 [cols="<15s,<85"]
 |===


### PR DESCRIPTION
In this PR, we want to add documentation for the following cluster procedures:

```
dbms.cluster.deallocateDatabaseFromServer(server, database, dryrun)
dbms.cluster.deallocateNumberOfDatabases(server, number, dryrun)
dbms.cluster.deallocateDatabaseFromServers(servers, database, dryrun)
dbms.cluster.reallocateDatabase(database, dryrun)
dbms.cluster.reallocateNumberOfDatabases(number, dryrun)
```

We also add some scenarios in which a user might use these new procedures for