### PR TITLE
Deprecate `existingDataSeedInstance` option to CREATE DATABASE

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -284,7 +284,7 @@ See <<#_create_database, `CREATE DATABASE`>> for more information.
 ----
 CREATE DATABASE foo
 TOPOLOGY [desired number of primaries] PRIMARIES [desired number of secondaries] SECONDARIES
-OPTIONS {existingData: 'use', existingDataSeedInstance: '8512c9b9-d9e8-48e6-b037-b15b0004ca18'};
+OPTIONS {existingData: 'use', existingDataSeedServer: '8512c9b9-d9e8-48e6-b037-b15b0004ca18'};
 ----
 . Verify that the `foo` database is online on the desired number of servers, in the desired roles.
 If the `foo` database is of considerable size, the execution of the command can take some time.

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -85,7 +85,8 @@ Currently, this is only supported with `existingDataSeedInstance`, `existingData
 | ID of the cluster server
 |
 Defines which server is used for seeding the data of the created database.
-The server ID can be found in the `serverId` column after running `SHOW SERVERS`. `existingDataSeedInstance` was replaced by `existingDataSeedServer` in Neo4j 5.25.
+The server ID can be found in the `serverId` column after running `SHOW SERVERS`. 
+`existingDataSeedInstance` is replaced by `existingDataSeedServer` in Neo4j 5.25.
 
 | `seedURI`
 | URI to a backup or a dump from an existing database.

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -114,7 +114,7 @@ For details about enrichment mode, see link:{neo4j-docs-base-uri}/cdc/current/ge
 | `aligned` \| `standard` \| `high_limit` \| `block`
 |
 Defines the store format if the database created is new.
-If the store is seeded with `seedURI`, `existingDataSeedInstance` or `existingDataSeedServer`, or if the command is being used to mount pre-existing store files already present on the disk, they will use their current store format without any alterations.
+If the store is seeded with `seedURI`, `existingDataSeedInstance` or `existingDataSeedServer`, or if the command is used to mount pre-existing store files already present on the disk, they will retain their current store format without any modifications.
 |===
 
 [NOTE]

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -76,13 +76,16 @@ The `CREATE DATABASE` command can have a map of options, e.g. `OPTIONS {key: 'va
 | `use`
 |
 Controls how the system handles existing data on disk when creating the database.
-Currently, this is only supported with `existingDataSeedInstance` and `seedURI`, and must be set to `use`, which indicates the existing data files should be used for the new database.
+Currently, this is only supported with `existingDataSeedInstance`, `existingDataSeedServer` and `seedURI`, and must be set to `use`, which indicates the existing data files should be used for the new database.
 
-| `existingDataSeedInstance`
+
+|`existingDataSeedServer` label:new[new in 5.25]
+
+`existingDataSeedInstance` label:deprecated[deprecated in 5.25]
 | ID of the cluster server
 |
 Defines which server is used for seeding the data of the created database.
-The server ID can be found in the `serverId` column after running `SHOW SERVERS`.
+The server ID can be found in the `serverId` column after running `SHOW SERVERS`. `existingDataSeedInstance` was replaced by `existingDataSeedServer` in Neo4j 5.25.
 
 | `seedURI`
 | URI to a backup or a dump from an existing database.
@@ -110,12 +113,12 @@ For details about enrichment mode, see link:{neo4j-docs-base-uri}/cdc/current/ge
 | `aligned` \| `standard` \| `high_limit` \| `block`
 |
 Defines the store format if the database created is new.
-If the store is seeded with `seedURI` or `existingDataSeedInstance`, or if the command is being used to mount pre-existing store files already present on the disk, they will use their current store format without any alterations.
+If the store is seeded with `seedURI`, `existingDataSeedInstance` or `existingDataSeedServer`, or if the command is being used to mount pre-existing store files already present on the disk, they will use their current store format without any alterations.
 |===
 
 [NOTE]
 ====
-The `existingData`, `existingDataSeedInstance`, `seedURI`, `seedConfig`, and `seedCredentials` options cannot be combined with the `OR REPLACE` part of this command.
+The `existingData`, `existingDataSeedInstance`, `existingDataSeedServer`, `seedURI`, `seedConfig`, and `seedCredentials` options cannot be combined with the `OR REPLACE` part of this command.
 More details about seeding options can be found in xref::clustering/databases.adoc#cluster-seed[Seed a cluster].
 ====
 

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -31,7 +31,7 @@ In versions previous to Neo4j 5.22, the default store format for all new databas
 From Neo4j 5.22, `block` is the default format for all newly-created databases as long as they do not have the xref:configuration/configuration-settings.adoc#config_db.format[`db.format`] setting specified. +
 If you want to change it, you can set a new value for the xref:configuration/configuration-settings.adoc#config_db.format[`db.format`] configuration in the _neo4j.conf_ file. +
 Alternatively, you can set the store format of new databases using the `CREATE DATABASE databasename OPTIONS {storeFormat: 'the-new-format'}` command.
-However, if the store is seeded with `seedURI` or `existingDataSeedInstance`, or if the command is being used to mount pre-existing store files already present on the disk, they will use their current store format without any alterations.
+However, if the store is seeded with `seedURI`, `existingDataSeedServer` or `existingDataSeedInstance`, or if the command is being used to mount pre-existing store files already present on the disk, they will use their current store format without any alterations.
 
 See xref:database-internals/store-formats.adoc[Store formats], for more details about available database store formats in Neo4j.
 


### PR DESCRIPTION
Replace with new option `existingDataSeedServer`

Documenting https://github.com/neo-technology/neo4j/pull/27123