### PR TITLE
Add a caution about REALLOCATE DATABASES moving too much

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -166,7 +166,8 @@ To rebalance all database allocations across the cluster, for example, because y
 [[reallocate-databases-procedure]]
 === Reallocate databases using a procedure
 
-You can use the procedure xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase`] to evaluate offloading a specific database from all servers containing it onto new servers or xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[dbms.cluster.reallocateNumberOfDatabases] to rebalance all database allocations across the cluster and relieve overloaded servers.
+You can use the procedure xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase`] to rebalance a specific database across the cluster, or xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[dbms.cluster.reallocateNumberOfDatabases] to rebalance a number of database allocations across the cluster and relieve overloaded servers.
+Note that if the cluster is already balanced, no reallocations will happen when running these procedures.
 These procedures do not require a server name and can be executed with or without a dry run.
 
 [NOTE]

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -166,7 +166,7 @@ To rebalance all database allocations across the cluster, for example, because y
 [[reallocate-databases-procedure]]
 === Reallocate databases using a procedure
 
-You can use the procedure xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase`] to rebalance a specific database across the cluster, or xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[dbms.cluster.reallocateNumberOfDatabases] to rebalance a number of database allocations across the cluster and relieve overloaded servers.
+You can use the procedure xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase`] to rebalance a specific database across the cluster, or xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[`dbms.cluster.reallocateNumberOfDatabases`] to rebalance a number of database allocations across the cluster and relieve overloaded servers.
 Note that if the cluster is already balanced, no reallocations will happen when running these procedures.
 These procedures do not require a server name and can be executed with or without a dry run.
 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -206,7 +206,7 @@ This command can also be used with `DRYRUN` to preview the new allocation of dat
 [CAUTION]
 ====
 `REALLOCATE DATABASES` on a large cluster with many databases has the potential to move a lot of allocations at once, which might stress the cluster.
-Consider starting with more limited reallocations, such as xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[dbms.cluster.reallocateNumberOfDatabases] with a small number, and let the databases complete their reallocation before calling it again, until no more reallocations are necessary.
+Consider starting with more limited reallocations, such as xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[`dbms.cluster.reallocateNumberOfDatabases`] with a small number, and let the databases complete their reallocation before calling it again, until no more reallocations are necessary.
 ====
 
 [NOTE]

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -166,7 +166,7 @@ To rebalance all database allocations across the cluster, for example, because y
 [[reallocate-databases-procedure]]
 === Reallocate databases using a procedure
 
-You can use the procedure xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase()`] to offload a specific database from all servers containing it onto new servers or xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[dbms.cluster.reallocateNumberOfDatabases] to rebalance all database allocations across the cluster and relieve overloaded servers.
+You can use the procedure xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateDatabase[`dbms.cluster.reallocateDatabase`] to evaluate offloading a specific database from all servers containing it onto new servers or xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[dbms.cluster.reallocateNumberOfDatabases] to rebalance all database allocations across the cluster and relieve overloaded servers.
 These procedures do not require a server name and can be executed with or without a dry run.
 
 [NOTE]
@@ -201,6 +201,12 @@ neo4j@system> CALL dbms.cluster.reallocateNumberOfDatabases(3);
 
 You can use the Cypher command `REALLOCATE DATABASES` to rebalance all database allocations across the cluster and relieve overloaded servers.
 This command can also be used with `DRYRUN` to preview the new allocation of databases.
+
+[WARNING]
+====
+`REALLOCATE DATABASES` on a large cluster with many databases has the potential to move a lot of allocations at once, which might stress the cluster.
+Consider starting with more limited reallocations, such as xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[dbms.cluster.reallocateNumberOfDatabases] with a small number, and let the databases complete their reallocation before calling it again, until no more reallocations are necessary.
+====
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -202,7 +202,7 @@ neo4j@system> CALL dbms.cluster.reallocateNumberOfDatabases(3);
 You can use the Cypher command `REALLOCATE DATABASES` to rebalance all database allocations across the cluster and relieve overloaded servers.
 This command can also be used with `DRYRUN` to preview the new allocation of databases.
 
-[WARNING]
+[CAUTION]
 ====
 `REALLOCATE DATABASES` on a large cluster with many databases has the potential to move a lot of allocations at once, which might stress the cluster.
 Consider starting with more limited reallocations, such as xref:reference/procedures.adoc#procedure_dbms_cluster_reallocateNumberOfDatabases[dbms.cluster.reallocateNumberOfDatabases] with a small number, and let the databases complete their reallocation before calling it again, until no more reallocations are necessary.


### PR DESCRIPTION
If there are lots of databases to move, an unbounded REALLOCATE can be stressful for the cluster and the databases involved. With the newly public limited reallocate procedures, they provide a gentler way to achieve the balancing incrementally.