### PR TITLE
adding health warning about insecure protocols for LOAD CSV

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/load-privileges.adoc
+++ b/modules/ROOT/pages/authentication-authorization/load-privileges.adoc
@@ -65,7 +65,7 @@ To only allow loading data from sources given by a specific CIDR range use `ON C
 It is strongly recommended to permit resource loading only over secure protocols such as HTTPS instead of insecure protocols like HTTP.
 This can be done by limiting the accessible ranges to only trusted sources that use secure protocols.
 If allowing an insecure protocol is absolutely unavoidable, Neo4j takes measures internally to enhance the security of these requests within their limitations.
-However, this means that insecure URLs on virtual hosts will not function unless you add the JVM argument `-Dsun.net.http.allowRestrictedHeaders=true` to the configuration setting link:{neo4j-docs-base-uri}/operations-manual/{page-version}/configuration/configuration-settings/#config_server.jvm.additional/[jvm.additional].
+However, this means that insecure URLs on virtual hosts will not function unless you add the JVM argument `-Dsun.net.http.allowRestrictedHeaders=true` to the configuration setting xref:configuration/configuration-settings.adoc#config_server.jvm.additional[server.jvm.additional].
 ====
 
 [[access-control-load-all-data]]

--- a/modules/ROOT/pages/authentication-authorization/load-privileges.adoc
+++ b/modules/ROOT/pages/authentication-authorization/load-privileges.adoc
@@ -65,7 +65,7 @@ To only allow loading data from sources given by a specific CIDR range use `ON C
 It is strongly recommended to permit resource loading only over secure protocols such as HTTPS instead of insecure protocols like HTTP.
 This can be done by limiting the accessible ranges to only trusted sources that use secure protocols.
 If allowing an insecure protocol is absolutely unavoidable, Neo4j takes measures internally to enhance the security of these requests within their limitations.
-However, this means that insecure URLs on virtual hosts will not function unless you add the JVM argument `-Dsun.net.http.allowRestrictedHeaders=true` to the configuration setting xref:configuration/configuration-settings.adoc#config_server.jvm.additional[server.jvm.additional].
+However, this means that insecure URLs on virtual hosts will not function unless you add the JVM argument `-Dsun.net.http.allowRestrictedHeaders=true` to the configuration setting xref:configuration/configuration-settings.adoc#config_server.jvm.additional[`server.jvm.additional`].
 ====
 
 [[access-control-load-all-data]]

--- a/modules/ROOT/pages/authentication-authorization/load-privileges.adoc
+++ b/modules/ROOT/pages/authentication-authorization/load-privileges.adoc
@@ -60,6 +60,14 @@ Unlike other privileges, the `LOAD` privilege is not granted, denied, or revoked
 Adding `ON ALL DATA` means a role has the privilege to load data from all sources.
 To only allow loading data from sources given by a specific CIDR range use `ON CIDR cidr`.
 
+[IMPORTANT]
+====
+It is strongly recommended to permit resource loading only over secure protocols such as HTTPS instead of insecure protocols like HTTP.
+This can be done by limiting the accessible ranges to only trusted sources that use secure protocols.
+If allowing an insecure protocol is absolutely unavoidable, Neo4j takes measures internally to enhance the security of these requests within their limitations.
+However, this means that insecure URLs on virtual hosts will not function unless you add the JVM argument `-Dsun.net.http.allowRestrictedHeaders=true` to the configuration setting link:{neo4j-docs-base-uri}/operations-manual/{page-version}/configuration/configuration-settings/#config_server.jvm.additional/[jvm.additional].
+====
+
 [[access-control-load-all-data]]
 == The `ALL DATA` privilege
 


### PR DESCRIPTION
adds a warning against allowing insecure protocols for `LOAD CSV`

this PR is the operations manual copy of the [cypher manual equivalent](https://github.com/neo4j/docs-cypher/pull/1006)