### PR TITLE
Docs for the rafted status check procedure.

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -148,6 +148,7 @@
 *** xref:clustering/monitoring/show-servers-monitoring.adoc[]
 *** xref:clustering/monitoring/show-databases-monitoring.adoc[]
 *** xref:clustering/monitoring/endpoints.adoc[]
+*** xref:clustering/monitoring/status-check.adoc[]
 ** xref:clustering/disaster-recovery.adoc[]
 //** xref:clustering/internals.adoc[]
 ** xref:clustering/settings.adoc[]

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -42,7 +42,7 @@ The procedure returns a row for all primary members of all the requested databas
 * *replicationSuccessful:* indicates if the server (on which the procedure is run) can replicate a transaction.
 +
 ** `TRUE` -- if this server managed to replicate the dummy transaction to a majority of cluster members within the given timeout.
-`FALSE` if it failed to replicate within the timeout.
+** `FALSE` -- if it failed to replicate within the timeout.
 The value is the same column-wise.
 A failed replication can either mean that there is a real issue in the cluster (e.g. no leader) or it may simply mean that this server is too far behind in apply, and can't therefore replicate.
 * *memberStatus:* shows the status of each primary member.

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -44,3 +44,14 @@ can either mean that there is a real issue in the cluster (e.g. no leader) or it
 
 In general the `replicationSuccessful` field can be used to determine overall write-availability, whereas the `memberStatus` field can be checked in order to see whether the database is fault-tolerant or not.
 
+[NOTE]
+====
+Members that are `REPLICATING` are good from a data safety point of view. They can participate in replication and keep the data durably until application. They are also up-to-date and therefore eligible leaders. So they add to the fault-tolerance.
+
+Members that are `APPLYING` have all the qualities of `REPLICATING` members, so they too add to the fault-tolerance. But they are also applying to the database, which is a requirement for writing transactions and reading with bookmarks in a timely manner.
+
+Lastly, `UNAVAILABLE` members are either too far behind or unreachable. They are unhealthy and cannot add to the fault-tolerance.
+
+====
+
+

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -40,6 +40,7 @@ The procedure returns a row for all primary members of all the requested databas
 * *serverName:* the server name of each primary member.
 * *address:* the Bolt address of each primary member.
 * *replicationSuccessful:* indicates if the server (on which the procedure is run) can replicate a transaction.
++
 ** `TRUE` -- if this server managed to replicate the dummy transaction to a majority of cluster members within the given timeout.
 `FALSE` if it failed to replicate within the timeout.
 The value is the same column-wise.

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -1,26 +1,36 @@
-:description: This section describes how to monitor a database's availability with the help of the cluster status check
-[role=label--new-5.24 label--enterprise-edition]
-[[database-status-check]]
-== Cluster Status Check
+:description: This section describes how to monitor a database's availability with the help of the cluster status check procedure.
 
-Neo4j 5.24 introduces the xref:reference/procedures.adoc#procedure_dbms_cluster_statusCheck[`dbms.cluster.statusCheck()`] procedure, which can be used to monitor the ability to replicate in clustered databases, which in most cases means being able to write to the database. You can also use the procedure to check which members are up-to-date and can participate in a successful replication. Therefore, it is useful in determining the fault-tolerance of a clustered database as well. A third and final function is to determine the leader of the cluster.
+[role=label--new-5.24 label--enterprise-edition]
+[[cluster-status-check]]
+= Cluster status check
+
+Neo4j 5.24 introduces the xref:reference/procedures.adoc#procedure_dbms_cluster_statusCheck[`dbms.cluster.statusCheck()`] procedure, which can be used to monitor the ability to replicate in clustered databases, which in most cases means being able to write to the database.
+You can also use the procedure to check which members are up-to-date and can participate in a successful replication.
+Therefore, it is useful in determining the fault-tolerance of a clustered database as well.
+A third and final function is to determine the leader of the cluster.
 
 [NOTE]
 ====
 The member on which the procedure is called replicates a dummy transaction in the same cluster as the real transactions, and verifies that it can be replicated and applied.
 
