### PR TITLE
Added detail on backup compression flag

### DIFF
--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -121,7 +121,7 @@ If <database> is "*", `neo4j-admin` will attempt to back up all databases of the
 |
 
 |--compress[=true\|false]
-|Request backup artifact to be compressed. Compression can yield a backup artifact many times smaller but the exact reduction depends upon many factors including the database format and kind of data stored. If disabled the size of the produced artifact will be approximately equal to the size of backed-up database. Speed of the backup operation is effected by compression, but which is faster depends upon the relative performance of CPU and storage. If backup speed is important, consider evaluating both options - with compression enabled and disabled.
+|Request backup artifact to be compressed. Compression can yield a backup artefact many times smaller, but the exact reduction depends upon many factors, including the database format and the kind of data stored. If disabled, the size of the produced artifact will be approximately equal to the size of the backed-up database. The speed of the backup operation is affected by compression, but which is faster depends upon the relative performance of CPU and storage. If backup speed is important, consider evaluating both options - with compression enabled and disabled.
 |true
 
 | --expand-commands

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -121,8 +121,7 @@ If <database> is "*", `neo4j-admin` will attempt to back up all databases of the
 |
 
 |--compress[=true\|false]
-|Request backup artifact to be compressed. If disabled, backup artifact creation is faster but
-the size of the produced artifact will be approximately equal to the size of backed-up database.
+|Request backup artifact to be compressed. Compression can yield a backup artifact many times smaller but the exact reduction depends upon many factors including the database format and kind of data stored. If disabled the size of the produced artifact will be approximately equal to the size of backed-up database. Speed of the backup operation is effected by compression, but which is faster depends upon the relative performance of CPU and storage. If backup speed is important, consider evaluating both options - with compression enabled and disabled.
 |true
 
 | --expand-commands


### PR DESCRIPTION
This support case shows how a customer is misled by absolute description of backup being faster when compression is disabled.

https://trello.com/c/xsCLZrwy/7747-s3dbs-risk-management5181-backup-is-taking-more-time-with-compressfalse