### PR TITLE
New SSL instructions for FIPS compatibility

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -190,6 +190,7 @@
 * xref:security/index.adoc[]
 ** xref:security/securing-extensions.adoc[]
 ** xref:security/ssl-framework.adoc[]
+*** xref:security/ssl-fips-compatibility.adoc[]
 ** xref:security/browser.adoc[]
 ** xref:security/checklist.adoc[]
 

--- a/modules/ROOT/pages/configuration/file-locations.adoc
+++ b/modules/ROOT/pages/configuration/file-locations.adoc
@@ -8,6 +8,8 @@
 
 The page describes the Neo4j directories, specifying their default locations per distribution and minimal file permissions.
 
+If Neo4j was installed using a `tar.gz` or `zip` archive,  _<NEO4J_HOME>_ refers to the location the archive was extracted to.
+
 Instructions provided for Neo4j Desktop are applicable across all operating systems where Neo4j Desktop is supported.
 
 [NOTE]

--- a/modules/ROOT/pages/docker/introduction.adoc
+++ b/modules/ROOT/pages/docker/introduction.adoc
@@ -11,8 +11,6 @@ Variants of the Neo4j image are tagged according to
 Community/Enterprise Edition and the operating system used as the base image.
 
 
-All supported tags can be found at https://hub.docker.com/_/neo4j/tags.
-
 === Neo4j editions
 Tags are available for both Community Edition and Enterprise Edition.
 Version-specific Enterprise Edition tags have an `-enterprise` suffix after the version number, for example: `neo4j:{neo4j-version-exact}-enterprise`.