-Since the status check doesn't replicate an actual transaction, it's not guaranteed that the database is write available even though the status check reports that it can replicate. Apart from replication there are other stops in the write path that can potentially block a transaction from being applied, e.g. issues in the database. However, it tells that the cluster is healthy and in most cases that means that the database is write available.
+Since the status check doesn't replicate an actual transaction, it's not guaranteed that the database is write available even though the status check reports that it can replicate.
+Apart from replication there are other stops in the write path that can potentially block a transaction from being applied, e.g. issues in the database.
+However, it tells that the cluster is healthy and in most cases that means that the database is write available.
 ====
 
-=== Syntax
+[[procedure-syntax]]
+== Syntax
 
 [source, shell]
 ----
 CALL dbms.cluster.statusCheck(databases :: LIST<STRING>, timeoutMilliseconds = null :: INTEGER)
 ----
 
-* *databases:* the list of databases for which the status check should run. Providing an empty list will run the status check for all *clustered* databases on that server, i.e. the status check won't run on singles or secondaries.
-* *timeoutMilliseconds:* specifies how long the replication may take. Default value is 1000 milliseconds. If replication takes longer than this timeout, it will return that replication is unsuccessful.
+* *databases:* the list of databases for which the status check should run.
+Providing an empty list runs the status check for all *clustered* databases on that server, i.e. the status check won't run on singles or secondaries.
+* *timeoutMilliseconds:* specifies how long the replication may take.
+Default value is 1000 milliseconds.
+If replication takes longer than this timeout, it will return that replication is unsuccessful.
 
 
 The procedure returns a row for all primary members of all the requested databases where each row consists of:
@@ -29,23 +39,37 @@ The procedure returns a row for all primary members of all the requested databas
 * *serverId:* the server id of each primary member, which did or did not participate in a successful replication of the `status check entry`.
 * *serverName:* the server name of each primary member.
 * *address:* the bolt address of each primary member.
-* *replicationSuccessful:* indicates if the server (on which the procedure is run) can replicate a transaction. Is `TRUE` if this server managed to replicate the dummy transaction to a majority of raft members within the given timeout. `FALSE` if it failed to replicate within the timeout. The value is the same column-wise. A failed replication can either mean that there is a real issue in the cluster (e.g. no leader) or it may simply mean that this server is too far behind in apply, and can't therefore replicate.
-* *memberStatus:* shows the status of each primary member. It can either be `APPLYING`, `REPLICATING` or `UNAVAILABLE`. `APPLYING` means that the member can replicate and is actively applying transactions. `REPLICATING` means that the member can participate in replicating, but can't apply. This state is uncommon, but may happen while waiting for the database to start and accept transactions.
+* *replicationSuccessful:* indicates if the server (on which the procedure is run) can replicate a transaction.
+Is `TRUE` if this server managed to replicate the dummy transaction to a majority of raft members within the given timeout.
+`FALSE` if it failed to replicate within the timeout.
+The value is the same column-wise.
+A failed replication can either mean that there is a real issue in the cluster (e.g. no leader) or it may simply mean that this server is too far behind in apply, and can't therefore replicate.
+* *memberStatus:* shows the status of each primary member.
+It can either be `APPLYING`, `REPLICATING` or `UNAVAILABLE`.
+`APPLYING` means that the member can replicate and is actively applying transactions.
+`REPLICATING` means that the member can participate in replicating, but can't apply.
+This state is uncommon, but may happen while waiting for the database to start and accept transactions.
 * *recognisedLeader:* shows the server id of the perceived leader of each primary member.
-* *recognisedLeaderTerm:* shows the term of the perceived leader of each primary member. If the members report different leaders, the one with the highest term should be trusted.
+* *recognisedLeaderTerm:* shows the term of the perceived leader of each primary member.
+If the members report different leaders, the one with the highest term should be trusted.
 * *requester:* is `TRUE` for the server on which the procedure is run, and `FALSE` on the remaining servers.
