### PR TITLE
Replace deprecated apt-key with keyrings

### DIFF
--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -87,8 +87,8 @@ The Debian package is available from https://debian.neo4j.com.
 +
 [source, shell]
 ----
-wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
-echo 'deb https://debian.neo4j.com stable latest' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
+wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/neotechnology.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/neotechnology.gpg] https://debian.neo4j.com stable latest' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
 sudo apt-get update
 ----
 +
@@ -99,8 +99,8 @@ The following method for production or business-critical installations is recomm
 +
 [source, shell, subs="attributes"]
 ----
-wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
-echo 'deb https://debian.neo4j.com stable {neo4j-version}' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
+wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/neotechnology.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/neotechnology.gpg] https://debian.neo4j.com stable {neo4j-version}' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
 sudo apt-get update
 ----
 


### PR DESCRIPTION
The way the repository was being added to Debian-based systems has been deprecated; this change keeps it in compliance with best practices and keeps your apt-update from yelling at you. 

### References
* [Linux Uprising | apt-key Is Deprecated. How To Add OpenPGP Repository Signing Keys Without It On Debian, Ubuntu, Linux Mint, Pop!_OS, Etc.](https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html)
* [opensource.com | Fix the apt-key deprecation error in Linux](https://opensource.com/article/22/9/deprecated-linux-apt-key)
* [Ask Ubuntu | What commands (exactly) should replace the deprecated apt-key?](https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key)