### PR TITLE
Netty and tcnative files are included in the /lib directory from v5.21 (#1801)

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -36,7 +36,7 @@ For more details, see the <<table, Netty support per Neo4j version>>.
 
 [NOTE]
 ====
-From Neo4j 5.12 on, required Netty and tcnative files are included in the _/lib_ directory.
+From Neo4j 5.21 on, required Netty and tcnative files are included in the _/lib_ directory.
 ====
 
 The following table includes detailed information about supported Neo4j versions:


### PR DESCRIPTION
Cherry-picked from #1801 