### PR TITLE
disabled section in ssl-fips page about docker image until docker image is finalised (#1848)

### DIFF
--- a/modules/ROOT/pages/security/ssl-fips-compatibility.adoc
+++ b/modules/ROOT/pages/security/ssl-fips-compatibility.adoc
@@ -20,38 +20,38 @@ Only xref:installation/requirements.adoc#deployment-requirements-software[Linux 
 * Install and configure a non-native authentication provider, for example LDAP or SSO. See xref:authentication-authorization/index.adoc[].
 
 
-[[fips-ssl-provider-docker]]
-== Enable FIPS SSL provider (Docker)
-
-The Neo4j RedHat UBI9 Docker image comes with the SSL provider and dependencies pre-installed, but it is not enabled by default.
-
-[NOTE]
-====
-The Debian based Neo4j Docker image does *not* support FIPS compatible encryption.
-====
-
-To enable the OpenSSL FIPS provider, set the environment variable `NEO4J_OPENSSL_FIPS_ENABLE=true` when starting the container.
-
-[source, console, subs="attributes"]
-.Example of starting a Neo4j UBI9 container with FIPS enable flag set.
-----
-docker run -it --rm \
-    --publish=7474:7474 \
-    --publish=7687:7687 \
-    --env=NEO4J_OPENSSL_FIPS_ENABLE=true \
-    --volume=$HOME/neo4j/data:/data \
-    --volume=$HOME/neo4j/conf:/conf \
-    --volume=$HOME/neo4j/certificates:/ssl \
-neo4j:{neo4j-version-exact}-enterprise-ubi9
-----
+// [[fips-ssl-provider-docker]]
+// == Enable FIPS SSL provider (Docker)
+//
+// The Neo4j RedHat UBI9 Docker image comes with the SSL provider and dependencies pre-installed, but it is not enabled by default.
+//
+// [NOTE]
+// ====
+// The Debian based Neo4j Docker image does *not* support FIPS compatible encryption.
+// ====
+//
+// To enable the OpenSSL FIPS provider, set the environment variable `NEO4J_OPENSSL_FIPS_ENABLE=true` when starting the container.
+//
+// [source, console, subs="attributes"]
+// .Example of starting a Neo4j UBI9 container with FIPS enable flag set.
+// ----
+// docker run -it --rm \
+//     --publish=7474:7474 \
+//     --publish=7687:7687 \
+//     --env=NEO4J_OPENSSL_FIPS_ENABLE=true \
+//     --volume=$HOME/neo4j/data:/data \
+//     --volume=$HOME/neo4j/conf:/conf \
+//     --volume=$HOME/neo4j/certificates:/ssl \
+// neo4j:{neo4j-version-exact}-enterprise-ubi9
+// ----
 
 [[fips-ssl-provider]]
 == Enable FIPS SSL provider
 
-[IMPORTANT]
-====
-Skip this section if using Neo4j in Docker.
-====
+// [IMPORTANT]
+// ====
+// Skip this section if using Neo4j in Docker.
+// ====
 
 The secure networking in Neo4j is provided through the Netty library, which supports both the native JDK SSL provider and Netty-supported OpenSSL derivatives.
 Specifically Netty's _Forked Tomcat Native_ library called https://github.com/netty/netty-tcnative[netty-tcnative].


### PR DESCRIPTION


the FIPS features had to be rolled back from the docker image, so we need to remove that section of the documentation for now. It will return once the docker image name is finalised so I only commented out the relevant bits.