### PR TITLE
 Add neo4j-admin-import section and parameter details for Parquet.

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -258,6 +258,7 @@ It can also be specified as a percentage of the available memory, for example `7
 
 |--multiline-fields[=true\|false]
 |Whether or not fields from an input source can span multiple lines, i.e. contain newline characters.
+| null
 
 |--multiline-fields-format=v1\|v2
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.
@@ -796,6 +797,7 @@ It can also be specified as a percentage of the available memory, for example `7
 
 |--multiline-fields[=true\|false]
 |Whether or not fields from an input source can span multiple lines, i.e. contain newline characters.
+| null
 
 |--multiline-fields-format=v1\|v2
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -619,7 +619,7 @@ neo4j-admin database import incremental [-h] [--expand-commands] --force [--verb
                                         [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>] [--delimiter=<char>]
                                         [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual] [--input-encoding=<character-set>]
                                         [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>]
-                                        [--report-file=<path>] [--schema=<path>] [--stage=all|prepare|build|merge] [--threads=<num>]
+                                        [--report-file=<path>] [--stage=all|prepare|build|merge] [--threads=<num>]
                                         --nodes=[<label>[: <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
                                         [--relationships=[<type>=]<files>...]... <database>
 ----

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -750,6 +750,11 @@ Possible values are:
 |Character set that input data is encoded in.
 |UTF-8
 
+|--input-type[=csv\|parquet]
+label:beta[]
+|File type to import.
+|csv
+
 |--legacy-style-quoting[=true\|false]
 |Whether or not a backslash-escaped quote e.g. \" is interpreted as an inner quote.
 |false

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -612,7 +612,7 @@ The syntax for importing a set of CSV files incrementally is:
 ----
 neo4j-admin database import incremental [-h] [--expand-commands] --force [--verbose] [--auto-skip-subsequent-headers[=true|false]]
                                         [--ignore-empty-strings[=true|false]] [--ignore-extra-columns[=true|false]]
-                                        [--legacy-style-quoting[=true|false]] [--multiline-fields[=true|false]] [--normalize-types[=true|false]][--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships[=true|false]]
+                                        [--legacy-style-quoting[=true|false]] [--multiline-fields[=true|false]] [--normalize-types[=true|false]] [--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships[=true|false]]
                                         [--skip-duplicate-nodes[=true|false]] [--strict[=true|false]] [--trim-strings[=true|false]]
                                         [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>] [--delimiter=<char>]
                                         [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual] [--input-encoding=<character-set>]

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -25,6 +25,17 @@ Change Data Capture does **not** capture any data changes resulting from the use
 See link:{neo4j-docs-base-uri}/cdc/current/get-started/self-managed/#non-tx-log-changes/[Change Data Capture -> Key considerations] for more information.
 ====
 
+[role=label--beta]
+== Parquet file support
+Starting with Neo4j 5.24, Neo4j provides support for the Parquet file format in a public beta version.
+The additional parameter `--input-type [csv|parquet]` was introduced to explicitly tell the importer to use either CSV or Parquet.
+Its value defaults to CSV if it is not defined.
+
+Most of the parameters that can be used to configure the import are also valid for the Parquet format.
+There are indicators in the parameter overview to point out which parameters are supported.
+
+The xref:tools/neo4j-admin/neo4j-admin-import.adoc#import-tool-examples[examples] for CSV can also be used with Parquet.
+
 == Overview
 
 The `neo4j-admin database import` command has two modes both used for initial data import:
@@ -150,7 +161,7 @@ For horizontal tabulation (HT), use `\t` or the Unicode character ID `\9`.
 Unicode character ID can be used if prepended by `\`.
 |;
 
-| --auto-skip-subsequent-headers[=true\|false]
+| --auto-skip-subsequent-headers[=true\|false]^1^
 |Automatically skip accidental header lines in subsequent files in file groups with more than one file.
 |false
 
@@ -158,7 +169,7 @@ Unicode character ID can be used if prepended by `\`.
 |Number of bad entries before the import is aborted. The import process is optimized for error-free data. Therefore, cleaning the data before importing it is highly recommended. If you encounter any bad entries during the import process, you can set the number of bad entries to a specific value that suits your needs. However, setting a high value may affect the performance of the tool.
 |1000
 
-|--delimiter=<char>
+|--delimiter=<char>^1^
 |Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
@@ -207,13 +218,18 @@ Possible values are:
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=true\|false]
+|--ignore-extra-columns[=true\|false]^1^
 |If unspecified columns should be ignored during the import.
 |false
 
-|--input-encoding=<character-set>
+|--input-encoding=<character-set>^1^
 |Character set that input data is encoded in.
 |UTF-8
+
+|--input-type[=csv\|parquet]
+label:beta[]
+|File type to import.
+|csv
 
 |--legacy-style-quoting[=true\|false]
 |Whether or not a backslash-escaped quote e.g. \" is interpreted as an inner quote.
@@ -226,9 +242,8 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields=true\|false\|<path>[,<path>]
-|label:changed[Changed in 5.26] In v1, whether or not fields from an input source can span multiple lines, i.e. contain newline characters. Setting `--multiline-fields=true` can severely degrade the performance of the importer. Therefore, use it with care, especially with large imports. In v2, this option will specify the list of files that contain multiline fields. Files can also be specified using regular expressions.
-|null
+|--multiline-fields[=true\|false]^1^
+|Whether or not fields from an input source can span multiple lines, i.e. contain newline characters.
 
 |--multiline-fields-format=v1\|v2
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.
@@ -255,7 +270,7 @@ For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |Delete any existing database files prior to the import.
 |false
 
-|--quote=<char>
+|--quote=<char>^1^
 |Character to treat as quotation character for values in CSV data.
 
 Quotes can be escaped as per link:{rfc-4180}[RFC 4180] by doubling them, for example `""` would be interpreted as a literal `"`.
@@ -330,7 +345,7 @@ If enabled all those relationships will be found but at the cost of lower perfor
 performance, this value should not be greater than the number of available processors.
 |20
 
-|--trim-strings[=true\|false]
+|--trim-strings[=true\|false]^1^
 |Whether or not strings should be trimmed for whitespaces.
 |false
 
@@ -339,6 +354,7 @@ performance, this value should not be greater than the number of available proce
 |
 |===
 
+^1^ __Ignored by Parquet import label:beta[].__ +
 
 [NOTE]
 .Heap size for the import
@@ -671,7 +687,7 @@ For horizontal tabulation (HT), use `\t` or the Unicode character ID `\9`.
 Unicode character ID can be used if prepended by `\`.
 |;
 
-| --auto-skip-subsequent-headers[=true\|false]
+| --auto-skip-subsequent-headers[=true\|false]^1^
 |Automatically skip accidental header lines in subsequent files in file groups with more than one file.
 |false
 
@@ -679,7 +695,7 @@ Unicode character ID can be used if prepended by `\`.
 |Number of bad entries before the import is aborted. The import process is optimized for error-free data. Therefore, cleaning the data before importing it is highly recommended. If you encounter any bad entries during the import process, you can set the number of bad entries to a specific value that suits your needs. However, setting a high value may affect the performance of the tool.
 |1000
 
-|--delimiter=<char>
+|--delimiter=<char>^1^
 |Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
@@ -726,11 +742,11 @@ Possible values are:
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=true\|false]
+|--ignore-extra-columns[=true\|false]^1^
 |If unspecified columns should be ignored during the import.
 |false
 
-|--input-encoding=<character-set>
+|--input-encoding=<character-set>^1^
 |Character set that input data is encoded in.
 |UTF-8
 
@@ -745,9 +761,8 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields=true\|false\|<path>[,<path>]
-|label:changed[Changed in 5.26] In v1, whether or not fields from an input source can span multiple lines, i.e. contain newline characters. Setting `--multiline-fields=true` can severely degrade the performance of the importer. Therefore, use it with care, especially with large imports. In v2, this option will specify the list of files that contain multiline fields. Files can also be specified using regular expressions.
-|null
+|--multiline-fields[=true\|false]^1^
+|Whether or not fields from an input source can span multiple lines, i.e. contain newline characters.
 
 |--multiline-fields-format=v1\|v2
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.
@@ -770,7 +785,7 @@ For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |When `true`, non-array property values are converted to their equivalent Cypher types. For example, all integer values will be converted to 64-bit long integers.
 | true
 
-|--quote=<char>
+|--quote=<char>^1^
 |Character to treat as quotation character for values in CSV data.
 
 Quotes can be escaped as per link:{rfc-4180}[RFC 4180] by doubling them, for example `""` would be interpreted as a literal `"`.
@@ -854,7 +869,7 @@ If enabled all those relationships will be found but at the cost of lower perfor
 performance, this value should not be greater than the number of available processors.
 |20
 
-|--trim-strings[=true\|false]
+|--trim-strings[=true\|false]^1^
 |Whether or not strings should be trimmed for whitespaces.
 |false
 
@@ -862,6 +877,8 @@ performance, this value should not be greater than the number of available proce
 |Enable verbose output.
 |
 |===
+
+^1^ __Ignored by Parquet import label:beta[].__ +
 
 [NOTE]
 .Using both a multi-value option and a positional parameter

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -242,7 +242,7 @@ Possible values are:
 |Character set that input data is encoded in.
 |UTF-8
 
-|--input-type[=csv\|parquet]
+|--input-type=csv\|parquet
 |label:beta[] File type to import from. Can be csv or parquet. Defaults to csv.
 |csv
 
@@ -789,7 +789,7 @@ Possible values are:
 |Character set that input data is encoded in.
 |UTF-8
 
-|--input-type[=csv\|parquet]
+|--input-type=csv\|parquet
 |label:beta[] File type to import from. Can be csv or parquet. Defaults to csv.
 |csv
 

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -141,7 +141,7 @@ The xref:tools/neo4j-admin/neo4j-admin-import.adoc#import-tool-examples[examples
 | Description
 | Default
 
-|--additional-config=<file>{empty}footnote:[See xref:tools/neo4j-admin/index.adoc#_configuration[Tools -> Configuration] for details.]
+|--additional-config=<file>footnote:[See xref:tools/neo4j-admin/index.adoc#_configuration[Tools -> Configuration] for details.]
 |Configuration file with additional configuration.
 |
 
@@ -160,7 +160,7 @@ For horizontal tabulation (HT), use `\t` or the Unicode character ID `\9`.
 Unicode character ID can be used if prepended by `\`.
 |;
 
-| --auto-skip-subsequent-headers[=true\|false]{empty}footnote:ingnoredByParquet1[Ignored by Parquet import.]
+| --auto-skip-subsequent-headers[=true\|false]footnote:ingnoredByParquet1[Ignored by Parquet import.]
 |Automatically skip accidental header lines in subsequent files in file groups with more than one file.
 |false
 
@@ -168,7 +168,7 @@ Unicode character ID can be used if prepended by `\`.
 |Number of bad entries before the import is aborted. The import process is optimized for error-free data. Therefore, cleaning the data before importing it is highly recommended. If you encounter any bad entries during the import process, you can set the number of bad entries to a specific value that suits your needs. However, setting a high value may affect the performance of the tool.
 |1000
 
-|--delimiter=<char>{empty}footnote:ingnoredByParquet1[]
+|--delimiter=<char>footnote:ingnoredByParquet1[]
 |Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
@@ -217,11 +217,11 @@ Possible values are:
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=true\|false]{empty}footnote:ingnoredByParquet1[]
+|--ignore-extra-columns[=true\|false]footnote:ingnoredByParquet1[]
 |If unspecified columns should be ignored during the import.
 |false
 
-|--input-encoding=<character-set>{empty}footnote:ingnoredByParquet1[]
+|--input-encoding=<character-set>footnote:ingnoredByParquet1[]
 |Character set that input data is encoded in.
 |UTF-8
 
@@ -240,11 +240,11 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields=true\|false\|<path>[,<path>]{empty}footnote:ingnoredByParquet1[]
+|--multiline-fields=true\|false\|<path>[,<path>]footnote:ingnoredByParquet1[]
 |label:changed[Changed in 5.26] In v1, whether or not fields from an input source can span multiple lines, i.e. contain newline characters. Setting `--multiline-fields=true` can severely degrade the performance of the importer. Therefore, use it with care, especially with large imports. In v2, this option will specify the list of files that contain multiline fields. Files can also be specified using regular expressions.
 |null
 
-|--multiline-fields-format=v1\|v2{empty}footnote:ingnoredByParquet1[]
+|--multiline-fields-format=v1\|v2footnote:ingnoredByParquet1[]
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.
 |null
 
@@ -269,7 +269,7 @@ For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |Delete any existing database files prior to the import.
 |false
 
-|--quote=<char>{empty}footnote:ingnoredByParquet1[]
+|--quote=<char>footnote:ingnoredByParquet1[]
 |Character to treat as quotation character for values in CSV data.
 
 Quotes can be escaped as per link:{rfc-4180}[RFC 4180] by doubling them, for example `""` would be interpreted as a literal `"`.
@@ -344,7 +344,7 @@ If enabled all those relationships will be found but at the cost of lower perfor
 performance, this value should not be greater than the number of available processors.
 |20
 
-|--trim-strings[=true\|false]{empty}footnote:ingnoredByParquet1[]
+|--trim-strings[=true\|false]footnote:ingnoredByParquet1[]
 |Whether or not strings should be trimmed for whitespaces.
 |false
 
@@ -668,7 +668,7 @@ If the database into which you import does not exist prior to importing, you mus
 | Description
 | Default
 
-|--additional-config=<file>{empty}footnote:[See xref:tools/neo4j-admin/index.adoc#_configuration[Tools -> Configuration] for details.]
+|--additional-config=<file>footnote:[See xref:tools/neo4j-admin/index.adoc#_configuration[Tools -> Configuration] for details.]
 |Configuration file with additional configuration.
 |
 
@@ -687,7 +687,7 @@ For horizontal tabulation (HT), use `\t` or the Unicode character ID `\9`.
 Unicode character ID can be used if prepended by `\`.
 |;
 
-| --auto-skip-subsequent-headers[=true\|false]{empty}footnote:ingnoredByParquet2[Ignored by Parquet import.]
+| --auto-skip-subsequent-headers[=true\|false]footnote:ingnoredByParquet2[Ignored by Parquet import.]
 |Automatically skip accidental header lines in subsequent files in file groups with more than one file.
 |false
 
@@ -695,7 +695,7 @@ Unicode character ID can be used if prepended by `\`.
 |Number of bad entries before the import is aborted. The import process is optimized for error-free data. Therefore, cleaning the data before importing it is highly recommended. If you encounter any bad entries during the import process, you can set the number of bad entries to a specific value that suits your needs. However, setting a high value may affect the performance of the tool.
 |1000
 
-|--delimiter=<char>{empty}footnote:ingnoredByParquet2[]
+|--delimiter=<char>footnote:ingnoredByParquet2[]
 |Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
@@ -742,11 +742,11 @@ Possible values are:
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=true\|false]{empty}footnote:ingnoredByParquet2[]
+|--ignore-extra-columns[=true\|false]footnote:ingnoredByParquet2[]
 |If unspecified columns should be ignored during the import.
 |false
 
-|--input-encoding=<character-set>{empty}footnote:ingnoredByParquet2[]
+|--input-encoding=<character-set>footnote:ingnoredByParquet2[]
 |Character set that input data is encoded in.
 |UTF-8
 
@@ -765,11 +765,11 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields=true\|false\|<path>[,<path>]{empty}footnote:ingnoredByParquet2[]
+|--multiline-fields=true\|false\|<path>[,<path>]footnote:ingnoredByParquet2[]
 |label:changed[Changed in 5.26] In v1, whether or not fields from an input source can span multiple lines, i.e. contain newline characters. Setting `--multiline-fields=true` can severely degrade the performance of the importer. Therefore, use it with care, especially with large imports. In v2, this option will specify the list of files that contain multiline fields. Files can also be specified using regular expressions.
 |null
 
-|--multiline-fields-format=v1\|v2{empty}footnote:ingnoredByParquet2[]
+|--multiline-fields-format=v1\|v2footnote:ingnoredByParquet2[]
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.
 |null
 
@@ -790,7 +790,7 @@ For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |When `true`, non-array property values are converted to their equivalent Cypher types. For example, all integer values will be converted to 64-bit long integers.
 | true
 
-|--quote=<char>{empty}footnote:ingnoredByParquet2[]
+|--quote=<char>footnote:ingnoredByParquet2[]
 |Character to treat as quotation character for values in CSV data.
 
 Quotes can be escaped as per link:{rfc-4180}[RFC 4180] by doubling them, for example `""` would be interpreted as a literal `"`.
@@ -832,7 +832,7 @@ If you need to debug the import, it might be useful to collect the stack trace.
 This is done by using the `--verbose` option.
 |import.report
 
-|--schema=<path>{empty}footnote:[The `--schema` option is available in this version but not yet supported. It will be functional in a future release.]
+|--schema=<path>footnote:[The `--schema` option is available in this version but not yet supported. It will be functional in a future release.]
 |label:new[Introduced in 5.24] Path to the file containing the Cypher commands for creating indexes and constraints during data import.
 |
 
@@ -874,7 +874,7 @@ If enabled all those relationships will be found but at the cost of lower perfor
 performance, this value should not be greater than the number of available processors.
 |20
 
-|--trim-strings[=true\|false]{empty}footnote:ingnoredByParquet2[]
+|--trim-strings[=true\|false]footnote:ingnoredByParquet2[]
 |Whether or not strings should be trimmed for whitespaces.
 |false
 

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -141,7 +141,7 @@ The xref:tools/neo4j-admin/neo4j-admin-import.adoc#import-tool-examples[examples
 | Description
 | Default
 
-|--additional-config=<file>footnote:[See xref:tools/neo4j-admin/index.adoc#_configuration[Tools -> Configuration] for details.]
+|--additional-config=<file>{empty}footnote:[See xref:tools/neo4j-admin/index.adoc#_configuration[Tools -> Configuration] for details.]
 |Configuration file with additional configuration.
 |
 
@@ -160,7 +160,7 @@ For horizontal tabulation (HT), use `\t` or the Unicode character ID `\9`.
 Unicode character ID can be used if prepended by `\`.
 |;
 
-| --auto-skip-subsequent-headers[=true\|false] footnote:ingnoredByParquet1[Ignored by Parquet import.]
+| --auto-skip-subsequent-headers[=true\|false]{empty}footnote:ingnoredByParquet1[Ignored by Parquet import.]
 |Automatically skip accidental header lines in subsequent files in file groups with more than one file.
 |false
 
@@ -168,7 +168,7 @@ Unicode character ID can be used if prepended by `\`.
 |Number of bad entries before the import is aborted. The import process is optimized for error-free data. Therefore, cleaning the data before importing it is highly recommended. If you encounter any bad entries during the import process, you can set the number of bad entries to a specific value that suits your needs. However, setting a high value may affect the performance of the tool.
 |1000
 
-|--delimiter=<char> footnote:ingnoredByParquet1[]
+|--delimiter=<char>{empty}footnote:ingnoredByParquet1[]
 |Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
@@ -217,11 +217,11 @@ Possible values are:
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=true\|false] footnote:ingnoredByParquet1[]
+|--ignore-extra-columns[=true\|false]{empty}footnote:ingnoredByParquet1[]
 |If unspecified columns should be ignored during the import.
 |false
 
-|--input-encoding=<character-set> footnote:ingnoredByParquet1[]
+|--input-encoding=<character-set>{empty}footnote:ingnoredByParquet1[]
 |Character set that input data is encoded in.
 |UTF-8
 
@@ -240,11 +240,11 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields=true\|false\|<path>[,<path>] footnote:ingnoredByParquet1[]
+|--multiline-fields=true\|false\|<path>[,<path>]{empty}footnote:ingnoredByParquet1[]
 |label:changed[Changed in 5.26] In v1, whether or not fields from an input source can span multiple lines, i.e. contain newline characters. Setting `--multiline-fields=true` can severely degrade the performance of the importer. Therefore, use it with care, especially with large imports. In v2, this option will specify the list of files that contain multiline fields. Files can also be specified using regular expressions.
 |null
 
-|--multiline-fields-format=v1\|v2 footnote:ingnoredByParquet1[]
+|--multiline-fields-format=v1\|v2{empty}footnote:ingnoredByParquet1[]
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.
 |null
 
@@ -269,7 +269,7 @@ For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |Delete any existing database files prior to the import.
 |false
 
-|--quote=<char> footnote:ingnoredByParquet1[]
+|--quote=<char>{empty}footnote:ingnoredByParquet1[]
 |Character to treat as quotation character for values in CSV data.
 
 Quotes can be escaped as per link:{rfc-4180}[RFC 4180] by doubling them, for example `""` would be interpreted as a literal `"`.
@@ -344,7 +344,7 @@ If enabled all those relationships will be found but at the cost of lower perfor
 performance, this value should not be greater than the number of available processors.
 |20
 
-|--trim-strings[=true\|false] footnote:ingnoredByParquet1[]
+|--trim-strings[=true\|false]{empty}footnote:ingnoredByParquet1[]
 |Whether or not strings should be trimmed for whitespaces.
 |false
 
@@ -668,7 +668,7 @@ If the database into which you import does not exist prior to importing, you mus
 | Description
 | Default
 
-|--additional-config=<file>footnote:[See xref:tools/neo4j-admin/index.adoc#_configuration[Tools -> Configuration] for details.]
+|--additional-config=<file>{empty}footnote:[See xref:tools/neo4j-admin/index.adoc#_configuration[Tools -> Configuration] for details.]
 |Configuration file with additional configuration.
 |
 
@@ -687,7 +687,7 @@ For horizontal tabulation (HT), use `\t` or the Unicode character ID `\9`.
 Unicode character ID can be used if prepended by `\`.
 |;
 
-| --auto-skip-subsequent-headers[=true\|false] footnote:ingnoredByParquet2[Ignored by Parquet import.]
+| --auto-skip-subsequent-headers[=true\|false]{empty}footnote:ingnoredByParquet2[Ignored by Parquet import.]
 |Automatically skip accidental header lines in subsequent files in file groups with more than one file.
 |false
 
@@ -695,7 +695,7 @@ Unicode character ID can be used if prepended by `\`.
 |Number of bad entries before the import is aborted. The import process is optimized for error-free data. Therefore, cleaning the data before importing it is highly recommended. If you encounter any bad entries during the import process, you can set the number of bad entries to a specific value that suits your needs. However, setting a high value may affect the performance of the tool.
 |1000
 
-|--delimiter=<char> footnote:ingnoredByParquet2[]
+|--delimiter=<char>{empty}footnote:ingnoredByParquet2[]
 |Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
@@ -742,11 +742,11 @@ Possible values are:
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=true\|false] footnote:ingnoredByParquet2[]
+|--ignore-extra-columns[=true\|false]{empty}footnote:ingnoredByParquet2[]
 |If unspecified columns should be ignored during the import.
 |false
 
-|--input-encoding=<character-set> footnote:ingnoredByParquet2[]
+|--input-encoding=<character-set>{empty}footnote:ingnoredByParquet2[]
 |Character set that input data is encoded in.
 |UTF-8
 
@@ -765,11 +765,11 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields=true\|false\|<path>[,<path>] footnote:ingnoredByParquet2[]
+|--multiline-fields=true\|false\|<path>[,<path>]{empty}footnote:ingnoredByParquet2[]
 |label:changed[Changed in 5.26] In v1, whether or not fields from an input source can span multiple lines, i.e. contain newline characters. Setting `--multiline-fields=true` can severely degrade the performance of the importer. Therefore, use it with care, especially with large imports. In v2, this option will specify the list of files that contain multiline fields. Files can also be specified using regular expressions.
 |null
 
-|--multiline-fields-format=v1\|v2 footnote:ingnoredByParquet2[]
+|--multiline-fields-format=v1\|v2{empty}footnote:ingnoredByParquet2[]
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.
 |null
 
@@ -790,7 +790,7 @@ For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |When `true`, non-array property values are converted to their equivalent Cypher types. For example, all integer values will be converted to 64-bit long integers.
 | true
 
-|--quote=<char> footnote:ingnoredByParquet2[]
+|--quote=<char>{empty}footnote:ingnoredByParquet2[]
 |Character to treat as quotation character for values in CSV data.
 
 Quotes can be escaped as per link:{rfc-4180}[RFC 4180] by doubling them, for example `""` would be interpreted as a literal `"`.
@@ -832,7 +832,7 @@ If you need to debug the import, it might be useful to collect the stack trace.
 This is done by using the `--verbose` option.
 |import.report
 
-|--schema=<path> footnote:[The `--schema` option is available in this version but not yet supported. It will be functional in a future release.]
+|--schema=<path>{empty}footnote:[The `--schema` option is available in this version but not yet supported. It will be functional in a future release.]
 |label:new[Introduced in 5.24] Path to the file containing the Cypher commands for creating indexes and constraints during data import.
 |
 
@@ -874,7 +874,7 @@ If enabled all those relationships will be found but at the cost of lower perfor
 performance, this value should not be greater than the number of available processors.
 |20
 
-|--trim-strings[=true\|false] footnote:ingnoredByParquet2[]
+|--trim-strings[=true\|false]{empty}footnote:ingnoredByParquet2[]
 |Whether or not strings should be trimmed for whitespaces.
 |false
 

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -4,7 +4,10 @@
 
 :rfc-4180: https://tools.ietf.org/html/rfc4180
 
-`neo4j-admin database import` writes CSV data into Neo4j's native file format as fast as possible. You should use this tool when:
+`neo4j-admin database import` writes CSV data into Neo4j's native file format as fast as possible. +
+From Neo4j 5.25, Neo4j also provides support for the Parquet file format in a public beta version.
+
+You should use this tool when:
 
 * Import performance is important because you have a large amount of data (millions/billions of entities).
 * The database can be taken offline and you have direct access to one of the servers hosting your Neo4j DBMS.
@@ -24,17 +27,6 @@ See link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/load-csv/[Cy
 Change Data Capture does **not** capture any data changes resulting from the use of `neo4j-admin database import`.
 See link:{neo4j-docs-base-uri}/cdc/current/get-started/self-managed/#non-tx-log-changes/[Change Data Capture -> Key considerations] for more information.
 ====
-
-[role=label--beta]
-== Parquet file support
-Starting with Neo4j 5.24, Neo4j provides support for the Parquet file format in a public beta version.
-The additional parameter `--input-type [csv|parquet]` was introduced to explicitly tell the importer to use either CSV or Parquet.
-Its value defaults to CSV if it is not defined.
-
-Most of the parameters that can be used to configure the import are also valid for the Parquet format.
-There are indicators in the parameter overview to point out which parameters are supported.
-
-The xref:tools/neo4j-admin/neo4j-admin-import.adoc#import-tool-examples[examples] for CSV can also be used with Parquet.
 
 == Overview
 
@@ -92,6 +84,7 @@ The syntax for importing a set of CSV files is:
 ----
 neo4j-admin database import full [-h] [--expand-commands] [--verbose] [--auto-skip-subsequent-headers[=true|false]]
                                  [--ignore-empty-strings[=true|false]] [--ignore-extra-columns[=true|false]]
+<<<<<<< HEAD
                                  [--legacy-style-quoting[=true|false]] [--normalize-types[=true|false]]
                                  [--overwrite-destination[=true|false]] [--skip-bad-entries-logging[=true|false]]
                                  [--skip-bad-relationships[=true|false]] [--skip-duplicate-nodes[=true|false]] [--strict
@@ -104,6 +97,20 @@ neo4j-admin database import full [-h] [--expand-commands] [--verbose] [--auto-sk
                                  <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
                                  [--relationships=[<type>=]<files>...]... [--multiline-fields=true|false|<path>[,
                                  <path>] [--multiline-fields-format=v1|v2]] <database>
+=======
+                                 [--legacy-style-quoting[=true|false]] [--multiline-fields[=true|false]]
+                                 [--normalize-types[=true|false]] [--overwrite-destination[=true|false]]
+                                 [--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships[=true|false]]
+                                 [--skip-duplicate-nodes[=true|false]] [--strict[=true|false]] [--trim-strings
+                                 [=true|false]] [--additional-config=<file>] [--array-delimiter=<char>]
+                                 [--bad-tolerance=<num>] [--delimiter=<char>] [--format=<format>]
+                                 [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual]
+                                 [--input-encoding=<character-set>] [--input-type[=csv\|parquet]]
+                                 [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>]
+                                 [--report-file=<path>] [--schema=<path>] [--threads=<num>]
+                                 --nodes=[<label>[:<label>]...=]<files>... [--nodes=[<label>[:<label>]...=]
+                                 <files>...]... [--relationships=[<type>=]<files>...]... <database>
+>>>>>>> 93d77067 (editorial changes)
 ----
 
 === Description
@@ -135,6 +142,21 @@ For more information, please contact Neo4j Professional Services.
 
 === Options
 
+[role=label--beta]
+.Parquet file support
+[NOTE]
+====
+Starting with Neo4j 5.25, Neo4j provides support for the Parquet file format in a public beta version.
+The additional parameter `--input-type [csv|parquet]` is introduced to explicitly tell the importer to use either CSV or Parquet.
+Its value defaults to CSV if it is not defined.
+
+Most of the parameters that can be used to configure the import are also valid for the Parquet format.
+There are indicators in the <<full-import-options-table, `neo4j-admin database import full` options>> table to point out which parameters are not supported.
+
+The xref:tools/neo4j-admin/neo4j-admin-import.adoc#import-tool-examples[examples] for CSV can also be used with Parquet.
+====
+
+[[full-import-options-table]]
 .`neo4j-admin database import full` options
 [options="header", cols="5m,10a,2m"]
 |===
@@ -228,7 +250,7 @@ Possible values are:
 
 |--input-type[=csv\|parquet]
 label:beta[]
-|File type to import.
+|File type to import from. Can be csv or parquet. Defaults to csv.
 |csv
 
 |--legacy-style-quoting[=true\|false]
@@ -661,6 +683,21 @@ If the database into which you import does not exist prior to importing, you mus
 
 === Options
 
+[role=label--beta]
+.Parquet file support
+[NOTE]
+====
+Starting with Neo4j 5.25, Neo4j provides support for the Parquet file format in a public beta version.
+The additional parameter `--input-type [csv|parquet]` is introduced to explicitly tell the importer to use either CSV or Parquet.
+Its value defaults to CSV if it is not defined.
+
+Most of the parameters that can be used to configure the import are also valid for the Parquet format.
+There are indicators in the <<incremental-import-options-table, `neo4j-admin database import incremental` options>> table to point out which parameters are not supported.
+
+The xref:tools/neo4j-admin/neo4j-admin-import.adoc#import-tool-examples[examples] for CSV can also be used with Parquet.
+====
+
+[[incremental-import-options-table]]
 .`neo4j-admin database import incremental` options
 [options="header", cols="5m,10a,2m"]
 |===
@@ -752,7 +789,7 @@ Possible values are:
 
 |--input-type[=csv\|parquet]
 label:beta[]
-|File type to import.
+|File type to import from. Can be csv or parquet. Defaults to csv.
 |csv
 
 |--legacy-style-quoting[=true\|false]

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -242,8 +242,7 @@ Possible values are:
 |UTF-8
 
 |--input-type[=csv\|parquet]
-label:beta[]
-|File type to import from. Can be csv or parquet. Defaults to csv.
+|label:beta[] File type to import from. Can be csv or parquet. Defaults to csv.
 |csv
 
 |--legacy-style-quoting[=true\|false]
@@ -613,15 +612,11 @@ The syntax for importing a set of CSV files incrementally is:
 ----
 neo4j-admin database import incremental [-h] [--expand-commands] --force [--verbose] [--auto-skip-subsequent-headers[=true|false]]
                                         [--ignore-empty-strings[=true|false]] [--ignore-extra-columns[=true|false]]
-                                        [--legacy-style-quoting[=true|false]] [--multiline-fields[=true|false]] [--normalize-types[=true|false]]
-                                        [--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships[=true|false]]
+                                        [--legacy-style-quoting[=true|false]] [--multiline-fields[=true|false]] [--normalize-types[=true|false]][--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships[=true|false]]
                                         [--skip-duplicate-nodes[=true|false]] [--strict[=true|false]] [--trim-strings[=true|false]]
                                         [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>] [--delimiter=<char>]
                                         [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual] [--input-encoding=<character-set>]
-                                        [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>]
-                                        [--report-file=<path>] [--stage=all|prepare|build|merge] [--threads=<num>]
-                                        --nodes=[<label>[: <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
-                                        [--relationships=[<type>=]<files>...]... <database>
+                                        [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>] [--report-file=<path>] [--schema=<file>] [--stage=all|prepare|build|merge] [--threads=<num>] --nodes=[<label>[: <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]... [--relationships=[<type>=]<files>...]... <database>
 ----
 
 === Description
@@ -785,8 +780,7 @@ Possible values are:
 |UTF-8
 
 |--input-type[=csv\|parquet]
-label:beta[]
-|File type to import from. Can be csv or parquet. Defaults to csv.
+|label:beta[] File type to import from. Can be csv or parquet. Defaults to csv.
 |csv
 
 |--legacy-style-quoting[=true\|false]

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -136,7 +136,15 @@ The additional parameter `--input-type [csv|parquet]` is introduced to explicitl
 Its value defaults to CSV if it is not defined.
 
 Most of the parameters that can be used to configure the import are also valid for the Parquet format.
-There are indicators in the <<full-import-options-table, `neo4j-admin database import full` options>> table to point out which parameters are not supported.
+The following parameters are not supported (see <<full-import-options-table, `neo4j-admin database import full` options>> table for more details):
+
+- `--auto-skip-subsequent-headers`
+- `--delimiter`
+- `--ignore-extra-columns`
+- `--input-encoding`
+- `--multiline-fields`
+- `--quote`
+- `--trim-strings`
 
 The xref:tools/neo4j-admin/neo4j-admin-import.adoc#import-tool-examples[examples] for CSV can also be used with Parquet.
 ====
@@ -168,7 +176,7 @@ For horizontal tabulation (HT), use `\t` or the Unicode character ID `\9`.
 Unicode character ID can be used if prepended by `\`.
 |;
 
-| --auto-skip-subsequent-headers[=true\|false]^1^
+| --auto-skip-subsequent-headers[=true\|false]
 |Automatically skip accidental header lines in subsequent files in file groups with more than one file.
 |false
 
@@ -176,7 +184,7 @@ Unicode character ID can be used if prepended by `\`.
 |Number of bad entries before the import is aborted. The import process is optimized for error-free data. Therefore, cleaning the data before importing it is highly recommended. If you encounter any bad entries during the import process, you can set the number of bad entries to a specific value that suits your needs. However, setting a high value may affect the performance of the tool.
 |1000
 
-|--delimiter=<char>^1^
+|--delimiter=<char>
 |Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
@@ -225,11 +233,11 @@ Possible values are:
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=true\|false]^1^
+|--ignore-extra-columns[=true\|false]
 |If unspecified columns should be ignored during the import.
 |false
 
-|--input-encoding=<character-set>^1^
+|--input-encoding=<character-set>
 |Character set that input data is encoded in.
 |UTF-8
 
@@ -249,7 +257,7 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields[=true\|false]^1^
+|--multiline-fields[=true\|false]
 |Whether or not fields from an input source can span multiple lines, i.e. contain newline characters.
 
 |--multiline-fields-format=v1\|v2
@@ -277,7 +285,7 @@ For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |Delete any existing database files prior to the import.
 |false
 
-|--quote=<char>^1^
+|--quote=<char>
 |Character to treat as quotation character for values in CSV data.
 
 Quotes can be escaped as per link:{rfc-4180}[RFC 4180] by doubling them, for example `""` would be interpreted as a literal `"`.
@@ -352,7 +360,7 @@ If enabled all those relationships will be found but at the cost of lower perfor
 performance, this value should not be greater than the number of available processors.
 |20
 
-|--trim-strings[=true\|false]^1^
+|--trim-strings[=true\|false]
 |Whether or not strings should be trimmed for whitespaces.
 |false
 
@@ -360,8 +368,6 @@ performance, this value should not be greater than the number of available proce
 |Enable verbose output.
 |
 |===
-
-^1^ __Ignored by Parquet import label:beta[].__ +
 
 [NOTE]
 .Heap size for the import
@@ -676,7 +682,15 @@ The additional parameter `--input-type [csv|parquet]` is introduced to explicitl
 Its value defaults to CSV if it is not defined.
 
 Most of the parameters that can be used to configure the import are also valid for the Parquet format.
-There are indicators in the <<incremental-import-options-table, `neo4j-admin database import incremental` options>> table to point out which parameters are not supported.
+The following parameters are not supported (see <<incremental-import-options-table, `neo4j-admin database import incremental` options>> table for more details):
+
+ - `--auto-skip-subsequent-headers`
+ - `--delimiter`
+ - `--ignore-extra-columns`
+ - `--input-encoding`
+ - `--multiline-fields`
+ - `--quote`
+ - `--trim-strings`
 
 The xref:tools/neo4j-admin/neo4j-admin-import.adoc#import-tool-examples[examples] for CSV can also be used with Parquet.
 ====
@@ -708,7 +722,7 @@ For horizontal tabulation (HT), use `\t` or the Unicode character ID `\9`.
 Unicode character ID can be used if prepended by `\`.
 |;
 
-| --auto-skip-subsequent-headers[=true\|false]^1^
+| --auto-skip-subsequent-headers[=true\|false]
 |Automatically skip accidental header lines in subsequent files in file groups with more than one file.
 |false
 
@@ -716,7 +730,7 @@ Unicode character ID can be used if prepended by `\`.
 |Number of bad entries before the import is aborted. The import process is optimized for error-free data. Therefore, cleaning the data before importing it is highly recommended. If you encounter any bad entries during the import process, you can set the number of bad entries to a specific value that suits your needs. However, setting a high value may affect the performance of the tool.
 |1000
 
-|--delimiter=<char>^1^
+|--delimiter=<char>
 |Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
@@ -763,11 +777,11 @@ Possible values are:
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=true\|false]^1^
+|--ignore-extra-columns[=true\|false]
 |If unspecified columns should be ignored during the import.
 |false
 
-|--input-encoding=<character-set>^1^
+|--input-encoding=<character-set>
 |Character set that input data is encoded in.
 |UTF-8
 
@@ -787,7 +801,7 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields[=true\|false]^1^
+|--multiline-fields[=true\|false]
 |Whether or not fields from an input source can span multiple lines, i.e. contain newline characters.
 
 |--multiline-fields-format=v1\|v2
@@ -811,7 +825,7 @@ For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |When `true`, non-array property values are converted to their equivalent Cypher types. For example, all integer values will be converted to 64-bit long integers.
 | true
 
-|--quote=<char>^1^
+|--quote=<char>
 |Character to treat as quotation character for values in CSV data.
 
 Quotes can be escaped as per link:{rfc-4180}[RFC 4180] by doubling them, for example `""` would be interpreted as a literal `"`.
@@ -895,7 +909,7 @@ If enabled all those relationships will be found but at the cost of lower perfor
 performance, this value should not be greater than the number of available processors.
 |20
 
-|--trim-strings[=true\|false]^1^
+|--trim-strings[=true\|false]
 |Whether or not strings should be trimmed for whitespaces.
 |false
 
@@ -903,8 +917,6 @@ performance, this value should not be greater than the number of available proce
 |Enable verbose output.
 |
 |===
-
-^1^ __Ignored by Parquet import label:beta[].__ +
 
 [NOTE]
 .Using both a multi-value option and a positional parameter

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -5,7 +5,7 @@
 :rfc-4180: https://tools.ietf.org/html/rfc4180
 
 `neo4j-admin database import` writes CSV data into Neo4j's native file format as fast as possible. +
-From Neo4j 5.25, Neo4j also provides support for the Parquet file format in a public beta version.
+Starting with version 5.26, Neo4j also provides support for the Parquet file format.
 
 You should use this tool when:
 
@@ -128,27 +128,10 @@ For more information, please contact Neo4j Professional Services.
 
 === Options
 
-[role=label--beta]
-.Parquet file support
-[NOTE]
-====
-Starting with Neo4j 5.25, Neo4j provides support for the Parquet file format in a public beta version.
-The additional parameter `--input-type [csv|parquet]` is introduced to explicitly tell the importer to use either CSV or Parquet.
-Its value defaults to CSV if it is not defined.
-
-Most of the parameters that can be used to configure the import are also valid for the Parquet format.
-The following parameters are not supported (see <<full-import-options-table, `neo4j-admin database import full` options>> table for more details):
-
-- `--auto-skip-subsequent-headers`
-- `--delimiter`
-- `--ignore-extra-columns`
-- `--input-encoding`
-- `--multiline-fields`
-- `--quote`
-- `--trim-strings`
-
+Starting from Neo4j 5.26, the importer also supports the Parquet file format.
+An additional parameter `--input-type=csv|parquet` has been introduced to explicitly specify whether to use CSV or Parquet for the importer.
+If not defined, the default value will be CSV.
 The xref:tools/neo4j-admin/neo4j-admin-import.adoc#import-tool-examples[examples] for CSV can also be used with Parquet.
-====
 
 [[full-import-options-table]]
 .`neo4j-admin database import full` options
@@ -177,7 +160,7 @@ For horizontal tabulation (HT), use `\t` or the Unicode character ID `\9`.
 Unicode character ID can be used if prepended by `\`.
 |;
 
-| --auto-skip-subsequent-headers[=true\|false]
+| --auto-skip-subsequent-headers[=true\|false] footnote:ingnoredByParquet1[Ignored by Parquet import.]
 |Automatically skip accidental header lines in subsequent files in file groups with more than one file.
 |false
 
@@ -185,7 +168,7 @@ Unicode character ID can be used if prepended by `\`.
 |Number of bad entries before the import is aborted. The import process is optimized for error-free data. Therefore, cleaning the data before importing it is highly recommended. If you encounter any bad entries during the import process, you can set the number of bad entries to a specific value that suits your needs. However, setting a high value may affect the performance of the tool.
 |1000
 
-|--delimiter=<char>
+|--delimiter=<char> footnote:ingnoredByParquet1[]
 |Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
@@ -234,16 +217,16 @@ Possible values are:
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=true\|false]
+|--ignore-extra-columns[=true\|false] footnote:ingnoredByParquet1[]
 |If unspecified columns should be ignored during the import.
 |false
 
-|--input-encoding=<character-set>
+|--input-encoding=<character-set> footnote:ingnoredByParquet1[]
 |Character set that input data is encoded in.
 |UTF-8
 
 |--input-type=csv\|parquet
-|label:beta[] File type to import from. Can be csv or parquet. Defaults to csv.
+|label:new[Introduced in 5.26] File type to import from. Can be csv or parquet. Defaults to csv.
 |csv
 
 |--legacy-style-quoting[=true\|false]
@@ -257,11 +240,11 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields=true\|false\|<path>[,<path>]
+|--multiline-fields=true\|false\|<path>[,<path>] footnote:ingnoredByParquet1[]
 |label:changed[Changed in 5.26] In v1, whether or not fields from an input source can span multiple lines, i.e. contain newline characters. Setting `--multiline-fields=true` can severely degrade the performance of the importer. Therefore, use it with care, especially with large imports. In v2, this option will specify the list of files that contain multiline fields. Files can also be specified using regular expressions.
 |null
 
-|--multiline-fields-format=v1\|v2
+|--multiline-fields-format=v1\|v2 footnote:ingnoredByParquet1[]
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.
 |null
 
@@ -286,7 +269,7 @@ For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |Delete any existing database files prior to the import.
 |false
 
-|--quote=<char>
+|--quote=<char> footnote:ingnoredByParquet1[]
 |Character to treat as quotation character for values in CSV data.
 
 Quotes can be escaped as per link:{rfc-4180}[RFC 4180] by doubling them, for example `""` would be interpreted as a literal `"`.
@@ -361,7 +344,7 @@ If enabled all those relationships will be found but at the cost of lower perfor
 performance, this value should not be greater than the number of available processors.
 |20
 
-|--trim-strings[=true\|false]
+|--trim-strings[=true\|false] footnote:ingnoredByParquet1[]
 |Whether or not strings should be trimmed for whitespaces.
 |false
 
@@ -465,7 +448,7 @@ bin/neo4j-admin database import full --nodes import/movies_header.csv,import/mov
 [[indexes-constraints-import]]
 ==== Provide indexes and constraints during import
 
-Starting with Neo4j 5.24, you can use the `--schema` option that allows Cypher commands to be provided to create indexes/constraints during the initial import process.
+Starting from Neo4j 5.24, you can use the `--schema` option that allows Cypher commands to be provided to create indexes/constraints during the initial import process.
 It currently only works for the block format and full import.
 
 You should have a Cypher script containing only `CREATE INDEX|CONSTRAINT` commands to be parsed and executed.
@@ -677,28 +660,6 @@ If the database into which you import does not exist prior to importing, you mus
 
 === Options
 
-[role=label--beta]
-.Parquet file support
-[NOTE]
-====
-Starting with Neo4j 5.25, Neo4j provides support for the Parquet file format in a public beta version.
-The additional parameter `--input-type [csv|parquet]` is introduced to explicitly tell the importer to use either CSV or Parquet.
-Its value defaults to CSV if it is not defined.
-
-Most of the parameters that can be used to configure the import are also valid for the Parquet format.
-The following parameters are not supported (see <<incremental-import-options-table, `neo4j-admin database import incremental` options>> table for more details):
-
- - `--auto-skip-subsequent-headers`
- - `--delimiter`
- - `--ignore-extra-columns`
- - `--input-encoding`
- - `--multiline-fields`
- - `--quote`
- - `--trim-strings`
-
-The xref:tools/neo4j-admin/neo4j-admin-import.adoc#import-tool-examples[examples] for CSV can also be used with Parquet.
-====
-
 [[incremental-import-options-table]]
 .`neo4j-admin database import incremental` options
 [options="header", cols="5m,10a,2m"]
@@ -726,7 +687,7 @@ For horizontal tabulation (HT), use `\t` or the Unicode character ID `\9`.
 Unicode character ID can be used if prepended by `\`.
 |;
 
-| --auto-skip-subsequent-headers[=true\|false]
+| --auto-skip-subsequent-headers[=true\|false] footnote:ingnoredByParquet2[Ignored by Parquet import.]
 |Automatically skip accidental header lines in subsequent files in file groups with more than one file.
 |false
 
@@ -734,7 +695,7 @@ Unicode character ID can be used if prepended by `\`.
 |Number of bad entries before the import is aborted. The import process is optimized for error-free data. Therefore, cleaning the data before importing it is highly recommended. If you encounter any bad entries during the import process, you can set the number of bad entries to a specific value that suits your needs. However, setting a high value may affect the performance of the tool.
 |1000
 
-|--delimiter=<char>
+|--delimiter=<char> footnote:ingnoredByParquet2[]
 |Delimiter character between values in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 
 ====
@@ -781,16 +742,16 @@ Possible values are:
 |Whether or not empty string fields, i.e. "" from input source are ignored, i.e. treated as null.
 |false
 
-|--ignore-extra-columns[=true\|false]
+|--ignore-extra-columns[=true\|false] footnote:ingnoredByParquet2[]
 |If unspecified columns should be ignored during the import.
 |false
 
-|--input-encoding=<character-set>
+|--input-encoding=<character-set> footnote:ingnoredByParquet2[]
 |Character set that input data is encoded in.
 |UTF-8
 
 |--input-type=csv\|parquet
-|label:beta[] File type to import from. Can be csv or parquet. Defaults to csv.
+|label:new[Introduced in 5.26]File type to import from. Can be csv or parquet. Defaults to csv.
 |csv
 
 |--legacy-style-quoting[=true\|false]
@@ -804,11 +765,11 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields=true\|false\|<path>[,<path>]
+|--multiline-fields=true\|false\|<path>[,<path>] footnote:ingnoredByParquet2[]
 |label:changed[Changed in 5.26] In v1, whether or not fields from an input source can span multiple lines, i.e. contain newline characters. Setting `--multiline-fields=true` can severely degrade the performance of the importer. Therefore, use it with care, especially with large imports. In v2, this option will specify the list of files that contain multiline fields. Files can also be specified using regular expressions.
 |null
 
-|--multiline-fields-format=v1\|v2
+|--multiline-fields-format=v1\|v2 footnote:ingnoredByParquet2[]
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.
 |null
 
@@ -829,7 +790,7 @@ For an example, see <<import-tool-multiple-input-files-regex-example>>.
 |When `true`, non-array property values are converted to their equivalent Cypher types. For example, all integer values will be converted to 64-bit long integers.
 | true
 
-|--quote=<char>
+|--quote=<char> footnote:ingnoredByParquet2[]
 |Character to treat as quotation character for values in CSV data.
 
 Quotes can be escaped as per link:{rfc-4180}[RFC 4180] by doubling them, for example `""` would be interpreted as a literal `"`.
@@ -913,7 +874,7 @@ If enabled all those relationships will be found but at the cost of lower perfor
 performance, this value should not be greater than the number of available processors.
 |20
 
-|--trim-strings[=true\|false]
+|--trim-strings[=true\|false] footnote:ingnoredByParquet2[]
 |Whether or not strings should be trimmed for whitespaces.
 |false
 

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -616,7 +616,7 @@ neo4j-admin database import incremental [-h] [--expand-commands] --force [--verb
                                         [--skip-duplicate-nodes[=true|false]] [--strict[=true|false]] [--trim-strings[=true|false]]
                                         [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>] [--delimiter=<char>]
                                         [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual] [--input-encoding=<character-set>]
-                                        [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>] [--report-file=<path>] [--schema=<file>] [--stage=all|prepare|build|merge] [--threads=<num>] --nodes=[<label>[: <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]... [--relationships=[<type>=]<files>...]... <database>
+                                        [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>] [--report-file=<path>] [--schema=<path>] [--stage=all|prepare|build|merge] [--threads=<num>] --nodes=[<label>[: <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]... [--relationships=[<type>=]<files>...]... <database>
 ----
 
 === Description

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -84,20 +84,6 @@ The syntax for importing a set of CSV files is:
 ----
 neo4j-admin database import full [-h] [--expand-commands] [--verbose] [--auto-skip-subsequent-headers[=true|false]]
                                  [--ignore-empty-strings[=true|false]] [--ignore-extra-columns[=true|false]]
-<<<<<<< HEAD
-                                 [--legacy-style-quoting[=true|false]] [--normalize-types[=true|false]]
-                                 [--overwrite-destination[=true|false]] [--skip-bad-entries-logging[=true|false]]
-                                 [--skip-bad-relationships[=true|false]] [--skip-duplicate-nodes[=true|false]] [--strict
-                                 [=true|false]] [--trim-strings[=true|false]] [--additional-config=<file>]
-                                 [--array-delimiter=<char>] [--bad-tolerance=<num>] [--delimiter=<char>]
-                                 [--format=<format>] [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual]
-                                 [--input-encoding=<character-set>] [--input-type=csv|parquet]
-                                 [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>]
-                                 [--report-file=<path>] [--schema=<path>] [--threads=<num>] --nodes=[<label>[:
-                                 <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
-                                 [--relationships=[<type>=]<files>...]... [--multiline-fields=true|false|<path>[,
-                                 <path>] [--multiline-fields-format=v1|v2]] <database>
-=======
                                  [--legacy-style-quoting[=true|false]] [--multiline-fields[=true|false]]
                                  [--normalize-types[=true|false]] [--overwrite-destination[=true|false]]
                                  [--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships[=true|false]]
@@ -105,12 +91,11 @@ neo4j-admin database import full [-h] [--expand-commands] [--verbose] [--auto-sk
                                  [=true|false]] [--additional-config=<file>] [--array-delimiter=<char>]
                                  [--bad-tolerance=<num>] [--delimiter=<char>] [--format=<format>]
                                  [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual]
-                                 [--input-encoding=<character-set>] [--input-type[=csv\|parquet]]
+                                 [--input-encoding=<character-set>] [--input-type[=csv|parquet]]
                                  [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>]
                                  [--report-file=<path>] [--schema=<path>] [--threads=<num>]
                                  --nodes=[<label>[:<label>]...=]<files>... [--nodes=[<label>[:<label>]...=]
                                  <files>...]... [--relationships=[<type>=]<files>...]... <database>
->>>>>>> 93d77067 (editorial changes)
 ----
 
 === Description
@@ -627,12 +612,11 @@ neo4j-admin database import incremental [-h] [--expand-commands] --force [--verb
                                         [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>]
                                         [--delimiter=<char>] [--high-parallel-io=on|off|auto]
                                         [--id-type=string|integer|actual] [--input-encoding=<character-set>]
-                                        [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>]
-                                        [--read-buffer-size=<size>] [--report-file=<path>] [--schema=<path>]
-                                        [--stage=all|prepare|build|merge] [--threads=<num>] --nodes=[<label>[:
-                                        <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
-                                        [--relationships=[<type>=]<files>...]... [--multiline-fields=true|false|<path>[,
-                                        <path>] [--multiline-fields-format=v1|v2]] <database>
+                                        [--input-type[=csv|parquet]] [--max-off-heap-memory=<size>]
+                                        [--quote=<char>] [--read-buffer-size=<size>] [--report-file=<path>]
+                                        [--stage=all|prepare|build|merge] [--threads=<num>]
+                                        --nodes=[<label>[:<label>]...=]<files>... [--nodes=[<label>[:<label>]...=]
+                                        <files>...]... [--relationships=[<type>=]<files>...]... <database>
 ----
 
 === Description

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -81,21 +81,21 @@ See <<indexes-constraints-import, Provide indexes and constraints during import>
 
 The syntax for importing a set of CSV files is:
 
+[source, syntax, role="nocopy"]
 ----
 neo4j-admin database import full [-h] [--expand-commands] [--verbose] [--auto-skip-subsequent-headers[=true|false]]
                                  [--ignore-empty-strings[=true|false]] [--ignore-extra-columns[=true|false]]
                                  [--legacy-style-quoting[=true|false]] [--multiline-fields[=true|false]]
                                  [--normalize-types[=true|false]] [--overwrite-destination[=true|false]]
                                  [--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships[=true|false]]
-                                 [--skip-duplicate-nodes[=true|false]] [--strict[=true|false]] [--trim-strings
-                                 [=true|false]] [--additional-config=<file>] [--array-delimiter=<char>]
-                                 [--bad-tolerance=<num>] [--delimiter=<char>] [--format=<format>]
-                                 [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual]
-                                 [--input-encoding=<character-set>] [--input-type[=csv|parquet]]
-                                 [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>]
-                                 [--report-file=<path>] [--schema=<path>] [--threads=<num>]
-                                 --nodes=[<label>[:<label>]...=]<files>... [--nodes=[<label>[:<label>]...=]
-                                 <files>...]... [--relationships=[<type>=]<files>...]... <database>
+                                 [--skip-duplicate-nodes[=true|false]] [--strict[=true|false]] [--trim-strings[=true|false]]
+                                 [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>]
+                                 [--delimiter=<char>] [--format=<format>] [--high-parallel-io=on|off|auto]
+                                 [--id-type=string|integer|actual] [--input-encoding=<character-set>]
+                                 [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>]
+                                 [--read-buffer-size=<size>] [--report-file=<path>] [--schema=<path>] [--threads=<num>]
+                                 --nodes=[<label>[: <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
+                                 [--relationships=[<type>=]<files>...]... <database>
 ----
 
 === Description
@@ -607,22 +607,21 @@ It is highly recommended to back up your database before running the incremental
 [[import-tool-incremental-syntax]]
 === Syntax
 
-[source, shell, role=noplay]
+The syntax for importing a set of CSV files incrementally is:
+
+[source, syntax, role="nocopy"]
 ----
-neo4j-admin database import incremental [-h] [--expand-commands] --force [--verbose] [--auto-skip-subsequent-headers
-                                        [=true|false]] [--ignore-empty-strings[=true|false]] [--ignore-extra-columns
-                                        [=true|false]] [--legacy-style-quoting[=true|false]] [--normalize-types
-                                        [=true|false]] [--skip-bad-entries-logging[=true|false]]
-                                        [--skip-bad-relationships[=true|false]] [--skip-duplicate-nodes[=true|false]]
-                                        [--strict[=true|false]] [--trim-strings[=true|false]]
-                                        [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>]
-                                        [--delimiter=<char>] [--high-parallel-io=on|off|auto]
-                                        [--id-type=string|integer|actual] [--input-encoding=<character-set>]
-                                        [--input-type[=csv|parquet]] [--max-off-heap-memory=<size>]
-                                        [--quote=<char>] [--read-buffer-size=<size>] [--report-file=<path>]
-                                        [--stage=all|prepare|build|merge] [--threads=<num>]
-                                        --nodes=[<label>[:<label>]...=]<files>... [--nodes=[<label>[:<label>]...=]
-                                        <files>...]... [--relationships=[<type>=]<files>...]... <database>
+neo4j-admin database import incremental [-h] [--expand-commands] --force [--verbose] [--auto-skip-subsequent-headers[=true|false]]
+                                        [--ignore-empty-strings[=true|false]] [--ignore-extra-columns[=true|false]]
+                                        [--legacy-style-quoting[=true|false]] [--multiline-fields[=true|false]] [--normalize-types[=true|false]]
+                                        [--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships[=true|false]]
+                                        [--skip-duplicate-nodes[=true|false]] [--strict[=true|false]] [--trim-strings[=true|false]]
+                                        [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>] [--delimiter=<char>]
+                                        [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual] [--input-encoding=<character-set>]
+                                        [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>]
+                                        [--report-file=<path>] [--schema=<path>] [--stage=all|prepare|build|merge] [--threads=<num>]
+                                        --nodes=[<label>[: <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
+                                        [--relationships=[<type>=]<files>...]... <database>
 ----
 
 === Description

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -85,17 +85,18 @@ The syntax for importing a set of CSV files is:
 ----
 neo4j-admin database import full [-h] [--expand-commands] [--verbose] [--auto-skip-subsequent-headers[=true|false]]
                                  [--ignore-empty-strings[=true|false]] [--ignore-extra-columns[=true|false]]
-                                 [--legacy-style-quoting[=true|false]] [--multiline-fields[=true|false]]
-                                 [--normalize-types[=true|false]] [--overwrite-destination[=true|false]]
-                                 [--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships[=true|false]]
-                                 [--skip-duplicate-nodes[=true|false]] [--strict[=true|false]] [--trim-strings[=true|false]]
-                                 [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>]
-                                 [--delimiter=<char>] [--format=<format>] [--high-parallel-io=on|off|auto]
-                                 [--id-type=string|integer|actual] [--input-encoding=<character-set>]
-                                 [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>]
-                                 [--read-buffer-size=<size>] [--report-file=<path>] [--schema=<path>] [--threads=<num>]
-                                 --nodes=[<label>[: <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
-                                 [--relationships=[<type>=]<files>...]... <database>
+                                 [--legacy-style-quoting[=true|false]] [--normalize-types[=true|false]]
+                                 [--overwrite-destination[=true|false]] [--skip-bad-entries-logging[=true|false]]
+                                 [--skip-bad-relationships[=true|false]] [--skip-duplicate-nodes[=true|false]] [--strict
+                                 [=true|false]] [--trim-strings[=true|false]] [--additional-config=<file>]
+                                 [--array-delimiter=<char>] [--bad-tolerance=<num>] [--delimiter=<char>]
+                                 [--format=<format>] [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual]
+                                 [--input-encoding=<character-set>] [--input-type=csv|parquet]
+                                 [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>]
+                                 [--report-file=<path>] [--schema=<path>] [--threads=<num>] --nodes=[<label>[:
+                                 <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
+                                 [--relationships=[<type>=]<files>...]... [--multiline-fields=true|false|<path>[,
+                                 <path>] [--multiline-fields-format=v1|v2]] <database>
 ----
 
 === Description
@@ -256,9 +257,9 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields[=true\|false]
-|Whether or not fields from an input source can span multiple lines, i.e. contain newline characters.
-| null
+|--multiline-fields=true\|false\|<path>[,<path>]
+|label:changed[Changed in 5.26] In v1, whether or not fields from an input source can span multiple lines, i.e. contain newline characters. Setting `--multiline-fields=true` can severely degrade the performance of the importer. Therefore, use it with care, especially with large imports. In v2, this option will specify the list of files that contain multiline fields. Files can also be specified using regular expressions.
+|null
 
 |--multiline-fields-format=v1\|v2
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.
@@ -611,13 +612,21 @@ The syntax for importing a set of CSV files incrementally is:
 
 [source, syntax, role="nocopy"]
 ----
-neo4j-admin database import incremental [-h] [--expand-commands] --force [--verbose] [--auto-skip-subsequent-headers[=true|false]]
-                                        [--ignore-empty-strings[=true|false]] [--ignore-extra-columns[=true|false]]
-                                        [--legacy-style-quoting[=true|false]] [--multiline-fields[=true|false]] [--normalize-types[=true|false]] [--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships[=true|false]]
-                                        [--skip-duplicate-nodes[=true|false]] [--strict[=true|false]] [--trim-strings[=true|false]]
-                                        [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>] [--delimiter=<char>]
-                                        [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual] [--input-encoding=<character-set>]
-                                        [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>] [--report-file=<path>] [--schema=<path>] [--stage=all|prepare|build|merge] [--threads=<num>] --nodes=[<label>[: <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]... [--relationships=[<type>=]<files>...]... <database>
+neo4j-admin database import incremental [-h] [--expand-commands] --force [--verbose] [--auto-skip-subsequent-headers
+                                        [=true|false]] [--ignore-empty-strings[=true|false]] [--ignore-extra-columns
+                                        [=true|false]] [--legacy-style-quoting[=true|false]] [--normalize-types
+                                        [=true|false]] [--skip-bad-entries-logging[=true|false]]
+                                        [--skip-bad-relationships[=true|false]] [--skip-duplicate-nodes[=true|false]]
+                                        [--strict[=true|false]] [--trim-strings[=true|false]]
+                                        [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>]
+                                        [--delimiter=<char>] [--high-parallel-io=on|off|auto]
+                                        [--id-type=string|integer|actual] [--input-encoding=<character-set>]
+                                        [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>]
+                                        [--read-buffer-size=<size>] [--report-file=<path>] [--schema=<path>]
+                                        [--stage=all|prepare|build|merge] [--threads=<num>] --nodes=[<label>[:
+                                        <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
+                                        [--relationships=[<type>=]<files>...]... [--multiline-fields=true|false|<path>[,
+                                        <path>] [--multiline-fields-format=v1|v2]] <database>
 ----
 
 === Description
@@ -795,9 +804,9 @@ Values can be plain numbers, such as `10000000`, or `20G` for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example `70%`.
 |90%
 
-|--multiline-fields[=true\|false]
-|Whether or not fields from an input source can span multiple lines, i.e. contain newline characters.
-| null
+|--multiline-fields=true\|false\|<path>[,<path>]
+|label:changed[Changed in 5.26] In v1, whether or not fields from an input source can span multiple lines, i.e. contain newline characters. Setting `--multiline-fields=true` can severely degrade the performance of the importer. Therefore, use it with care, especially with large imports. In v2, this option will specify the list of files that contain multiline fields. Files can also be specified using regular expressions.
+|null
 
 |--multiline-fields-format=v1\|v2
 |label:new[Introduced in 5.26] Controls the parsing of input source that can span multiple lines, i.e. contain newline characters. When set to v1, the value for `--multiline-fields` can only be true or false. When set to v2, the value for `--multiline-fields` should be the list of files that contain multiline fields.


### PR DESCRIPTION
The Parquet file support for neo4j admin import will come out in on of the next minor versions as a preview feature.
Depending on the feedback we get from customers and users, there will be definitely coming more (also to the docs).
This is a quite defensive change to avoid promising too much but also pointing out that this feature exists at all ;)

Because the feature itself is not merged yet, I added the DO NOT MERGE label.
Please let us get this into a shape where we can just merge it after the feature went into the product, thanks.


This supersedes https://github.com/neo4j/docs-operations/pull/1850