### PR TITLE
Remove the config `db.logs.query.time_logging_enabled`

### DIFF
--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -803,10 +803,6 @@ The following configuration settings are available for the query logging:
 | Default value
 | Description
 
-| xref:configuration/configuration-settings.adoc#config_db.logs.query.time_logging_enabled[`db.logs.query.time_logging_enabled`]
-| `true`
-| Include the time taken for the executed queries to be logged (this is enabled by default).
-
 | xref:configuration/configuration-settings.adoc#config_db.logs.query.early_raw_logging_enabled[`db.logs.query.early_raw_logging_enabled`]
 | `false`
 a|


### PR DESCRIPTION
Remove the configuration setting from the table as it was removed in 5.0 (see [PR#16649](https://github.com/neo-technology/neo4j/pull/16649))