### PR TITLE
Add a note about clusters with 2 members

### DIFF
--- a/modules/ROOT/pages/clustering/setup/deploy.adoc
+++ b/modules/ROOT/pages/clustering/setup/deploy.adoc
@@ -256,8 +256,8 @@ If you want to follow along with the startup, you can see the messages in xref:c
 [CAUTION]
 ====
 The setting
-xref:configuration/configuration-settings.adoc#dbms.cluster.minimum_initial_system_primaries_count[`dbms.cluster.minimum_initial_system_primaries_count`]
-must be set to `2` on all servers in case setting up a cluster with only _two_ servers.
+xref:configuration/configuration-settings.adoc#config_dbms.cluster.minimum_initial_system_primaries_count[`dbms.cluster.minimum_initial_system_primaries_count`]
+must be set to `2` on all servers in case setting up a cluster with only *two* servers.
 ====
 
 [[cluster-example-create-databases-on-cluster]]

--- a/modules/ROOT/pages/clustering/setup/deploy.adoc
+++ b/modules/ROOT/pages/clustering/setup/deploy.adoc
@@ -253,6 +253,13 @@ If you want to follow along with the startup, you can see the messages in xref:c
 ======
 =====
 
+[CAUTION]
+====
+The setting
+xref:configuration/configuration-settings.adoc#dbms.cluster.minimum_initial_system_primaries_count[`dbms.cluster.minimum_initial_system_primaries_count`]
+must be set to `2` on all servers in case setting up a cluster with only _two_ servers.
+====
+
 [[cluster-example-create-databases-on-cluster]]
 == Create new databases in a cluster
 


### PR DESCRIPTION
Recent question in slack pointed out that we describe how to set up a 3 cluster (as that should be the normal), but we don't mention anywhere that in case of a 2 member cluster an extra setting is needed.