-* *error:* contains the error message if there is one. An example of an error is that one or more of the requested databases doesn't exist on the requester.
+* *error:* contains the error message if there is one.
+An example of an error is that one or more of the requested databases doesn't exist on the requester.
 
 In general the `replicationSuccessful` field can be used to determine overall write-availability, whereas the `memberStatus` field can be checked in order to see whether the database is fault-tolerant or not.
 
 [NOTE]
 ====
-Members that are `REPLICATING` are good from a data safety point of view. They can participate in replication and keep the data durably until application. They are also up-to-date and therefore eligible leaders. So they add to the fault-tolerance.
+Members that are `REPLICATING` are good from a data safety point of view.
+They can participate in replication and keep the data durably until application.
+They are also up-to-date and therefore eligible leaders.
+So they add to the fault-tolerance.
 
-Members that are `APPLYING` have all the qualities of `REPLICATING` members, so they too add to the fault-tolerance. But they are also applying to the database, which is a requirement for writing transactions and reading with bookmarks in a timely manner.
+Members that are `APPLYING` have all the qualities of `REPLICATING` members, so they too add to the fault-tolerance.
+But they are also applying to the database, which is a requirement for writing transactions and reading with bookmarks in a timely manner.
 
-Lastly, `UNAVAILABLE` members are either too far behind or unreachable. They are unhealthy and cannot add to the fault-tolerance.
-
+Lastly, `UNAVAILABLE` members are either too far behind or unreachable.
+They are unhealthy and cannot add to the fault-tolerance.
 ====
 
 

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -1,16 +1,15 @@
-:description: This section describes how to monitor a database's availability with the help of the rafted status check
-[role=label--new-5.24]
-== Rafted Status Check
+:description: This section describes how to monitor a database's availability with the help of the cluster status check
+[role=label--new-5.24 label--enterprise-edition]
+[[database-status-check]]
+== Cluster Status Check
 
-Neo4j 5.24 introduces the xref:reference/procedures.adoc#procedure_dbms_cluster_statusCheck[`dbms.cluster.statusCheck()`] procedure, which can be used to monitor the ability to replicate in rafted databases, which in most cases means being able to write to the database. It can also
-be used to check which members are up-to-date and can participate in a successful replication. Therefore, it is useful in determining the fault-tolerance of a rafted database as well. A third and final function is to determine the leader of the raft group.
+Neo4j 5.24 introduces the xref:reference/procedures.adoc#procedure_dbms_cluster_statusCheck[`dbms.cluster.statusCheck()`] procedure, which can be used to monitor the ability to replicate in clustered databases, which in most cases means being able to write to the database. You can also use the procedure to check which members are up-to-date and can participate in a successful replication. Therefore, it is useful in determining the fault-tolerance of a clustered database as well. A third and final function is to determine the leader of the cluster.
 
 [NOTE]
 ====
-The member on which the procedure is called replicates a `status check entry` in the same raft group as the transactions, and verifies that the entry can be replicated and applied.
+The member on which the procedure is called replicates a dummy transaction in the same cluster as the real transactions, and verifies that it can be replicated and applied.
 
-Since the entry is not applied to the transaction state machine, it's not guaranteed that the database is write available even though the status check reports that
-it can replicate. However, it tells that the raft group is healthy and in most cases that means that the database is write available.
+Since the status check doesn't replicate an actual transaction, it's not guaranteed that the database is write available even though the status check reports that it can replicate. Apart from replication there are other stops in the write path that can potentially block a transaction from being applied, e.g. issues in the database. However, it tells that the cluster is healthy and in most cases that means that the database is write available.
 ====
 
 === Syntax
@@ -20,27 +19,22 @@ it can replicate. However, it tells that the raft group is healthy and in most c
 CALL dbms.cluster.statusCheck(databases :: LIST<STRING>, timeoutMilliseconds = null :: INTEGER)
 ----
 
