### PR TITLE
clarifying that `auth_cache_ttl` abd `use_ttl` applies to OIDC too

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -3856,7 +3856,7 @@ m|+++10000+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|The time to live (TTL) for cached authentication and authorization info when using external auth providers (LDAP or plugin). Setting the TTL to 0 will disable auth caching. Disabling caching while using the LDAP auth provider requires the use of an LDAP system account for resolving authorization information.
+a|The time to live (TTL) for cached authentication and authorization info when using external auth providers (OIDC, LDAP or plugin). Setting the TTL to 0 will disable auth caching. Disabling caching while using the LDAP auth provider requires the use of an LDAP system account for resolving authorization information.
 |Valid values
 a|A duration (Valid units are: `ns`, `μs`, `ms`, `s`, `m`, `h` and `d`; default unit is `s`).
 |Default value
@@ -3874,7 +3874,7 @@ m|+++10m+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|Enable time-based eviction of the authentication and authorization info cache for external auth providers (LDAP or plugin). Disabling this setting will make the cache live forever and only be evicted when `<<config_dbms.security.auth_cache_max_capacity,dbms.security.auth_cache_max_capacity>>` is exceeded.
+a|Enable time-based eviction of the authentication and authorization info cache for external auth providers (OIDC, LDAP or plugin). Disabling this setting will make the cache live forever and only be evicted when `<<config_dbms.security.auth_cache_max_capacity,dbms.security.auth_cache_max_capacity>>` is exceeded.
 |Valid values
 a|A boolean.
 |Default value


### PR DESCRIPTION
relates to https://github.com/neo-technology/neo4j/pull/26373