--- a/modules/ROOT/pages/security/ssl-fips-compatibility.adoc
+++ b/modules/ROOT/pages/security/ssl-fips-compatibility.adoc
@@ -1,0 +1,182 @@
+:description: How to configure Neo4j to use FIPS compatible SSL encryption.
+[role=enterprise-edition]
+[[ssl-fips-compatibility]]
+= Configuring SSL for FIPS 140-2 compatibility
+
+Federal Information Processing Standards (FIPS) is ...
+
+https://csrc.nist.gov/pubs/fips/140-2/upd2/final
+
+This is a guide to help configure Neo4j to use SSL encryption in a FIPS compatible way.
+It is supplementary to xref:security/ssl-framework.adoc[] as many of the configuration processes and requirements are the same.
+
+. Enable a FIPS certified cryptographic provider
+. Generate SSL certificate and private key xref:security/ssl-framework.adoc#ssl-certificates[instructions]
+. Configure Neo4j to use SSL for all network connections xref:security/ssl-framework.adoc#ssl-configuration[]
+. Setup a non-native authentication provider, for example LDAP or SSO. xref:authentication-authorization/index.adoc[]
+. verify?
+. security checklist? (cross ref)
+
+
+== Prerequisites
+TODO
+
+* FIPS compatible operating system and hardware. Only Linux operating systems are supported for Neo4j FIPS compatibility at this time.
+* Neo4j Enterprise 5.23.0 or later.
+
+== Enable FIPS SSL Provider (Docker)
+
+The Neo4j RedHat UBI9 Docker image comes with the SSL provider and dependencies pre-installed, but it is not enabled by default.
+
+[NOTE]
+====
+The Debian based Neo4j Docker image does *not* support FIPS compatible encryption.
+====
+
+To enable the OpenSSL FIPS provider, set the environment variable `NEO4J_OPENSSL_FIPS_ENABLE=true` when starting the container.
+
+[source, shell, subs="attributes"]
+.Example starting a Neo4j UBI9 container with FIPS enable flag set.
+----
+docker run -it --rm \
+    --publish=7474:7474 \
+    --publish=7687:7687 \
+    --env=NEO4J_OPENSSL_FIPS_ENABLE=true \
+    --volume=$HOME/neo4j/data:/data \
+    --volume=$HOME/neo4j/conf:/conf \
+    --volume=$HOME/neo4j/certificates:/ssl \
+neo4j:{neo4j-version-exact}-enterprise-ubi9
+----
+
+== Enable FIPS SSL provider
+
+[IMPORTANT]
+====
+Skip this section if using Neo4j in Docker.
+====
+
+The secure networking in Neo4j is provided through the Netty library, which supports both the native JDK SSL provider as well as Netty-supported OpenSSL derivatives.
+Specifically Netty's "Forked Tomcat Native" library called https://github.com/netty/netty-tcnative[netty-tcnative].
+
+To be FIPS compatible, the dynamically linked version of `netty-tcnative` must be used, alongside a FIPS compatible installation of OpenSSL.
+
+The `netty-tcnative` library is provided in several variants, but
+to be FIPS compatible the dynamically linked version of `netty-tcnative` must be used.
+This dynamically linked library requires that the following dependencies are installedfootnote:[https://netty.io/wiki/forked-tomcat-native.html]:
+
+* Apache Portable Runtime Library
+* A FIPS certified version of OpenSSL, with a FIPS provider installed and set as default.
+
+Refer to https://netty.io/wiki/forked-tomcat-native.html for more information.
+
+
+[NOTE]
+====
+Netty provide a convenient pre-build, statically linked version of `netty-tcnative` using BoringSSL, but this is not FIPS certifiedfootnote:[https://boringssl.googlesource.com/boringssl/+/master/crypto/fipsmodule/FIPS.md].
+
+By using the dynamic `netty-tcnative` library variant combined with a FIPS certified OpenSSL installation, Neo4j's cryptographic operations are delegated by `netty-tcnative` to OpenSSL, transitively giving FIPS compatibility.
+====
+
+[[install-apr]]
+=== Install Apache portable runtime library
+
+The simplest way to install https://apr.apache.org[Apache Portable Runtime Library] is to use the operating system's package manager.
+
+In Debian/Ubuntu this package is usually called `libapr1`
+[source, shell, subs="attributes"]
+.Install Apache Portable Runtime Library in Debian or Ubuntu
+----
+apt install -y libapr1
+----
+
+In RedHat Enterprise Linux the package is usually called `apr`:
+
+[source, shell, subs="attributes"]
+.Install Apache Portable Runtime Library in RedHat
+----
+dnf install -y apr
+----
+
+=== Install OpenSSL
+
+Instructions on how to build and install a FIPS compatible OpenSSL are out of scope for this document. Installation steps can differ depending on operating system, and other security requirements you might have for OpenSSL.
+
+In general:
+
+* A list of FIPS certified OpenSSL versions can be found at https://openssl-library.org/source/
+* A FIPS provider must be installed into OpenSSL.
++
+See: https://github.com/openssl/openssl/blob/master/README-FIPS.md
+* OpenSSL must be configured to use the FIPS provider by default.
++
+See: https://docs.openssl.org/master/man7/fips_module/
+
+OpenSSL documentation can be found at:
+
+* https://openssl-library.org/
+
+and on the project's Github page:
+
+* https://github.com/openssl/openssl
+
+
+=== Install correct `netty-tcnative` library
+
+Since Neo4j 5.23.0, builds of `netty-tcnative` dynamic library are provided in
+the Neo4j `lib` directory under their own subfolder called `netty-tcnative`.
+
+Installation is just a case of copying the correct jar for the local machine's operating system and architecture into the
+
+To install the `netty-tcnative` dynamic library:
+
+. Locate the Neo4j `lib` directory.
++
+The location of the `lib` directory is different depending on the method used to install Neo4j. Check the xref:configuration/file-locations.adoc#neo4j-lib[file locations] documentation for the correct location.
++
+This location will be referred to as _<NEO4J_LIB>_.
++
+. BLAh
++
+[source, shell]
+.Check which netty-tcnative libraries are available
+----
+ls -l <NEO4J_LIB>/netty-tcnative
+----
+There should be
+
+
+2. verify jar
+3. copy jar to <neo4j_home>/lib
+
+
+
+<home>/lib/netty-tcnative
+copy the jar matching OS and arch to <home>/lib/
+xref:configuration/file-locations.adoc#neo4j-lib[]
+
+
+Finally, test the library by extracting the jar and using `ldd` to verify all its dependencies are met:
+eg
+[source, shell, subs="attributes"]
+----
+unzip -d /tmp /usr/share/neo4j/lib/netty-tcnative/netty-tcnative-*-linux-$(arch).jar
+ldd /tmp/META-INF/native/libnetty_tcnative_linux_*.so
+rm -rf /tmp/META-INF
+----
+The `ldd` command will show a list of `netty-tcnative` library dependencies and where they will be loaded from on the local machine.
+If any dependencies are missing, they must be installed or Neo4j will fail to run.
+
+
+== Generate SSL certificate and private key
+
+Neo4j SSL encryption requires a
+xref:security/ssl-framework.adoc#term-ssl-certificate[certificate] in the xref:security/ssl-framework.adoc#term-ssl-x509[X.509] standard, encoded in PEM format.
+and a private key in xref:security/ssl-framework.adoc#term-ssl-pkcs8[PKCS #8] format, also PEM encoded.
+
+For FIPS compatibility, the private key must also be secured with a passphrase.
+
+Refer to the xref:security/ssl-framework.adoc#ssl-certificates[SSL certificate and key instructions] for a detailed setup guide to creating the SSL certificate and key pair.
+
+== Configure Neo4j to use SSL encryption
+
+xxx

--- a/modules/ROOT/pages/security/ssl-fips-compatibility.adoc
+++ b/modules/ROOT/pages/security/ssl-fips-compatibility.adoc
@@ -1,28 +1,33 @@
-:description: How to configure Neo4j to use FIPS compatible SSL encryption.
 [role=enterprise-edition]
 [[ssl-fips-compatibility]]
 = Configuring SSL for FIPS 140-2 compatibility
+:description: How to configure Neo4j to use FIPS compatible SSL encryption.
+:keywords: ssl, tls, authentication, encryption, encrypted, security, fips, fips 140, fips 140-2, nist, hipaa
 
-Federal Information Processing Standards (FIPS) is ...
+Federal Information Processing Standards (FIPS) 140 is a U.S. government standard established by the National Institute of Standards and Technology (NIST) which is used to accredit cryptographic modules such as those used in TLS network encryption.  While FIPS 140 compliance is primarily required for federal agencies and their contractors, it also is used in the healthcare sector under regulations like the Health Insurance Portability and Accountability Act (HIPAA) to protect patient data.
 
-https://csrc.nist.gov/pubs/fips/140-2/upd2/final
+For more information see:
 
-This is a guide to help configure Neo4j to use SSL encryption in a FIPS compatible way.
-It is supplementary to xref:security/ssl-framework.adoc[] as many of the configuration processes and requirements are the same.
+* https://cloudsecurityalliance.org/blog/2023/03/23/what-is-fips-140-and-what-does-it-mean-to-be-fips-compliant
+* https://csrc.nist.gov/pubs/fips/140-2/upd2/final
 
-. Enable a FIPS certified cryptographic provider
-. Generate SSL certificate and private key xref:security/ssl-framework.adoc#ssl-certificates[instructions]
-. Configure Neo4j to use SSL for all network connections xref:security/ssl-framework.adoc#ssl-configuration[]
-. Setup a non-native authentication provider, for example LDAP or SSO. xref:authentication-authorization/index.adoc[]
-. verify?
-. security checklist? (cross ref)
+This is a guide to help configure Neo4j to use TLS / SSL encryption in a FIPS compatible way.
+It is supplementary to the xref:security/ssl-framework.adoc[] documentation, as many of the configuration processes and requirements are the same.
+
+// . Enable a FIPS certified cryptographic provider
+// . Generate SSL certificate and private key xref:security/ssl-framework.adoc#ssl-certificates[instructions]
+// . Configure Neo4j to use SSL for all network connections xref:security/ssl-framework.adoc#ssl-configuration[]
+// . Setup a non-native authentication provider, for example LDAP or SSO. xref:authentication-authorization/index.adoc[]
+// . verify?
 
 
 == Prerequisites
-TODO
 
-* FIPS compatible operating system and hardware. Only Linux operating systems are supported for Neo4j FIPS compatibility at this time.
+* Verify that the machine running Neo4j has FIPS compatible hardware and operating system.
+Only xref:installation/requirements.adoc#deployment-requirements-software[Linux operating systems] are supported for Neo4j FIPS compatibility at this time.
 * Neo4j Enterprise 5.23.0 or later.
+* Install and configure a non-native authentication provider, for example LDAP or SSO. See xref:authentication-authorization/index.adoc[].
+// * Follow the xref:security/checklist.adoc[] to ensure good security practices.
 
 == Enable FIPS SSL Provider (Docker)
 
@@ -105,8 +110,6 @@ In general:
 
 * A list of FIPS certified OpenSSL versions can be found at https://openssl-library.org/source/
 * A FIPS provider must be installed into OpenSSL.
-+
-See: https://github.com/openssl/openssl/blob/master/README-FIPS.md
 * OpenSSL must be configured to use the FIPS provider by default.
 +
 See: https://docs.openssl.org/master/man7/fips_module/
@@ -135,48 +138,134 @@ The location of the `lib` directory is different depending on the method used to
 +
 This location will be referred to as _<NEO4J_LIB>_.
 +
-. BLAh
+. Check which netty-tcnative libraries are available
 +
 [source, shell]
-.Check which netty-tcnative libraries are available
 ----
 ls -l <NEO4J_LIB>/netty-tcnative
 ----
-There should be
-
-
-2. verify jar
-3. copy jar to <neo4j_home>/lib
-
-
-
-<home>/lib/netty-tcnative
-copy the jar matching OS and arch to <home>/lib/
-xref:configuration/file-locations.adoc#neo4j-lib[]
-
-
-Finally, test the library by extracting the jar and using `ldd` to verify all its dependencies are met:
-eg
+There should be linux and fedora linux variants available, compiled for both x86_64 and arm64 architectures.
+Select the one matching the local machine's operating system and architecture.
++
+. Verify the dependencies are correctly installed using https://www.man7.org/linux/man-pages/man1/ldd.1.html[`ldd`]:
++
 [source, shell, subs="attributes"]
+.Verify netty-tcnative dependencies are installed
 ----
 unzip -d /tmp /usr/share/neo4j/lib/netty-tcnative/netty-tcnative-*-linux-$(arch).jar
 ldd /tmp/META-INF/native/libnetty_tcnative_linux_*.so
 rm -rf /tmp/META-INF
 ----
-The `ldd` command will show a list of `netty-tcnative` library dependencies and where they will be loaded from on the local machine.
-If any dependencies are missing, they must be installed or Neo4j will fail to run.
++
+[source, shell, subs="attributes"]
+.Verify fedora variant of netty-tcnative dependencies are installed
+----
+unzip -d /tmp /usr/share/neo4j/lib/netty-tcnative/netty-tcnative-*-linux-$(arch)-fedora.jar
+ldd /tmp/META-INF/native/libnetty_tcnative_linux_$(arch).so
+rm -rf /tmp/META-INF
+----
+The `ldd` command will show a list of library dependencies and where they will be loaded from on the local machine.
+** If any dependencies are missing, they must be installed or Neo4j will fail to run.
+** The `libssl.so` and `libcrypto.so` libraries listed must be the ones installed with OpenSSL in the previous steps.
++
+. Copy the verified jar to _<NEO4J_LIB>_.
++
+[NOTE]
+====
+Only copy *one* of the jars, otherwise Neo4j will not be able to resolve dependencies at runtime.
+The error, if this happens, will contain a message like:
+[source]
+----
+"Failed to load any of the given libraries: [netty_tcnative_linux_x86_64, netty_tcnative_linux_x86_64_fedora, netty_tcnative_x86_64, netty_tcnative]".
+----
+====
 
 
 == Generate SSL certificate and private key
 
-Neo4j SSL encryption requires a
-xref:security/ssl-framework.adoc#term-ssl-certificate[certificate] in the xref:security/ssl-framework.adoc#term-ssl-x509[X.509] standard, encoded in PEM format.
+Neo4j SSL encryption requires a xref:security/ssl-framework.adoc#term-ssl-certificate[certificate] in the xref:security/ssl-framework.adoc#term-ssl-x509[X.509] standard, encoded in PEM format.
 and a private key in xref:security/ssl-framework.adoc#term-ssl-pkcs8[PKCS #8] format, also PEM encoded.
+*For FIPS compatibility, the private key must be secured with a password*.
 
-For FIPS compatibility, the private key must also be secured with a passphrase.
+Refer to the xref:security/ssl-framework.adoc#ssl-certificates[SSL certificate and key instructions] for more information.
 
-Refer to the xref:security/ssl-framework.adoc#ssl-certificates[SSL certificate and key instructions] for a detailed setup guide to creating the SSL certificate and key pair.
 
 == Configure Neo4j to use SSL encryption
 
-xxx
+// TODO
+
+
+SSL configuration is described in detail at xref:security/ssl-framework.adoc#ssl-configuration[SSL framework configuration].
+
+this section describes configuration that must be done *in addition to* standard non-FIPS compliant SSL configuration.
+
+connectors are bolt, https, cluster and backup.
+
+=== Bolt
+
+. Set `xref:configuration/configuration-settings.adoc#config_dbms.netty.ssl.provider[dbms.netty.ssl.provider]=OPENSSL`
+. Set `xref:configuration/configuration-settings.adoc#config_server.bolt.tls_level[server.bolt.tls_level]=REQUIRED`
+. Follow instructions to xref:security/ssl-framework.adoc#ssl-bolt-config[Configure SSL over bolt].
+. Set additional bolt configurations:
++
+[source, properties]
+----
+dbms.ssl.policy.bolt.trust_all=false
+dbms.ssl.policy.bolt.tls_level=REQUIRED
+dbms.ssl.policy.bolt.tls_versions=TLSv1.2,TLSv1.3
+dbms.ssl.policy.bolt.ciphers=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+----
+. Follow the instructions in xref:security/ssl-framework.adoc#ssl-config-private-key[SSL Framework/Using encrypted private key] to configure `dbms.ssl.policy.bolt.private_key_password` to dynamically read the password from an encrypted password file. The password must NOT be set in plain text.
+
+
+=== HTTPS
+
+This section is only applicable if HTTPS is enabled.
+
+. Follow instructions to xref:security/ssl-framework.adoc#ssl-https-config[Configure SSL over HTTPS].
++
+. Set additional HTTPS configurations:
++
+[source, properties]
+----
+dbms.ssl.policy.https.trust_all=false
+dbms.ssl.policy.https.tls_level=REQUIRED
+dbms.ssl.policy.https.tls_versions=TLSv1.2,TLSv1.3
+dbms.ssl.policy.https.ciphers=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CCM,TLS_ECDHE_ECDSA_WITH_AES_128_CCM,TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8,TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+----
+. Follow the instructions in xref:security/ssl-framework.adoc#ssl-config-private-key[SSL Framework/Using encrypted private key] to configure `dbms.ssl.policy.https.private_key_password` to dynamically read the password from an encrypted password file. The password must NOT be set in plain text.
+
+=== Intra-cluster encryption
+
+For FIPS compatbility, intra-cluster encryption must be enabled if you are running a Neo4j cluster.
+
+. Follow instructions to xref:security/ssl-framework.adoc#ssl-cluster-config[configure SSL for intra-cluster communication].
+. Set additional cluster configurations:
++
+[source, properties]
+----
+dbms.ssl.policy.cluster.enabled=true
+dbms.ssl.policy.cluster.tls_level=REQUIRED
+dbms.ssl.policy.cluster.client_auth=REQUIRED
+dbms.ssl.policy.cluster.tls_versions=TLSv1.2,TLSv1.3
+dbms.ssl.policy.cluster.ciphers=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+----
+. Follow the instructions in xref:security/ssl-framework.adoc#ssl-config-private-key[SSL Framework/Using encrypted private key] to configure `dbms.ssl.policy.cluster.private_key_password` to dynamically read the password from an encrypted password file. The password must NOT be set in plain text.
+
+
+=== Backup
+
+This section is applicable on instances or cluster members used for taking backups.
+
+. Follow instructions to xref:security/ssl-framework.adoc#ssl-backup-config[configure SSL for backup communication].
+. Set additional backup configurations:
++
+[source, properties]
+----
+dbms.ssl.policy.backup.enabled=true
+dbms.ssl.policy.backup.client_auth=REQUIRED
+dbms.ssl.policy.backup.trust_all=false
+dbms.ssl.policy.backup.tls_versions=TLSv1.2,TLSv1.3
+dbms.ssl.policy.backup.ciphers=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+----
+. Follow the instructions in xref:security/ssl-framework.adoc#ssl-config-private-key[SSL Framework/Using encrypted private key] to configure `dbms.ssl.policy.backup.private_key_password` to dynamically read the password from an encrypted password file. The password must NOT be set in plain text.

--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -13,138 +13,76 @@ The SSL framework provides support for securing the following Neo4j communicatio
 This page describes how to set up SSL within your environment, how to view, validate, and test the certificates.
 
 [[ssl-providers]]
-== SSL providers
+== SSL Providers
 
 The secure networking in Neo4j is provided through the Netty library, which supports both the native JDK SSL provider as well as Netty-supported OpenSSL derivatives.
+Each version of Neo4j ships with a version of Netty, and Netty requires a specific version of the `netty-tcnative` library for compatibility.
 
 Follow these steps to use OpenSSL:
 
-- Install a suitable dependency into the `plugins/` folder of Neo4j.
+* Install a suitable `netty-tcnative` dependency into the `plugins/` folder of Neo4j.
+** Dependencies can be downloaded from https://netty.io/wiki/forked-tomcat-native.html.
+** Which `netty-tcnative` version you need depends upon the Neo4j version.
+For versioning details, see the <<table, Netty support per Neo4j version>> table.
+Make sure to install a build variant that matches your OS and architecture.
+* Set `xref:configuration/configuration-settings.adoc#config_dbms.netty.ssl.provider[dbms.netty.ssl.provider]=OPENSSL`.
+* Restart Neo4j.
 
 [NOTE]
 ====
-Dependencies can be downloaded from https://netty.io/wiki/forked-tomcat-native.html.
-Which dependencies you need depends upon the Neo4j version.
-Each version of Neo4j ships with a version of Netty and Netty requires specific tcnative versions.
-Make sure to install the version that matches your OS processor.
-For more details, see the <<table, Netty support per Neo4j version>>.
+Using non-static versions of tcnative will require installation of platform-specific dependency libraries as described in https://netty.io/wiki/forked-tomcat-native.html.
+
+In most use cases, the statically linked `boringssl` variant of `netty-tcnative` will be sufficient to enable SSL encryption.
 ====
 
-- Using non static versions of tcnative will require installation of platform-specific OpenSSL dependencies as described in https://netty.io/wiki/forked-tomcat-native.html.
-- Set `xref:configuration/configuration-settings.adoc#config_dbms.netty.ssl.provider[dbms.netty.ssl.provider]=OPENSSL`.
-- Restart Neo4j.
+The following table shows information about supported Neo4j versions.
 
-[NOTE]
+The following table lists when the `netty-tcnative` dependency was updated in Neo4j.
+
+[TIP]
 ====
-From Neo4j 5.21 on, required Netty and tcnative files are included in the _/lib_ directory.
+If a Neo4j version is not listed, use the table entry for the next earliest Neo4j version listed.
+
+For example: for Neo4j 5.15.0 the next earliest version listed in the table is 5.10, so the required `netty-tcnative` version is `2.0.61.Final`.
 ====
 
-The following table includes detailed information about supported Neo4j versions:
 
 [[table]]
-.Netty support per Neo4j version
-[options="header", cols="1,1,2,3"]
+.Netty-TCNative support per Neo4j version
+[options="header,autowidth", cols="1,4,2"]
 |===
 | Neo4j version
-| Netty version
 | tcnative version
 | Direct link
 
-| 5.22
-| 4.1.111.Final
-| 2.0.65.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.65.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.65.Final/jar
-
-| 5.21
-| 4.1.110.Final
-| 2.0.65.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.65.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.65.Final/jar
+| 5.23
+| 2.0.65.Final. Only netty-tcnative-boringssl-static is required.
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.65.Final/jar[netty-tcnative-boringssl-static-2.0.65.Final]
 
 | 5.20
-| 4.1.109.Final
 | 2.0.65.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.65.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.65.Final/jar
-
-| 5.19
-| 4.1.107.Final
-| 2.0.61.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.61.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.61.Final/jar
-
-| 5.18
-| 4.1.106.Final
-| 2.0.61.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.61.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.61.Final/jar
-
-| 5.16
-| 4.1.101.Final
-| 2.0.61.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.61.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.61.Final/jar
-
-| 5.13
-| 4.1.100.Final
-| 2.0.61.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.61.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.61.Final/jar
-
-| 5.12
-| 4.1.96.Final
-| 2.0.61.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.61.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.61.Final/jar
-
-| 5.11
-| 4.1.94.Final
-| 2.0.61.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.61.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.61.Final/jar
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.65.Final/jar[netty-tcnative-boringssl-static-2.0.65.Final]
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.65.Final/jar[netty-tcnative-classes-2.0.65.Final]
 
 | 5.10
-| 4.1.93.Final
 | 2.0.61.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.61.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.61.Final/jar
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.61.Final/jar[netty-tcnative-boringssl-static-2.0.61.Final]
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.61.Final/jar[netty-tcnative-classes-2.0.61.Final]
 
 | 5.8
-| 4.1.92.Final
 | 2.0.60.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.60.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.60.Final/jar
-
-| 5.7
-| 4.1.89.Final
-| 2.0.56.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.56.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.56.Final/jar
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.60.Final/jar[netty-tcnative-boringssl-static-2.0.60.Final]
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.60.Final/jar[netty-tcnative-classes-2.0.60.Final]
 
 | 5.5
-| 4.1.87.Final
 | 2.0.56.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.56.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.56.Final/jar
-
-| 5.4
-| 4.1.85.Final
-| 2.0.54.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.54.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.54.Final/jar
-
-| 5.2
-| 4.1.84.Final
-| 2.0.54.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.54.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.54.Final/jar
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.56.Final/jar[netty-tcnative-boringssl-static-2.0.56.Final]
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.56.Final/jar[netty-tcnative-classes-2.0.56.Final]
 
 | 5.1
-| 4.1.82.Final
 | 2.0.54.Final. Both netty-tcnative-boringssl-static and netty-tcnative-classes are required.
-| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.54.Final/jar
-https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.54.Final/jar
+| https://search.maven.org/artifact/io.netty/netty-tcnative-boringssl-static/2.0.54.Final/jar[netty-tcnative-boringssl-static-2.0.54.Final]
+https://search.maven.org/artifact/io.netty/netty-tcnative-classes/2.0.54.Final/jar[netty-tcnative-classes-2.0.54.Final]
 |===
 
 
@@ -1133,7 +1071,7 @@ For more information, see xref:configuration/command-expansion.adoc[Command expa
 There are cases where Neo4j Enterprise requires the use of specific ciphers for encryptions.
 One can set up a Neo4j configuration by specifying the list of cipher suites that will be allowed during cipher negotiation.
 Valid values depend on the current JRE and SSL provider.
-For Oracle JRE here is the list of supported ones - https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#jsse-cipher-suite-names.
+For Oracle JRE here is the list of supported ones - https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html#jsse-cipher-suite-names.
 
 .Bolt
 [source, properties]

--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -1000,6 +1000,7 @@ dbms.ssl.policy.backup.client_auth=REQUIRE
 [[ssl-other-configs]]
 === Other configurations for SSL
 
+[[ssl-config-private-key]]
 ==== Using encrypted private key
 
 To use an encrypted private key, configure the following settings.


### PR DESCRIPTION
I cleaned up the existing SSL documentation and added a new page about how to configure SSL to be FIPS compatible.