-* *databases:* the list of databases for which the status check should run. Providing an empty list will run the
-status check for all *rafted* databases on that server.
-* *timeoutMilliseconds:* specifies how long the replication may take. Default value is 1000 milliseconds. If replication takes longer than this timeout, it will return that
-replication is unsuccessful.
+* *databases:* the list of databases for which the status check should run. Providing an empty list will run the status check for all *clustered* databases on that server, i.e. the status check won't run on singles or secondaries.
+* *timeoutMilliseconds:* specifies how long the replication may take. Default value is 1000 milliseconds. If replication takes longer than this timeout, it will return that replication is unsuccessful.
 
 
-The procedure returns a row for all raft group members of all the requested databases where each row consists of:
+The procedure returns a row for all primary members of all the requested databases where each row consists of:
 
 * *database:* the database for which the `status check entry` was replicated.
-* *serverId:* the server id of each raft group member, which did or did not participate in a successful replication of the `status check entry`.
-* *serverName:* the server name of each raft group member.
-* *address:* the bolt address of each raft group member.
-* *replicationSuccessful:* indicates if the server (on which the procedure is run) can replicate an entry in raft. Is `TRUE` if this server managed to replicate the `status check entry` to a majority of raft members within the given timeout. `FALSE`
-if it failed to replicate within the timeout. The value is the same column-wise. A failed replication
-can either mean that there is a real issue in the cluster (e.g. no leader) or it may simply mean that this server is too far behind in raft, and can't therefore replicate.
-* *memberStatus:* shows the status of each raft group member. It can either be `APPLYING`, `REPLICATING` or `UNAVAILABLE`. `APPLYING` means that the raft group member has raft running and is actively applying entries, including transactions.
-`REPLICATING` means that the member can participate in replicating, but can't apply. This state is uncommon, but may happen while waiting for the database to start and accept transactions.
-* *recognisedLeader:* shows the server id of the perceived leader of each raft group member.
-* *recognisedLeaderTerm:* shows the term of the perceived leader of each raft group member. If the raft group members report different leaders, the one with the highest term should be trusted.
+* *serverId:* the server id of each primary member, which did or did not participate in a successful replication of the `status check entry`.
+* *serverName:* the server name of each primary member.
+* *address:* the bolt address of each primary member.
+* *replicationSuccessful:* indicates if the server (on which the procedure is run) can replicate a transaction. Is `TRUE` if this server managed to replicate the dummy transaction to a majority of raft members within the given timeout. `FALSE` if it failed to replicate within the timeout. The value is the same column-wise. A failed replication can either mean that there is a real issue in the cluster (e.g. no leader) or it may simply mean that this server is too far behind in apply, and can't therefore replicate.
+* *memberStatus:* shows the status of each primary member. It can either be `APPLYING`, `REPLICATING` or `UNAVAILABLE`. `APPLYING` means that the member can replicate and is actively applying transactions. `REPLICATING` means that the member can participate in replicating, but can't apply. This state is uncommon, but may happen while waiting for the database to start and accept transactions.
+* *recognisedLeader:* shows the server id of the perceived leader of each primary member.
+* *recognisedLeaderTerm:* shows the term of the perceived leader of each primary member. If the members report different leaders, the one with the highest term should be trusted.
 * *requester:* is `TRUE` for the server on which the procedure is run, and `FALSE` on the remaining servers.
-* *error:* contains the error message if there is one. An example of an error is that one of more of the requested databases doesn't exist on the requester.
+* *error:* contains the error message if there is one. An example of an error is that one or more of the requested databases doesn't exist on the requester.
 
 In general the `replicationSuccessful` field can be used to determine overall write-availability, whereas the `memberStatus` field can be checked in order to see whether the database is fault-tolerant or not.
 

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -38,7 +38,7 @@ The procedure returns a row for all primary members of all the requested databas
 * *database:* the database for which the `status check entry` was replicated.
 * *serverId:* the server id of each primary member, which did or did not participate in a successful replication of the `status check entry`.
 * *serverName:* the server name of each primary member.
