### PR TITLE
updated netty compatibility table for SSL usage

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -47,7 +47,7 @@ See the table below for detailed information:
 | tcnative version
 | Direct link
 
-| 4.4.35
+| 4.4.36
 | 4.1.111.Final
 | 2.0.65.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
 | https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.65.Final/jar
@@ -55,15 +55,45 @@ https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.65.Final/j
 
 | 4.4.27
 | 4.1.100.Final
-| 2.0.65.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.65.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.65.Final/jar
+| 2.0.61.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.61.Final/jar
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.61.Final/jar
 
-| 4.4.9
+| 4.4.24
+| 4.1.94.Final
+| 2.0.61.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.61.Final/jar
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.61.Final/jar
+
+| 4.4.16
+| 4.1.86.Final
+| 2.0.54.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.54.Final/jar
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.54.Final/jar
+
+| 4.4.10
 | 4.1.77.Final
 | 2.0.52.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
 | https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.52.Final/jar
 https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.52.Final/jar
+
+| 4.4.6
+| 4.1.75.Final
+| 2.0.50.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.50.Final/jar
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.50.Final/jar
+
+| 4.4.4
+| 4.1.73.Final
+| 2.0.46.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.46.Final/jar
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.46.Final/jar
+
+| 4.4.0
+| 4.1.69.Final
+| 2.0.44.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.44.Final/jar
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.44.Final/jar
 |===
 
 


### PR DESCRIPTION
it's a bit complicated to describe the table though, because the paragraph before makes it sound like all Neo4j versions except the ones listed use netty 4.1.11.

But the reality is that:
- 4.4.27 to 4.4.35 use netty 4.1.100.Final
- 4.4.24 to 4.4.26 use netty 4.1.94.Final
- 4.4.16 to 4.4.23 use netty 4.1.86.Final
- 4.4.10 to 4.4.15 use netty 4.1.86.Final
- etc
I'm not sure what the best way to describe that would be.