-* *address:* the bolt address of each primary member.
+* *address:* the Bolt address of each primary member.
 * *replicationSuccessful:* indicates if the server (on which the procedure is run) can replicate a transaction.
 Is `TRUE` if this server managed to replicate the dummy transaction to a majority of raft members within the given timeout.
 `FALSE` if it failed to replicate within the timeout.

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -44,7 +44,7 @@ The procedure returns a row for all primary members of all the requested databas
 ** `TRUE` -- if this server managed to replicate the dummy transaction to a majority of cluster members within the given timeout.
 ** `FALSE` -- if it failed to replicate within the timeout.
 The value is the same column-wise.
-A failed replication can either mean that there is a real issue in the cluster (e.g. no leader) or it may simply mean that this server is too far behind in apply, and can't therefore replicate.
+A failed replication can either mean a real issue in the cluster (e.g., no leader) or that this server is too far behind in apply and can't replicate.
 * *memberStatus:* shows the status of each primary member.
 It can either be `APPLYING`, `REPLICATING` or `UNAVAILABLE`.
 `APPLYING` means that the member can replicate and is actively applying transactions.

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -40,7 +40,7 @@ The procedure returns a row for all primary members of all the requested databas
 * *serverName:* the server name of each primary member.
 * *address:* the Bolt address of each primary member.
 * *replicationSuccessful:* indicates if the server (on which the procedure is run) can replicate a transaction.
-Is `TRUE` if this server managed to replicate the dummy transaction to a majority of raft members within the given timeout.
+** `TRUE` -- if this server managed to replicate the dummy transaction to a majority of cluster members within the given timeout.
 `FALSE` if it failed to replicate within the timeout.
 The value is the same column-wise.
 A failed replication can either mean that there is a real issue in the cluster (e.g. no leader) or it may simply mean that this server is too far behind in apply, and can't therefore replicate.

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -49,7 +49,7 @@ A failed replication can either mean a real issue in the cluster (e.g., no leade
 It can be `APPLYING`, `REPLICATING`, or `UNAVAILABLE`.
 +
 ** `APPLYING` means that the member can replicate and is actively applying transactions.
-`REPLICATING` means that the member can participate in replicating, but can't apply.
+** `REPLICATING` means that the member can participate in replicating, but can't apply.
 This state is uncommon, but may happen while waiting for the database to start and accept transactions.
 * *recognisedLeader:* shows the server id of the perceived leader of each primary member.
 * *recognisedLeaderTerm:* shows the term of the perceived leader of each primary member.

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -1,0 +1,46 @@
+:description: This section describes how to monitor a database's availability with the help of the rafted status check
+[role=label--new-5.24]
+== Rafted Status Check
+
+Neo4j 5.24 introduces the xref:reference/procedures.adoc#procedure_dbms_cluster_statusCheck[`dbms.cluster.statusCheck()`] procedure, which can be used to monitor the ability to replicate in rafted databases, which in most cases means being able to write to the database. It can also
+be used to check which members are up-to-date and can participate in a successful replication. Therefore, it is useful in determining the fault-tolerance of a rafted database as well. A third and final function is to determine the leader of the raft group.
+
+[NOTE]
+====
+The member on which the procedure is called replicates a `status check entry` in the same raft group as the transactions, and verifies that the entry can be replicated and applied.
+
+Since the entry is not applied to the transaction state machine, it's not guaranteed that the database is write available even though the status check reports that
+it can replicate. However, it tells that the raft group is healthy and in most cases that means that the database is write available.
+====
+
+=== Syntax
+
+[source, shell]
+----
+CALL dbms.cluster.statusCheck(databases :: LIST<STRING>, timeoutMilliseconds = null :: INTEGER)
+----
+
+* *databases:* the list of databases for which the status check should run. Providing an empty list will run the
+status check for all *rafted* databases on that server.
+* *timeoutMilliseconds:* specifies how long the replication may take. Default value is 1000 milliseconds. If replication takes longer than this timeout, it will return that
+replication is unsuccessful.
+
+
+The procedure returns a row for all raft group members of all the requested databases where each row consists of:
+
+* *database:* the database for which the `status check entry` was replicated.
+* *serverId:* the server id of each raft group member, which did or did not participate in a successful replication of the `status check entry`.
+* *serverName:* the server name of each raft group member.
+* *address:* the bolt address of each raft group member.
+* *replicationSuccessful:* indicates if the server (on which the procedure is run) can replicate an entry in raft. Is `TRUE` if this server managed to replicate the `status check entry` to a majority of raft members within the given timeout. `FALSE`
+if it failed to replicate within the timeout. The value is the same column-wise. A failed replication
+can either mean that there is a real issue in the cluster (e.g. no leader) or it may simply mean that this server is too far behind in raft, and can't therefore replicate.
+* *memberStatus:* shows the status of each raft group member. It can either be `APPLYING`, `REPLICATING` or `UNAVAILABLE`. `APPLYING` means that the raft group member has raft running and is actively applying entries, including transactions.
+`REPLICATING` means that the member can participate in replicating, but can't apply. This state is uncommon, but may happen while waiting for the database to start and accept transactions.
+* *recognisedLeader:* shows the server id of the perceived leader of each raft group member.
+* *recognisedLeaderTerm:* shows the term of the perceived leader of each raft group member. If the raft group members report different leaders, the one with the highest term should be trusted.
+* *requester:* is `TRUE` for the server on which the procedure is run, and `FALSE` on the remaining servers.
+* *error:* contains the error message if there is one. An example of an error is that one of more of the requested databases doesn't exist on the requester.
+
+In general the `replicationSuccessful` field can be used to determine overall write-availability, whereas the `memberStatus` field can be checked in order to see whether the database is fault-tolerant or not.
+

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -48,7 +48,7 @@ A failed replication can either mean a real issue in the cluster (e.g., no leade
 * *memberStatus:* shows the status of each primary member.
 It can be `APPLYING`, `REPLICATING`, or `UNAVAILABLE`.
 +
-`APPLYING` means that the member can replicate and is actively applying transactions.
+** `APPLYING` means that the member can replicate and is actively applying transactions.
 `REPLICATING` means that the member can participate in replicating, but can't apply.
 This state is uncommon, but may happen while waiting for the database to start and accept transactions.
 * *recognisedLeader:* shows the server id of the perceived leader of each primary member.

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -46,7 +46,8 @@ The procedure returns a row for all primary members of all the requested databas
 The value is the same column-wise.
 A failed replication can either mean a real issue in the cluster (e.g., no leader) or that this server is too far behind in apply and can't replicate.
 * *memberStatus:* shows the status of each primary member.
-It can either be `APPLYING`, `REPLICATING` or `UNAVAILABLE`.
+It can be `APPLYING`, `REPLICATING`, or `UNAVAILABLE`.
++
 `APPLYING` means that the member can replicate and is actively applying transactions.
 `REPLICATING` means that the member can participate in replicating, but can't apply.
 This state is uncommon, but may happen while waiting for the database to start and accept transactions.

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -58,7 +58,7 @@ If the members report different leaders, the one with the highest term should be
 * *error:* contains the error message if there is one.
 An example of an error is that one or more of the requested databases doesn't exist on the requester.
 
-In general the `replicationSuccessful` field can be used to determine overall write-availability, whereas the `memberStatus` field can be checked in order to see whether the database is fault-tolerant or not.
+In general, you can use the `replicationSuccessful` field to determine overall write-availability, whereas the `memberStatus` field can be checked in order to see whether the database is fault-tolerant or not.
 
 [NOTE]
 ====


### PR DESCRIPTION
As part of the 2DC support, we needed to make the rafted status check procedure public. And therefore, we also need to add a public documentation. I've kept it quite simple. But it may be too technical in some parts, let me know.

P.S It's required to be part of the 5.24 release. 