### PR TITLE
Describe the semi-automated procedure that migrates Discovery Service V1 to V2.

### DIFF
--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -566,7 +566,7 @@ It automates the approach described in the xref:clustering/setup/discovery.adoc#
 
 . Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section
 . For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
-. Connect to any server using server-side routing
+. Connect to any server.
 +
 [source,cypher]
 ----

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -412,8 +412,51 @@ CALL dbms.cluster.showParallelDiscoveryState();
 +-------------------------------------------------------------+
 ----
 
+[[discovery-v1-to-v2-semi-automated-procedure]]
+=== Semi-automated procedure
+
+Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process
+It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[next section].
+
+. Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section
+. For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
+. Connect to any server using server-side routing
++
+[source,cypher]
+----
+./cypher-shell -a neo4j://localhost:7691 -d system
+----
+
+. Run the following procedure three times to move all members from `V1_ONLY` to `V2_ONLY`.
++
+[source,cypher]
+----
+CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
+----
+After each call `internal.dbms.cluster.moveToNextDiscoveryVersion()` you need to make sure that `dbms.cluster.showParallelDiscoveryState()` display `Matching` in the `stateComparison` column.
+If they are not, wait and try again till matching.
+
+The output should display `Matching` in the `stateComparison` column.
+If they are not, wait and try again till matching.
+
+If the procedure fails, read the error message and resolve the issue manually.
+One possible reason for failure is that some members might have had inconsistent `dbms.cluster.discovery.version` settings initially.
+Refer to the next section for guidance on debugging and fixing issues.
+
+. To check that the migration was successful, you can execute `CALL dbms.cluster.showParallelDiscoveryState()` on all members of the cluster. You should see that V2_ONLY is the current version.
++
+[queryresult]
+----
++-------------------------------------------------------------+
+| mode      | stateComparison | v1ServerCount | v2ServerCount |
++-------------------------------------------------------------+
+| "V2_ONLY" | "N/A"           | "N/A"         | "3"           |
++-------------------------------------------------------------+
+----
+. In the last step, set the `dbms.cluster.discovery.version=V2_ONLY` for each member of the cluster, so that the version change is retained after a restart.
+
 [[discovery-v1-to-v2-procedures]]
-=== Using procedures
+=== Manual procedures
 
 // By using just procedures, the nice thing is that during the user's normal version upgrade, they can also add the new settings required for v2 discovery service.
 // Then, when they are ready to migrate to v2, they can use the procedures and then finally, set the version to 'V2' in the neo4j.conf at the very end - which can just sit there till the next restart
@@ -557,41 +600,6 @@ Therefore, when a server restarts, it starts right back with only v1 running.
 As such, ensure that `dbms.cluster.discovery.version=V2_ONLY`, and that `dbms.cluster.discovery.v2.endpoints` or `dbms.kubernetes.discovery.v2.service_port_name`
 are set as required, so that the servers start with v2 running on the next restart.
 ====
-
-[[discovery-v1-to-v2-semi-automated-procedure]]
-=== Semi-automated procedure
-
-Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process.
-It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[previous section].
-
-. Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section
-. For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
-. Connect to any server.
-+
-[source,cypher]
-----
-./cypher-shell -a neo4j://localhost:7691 -d system
-----
-
-. Run the following procedure three times to move all members from `V1_ONLY` to `V2_ONLY`. If the procedure fails, read the error message and resolve the issue manually.
-One possible reason for failure is that some members might have had inconsistent `dbms.cluster.discovery.version` settings initially.
-Refer to the previous section for guidance on debugging and fixing issues.
-+
-[source,cypher]
-----
-CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
-----
-. To check that the migration was successful, you can execute `CALL dbms.cluster.showParallelDiscoveryState()` on all members of the cluster. You should see that V2_ONLY is the current version.
-+
-[queryresult]
-----
-+-------------------------------------------------------------+
-| mode      | stateComparison | v1ServerCount | v2ServerCount |
-+-------------------------------------------------------------+
-| "V2_ONLY" | "N/A"           | "N/A"         | "3"           |
-+-------------------------------------------------------------+
-----
-. In the last step, add `dbms.cluster.discovery.version=V2_ONLY` to the config file for each member of the cluster, so that the version change is retained after a restart.
 
 == Monitoring the progress and metrics
 

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -558,6 +558,27 @@ As such, ensure that `dbms.cluster.discovery.version=V2_ONLY`, and that `dbms.cl
 are set as required, so that the servers start with v2 running on the next restart.
 ====
 
+[[discovery-v1-to-v2-semi-automated-procedure]]
+=== Semi-automated procedure
+
+Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process
+It automates the approach described in the xref:clustering/setup/discovery.adoc#_using_procedures[previous section].
+
+. Make sure that server side routing is enabled as detailed in xref:https://neo4j.com/docs/operations-manual/current/clustering/setup/routing/#clustering-routing[Server-side routing] section
+. For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
+. Connect to any server using server-side routing
++
+[source,cypher]
+----
+./cypher-shell -a neo4j://localhost:7691 -d system
+----
+. Run the following procedure three times to move all members from `V1_ONLY` to `V2_ONLY`. If the procedure fails, read the error message and resolve the issue manually.
+One possible reason for failure is that some members might have had inconsistent `dbms.cluster.discovery.version` settings initially.
+Refer to the previous section for guidance on debugging and fixing issues.
+[source,cypher]
+----
+CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
+----
 
 
 == Monitoring the progress and metrics

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -268,7 +268,7 @@ The output indicates mode `V1_ONLY`, i.e., only `V1` is running on this server.
 ----
 . Run the following procedure to turn on `V2` in the background for all servers, but keep `V1` running in the foreground.
 If the procedure fails, read the error message and resolve the issue manually.
-One possible reason for failure is that some members might have had inconsistent `dbms.cluster.discovery.version` settings initially.
+One possible reason for failure is that some servers might have had inconsistent xref:configuration/configuration.settings.adoc#config_dbms.cluster.discovery.version[`dbms.cluster.discovery.version`] settings initially.
 +
 [source,cypher]
 ----

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -564,7 +564,7 @@ are set as required, so that the servers start with v2 running on the next resta
 Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process
 It automates the approach described in the xref:clustering/setup/discovery.adoc#_using_procedures[previous section].
 
-. Make sure that server side routing is enabled as detailed in xref:https://neo4j.com/docs/operations-manual/current/clustering/setup/routing/#clustering-routing[Server-side routing] section
+. Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section
 . For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
 . Connect to any server using server-side routing
 +

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -581,7 +581,16 @@ Refer to the previous section for guidance on debugging and fixing issues.
 ----
 CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
 ----
-
+. To check that the migration was successful, you can execute `CALL dbms.cluster.showParallelDiscoveryState()` on all members of the cluster. You should see that V2_ONLY is the current version.
++
+[queryresult]
+----
++-------------------------------------------------------------+
+| mode      | stateComparison | v1ServerCount | v2ServerCount |
++-------------------------------------------------------------+
+| "V2_ONLY" | "N/A"           | "N/A"         | "3"           |
++-------------------------------------------------------------+
+----
 . In the last step, set the `dbms.cluster.discovery.version=V2_ONLY` for each member of the cluster, so that the version change is retained after a restart.
 
 == Monitoring the progress and metrics

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -242,7 +242,7 @@ dbms.cluster.discovery.endpoints=server01.example.com:5000,server02.example.com:
 dbms.cluster.discovery.v2.endpoints=server01.example.com:6000,server02.example.com:6000,server03.example.com:6000
 ----
 +
-. In Cypher Shell, connect to the `system` database of any server
+. In Cypher Shell, connect to the `system` database of any server:
 +
 [source, shell, role=nocopy noplay]
 ----

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -562,7 +562,7 @@ are set as required, so that the servers start with v2 running on the next resta
 === Semi-automated procedure
 
 Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process
-It automates the approach described in the xref:clustering/setup/discovery.adoc#_using_procedures[previous section].
+It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[previous section].
 
 . Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section
 . For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
@@ -572,14 +572,17 @@ It automates the approach described in the xref:clustering/setup/discovery.adoc#
 ----
 ./cypher-shell -a neo4j://localhost:7691 -d system
 ----
+
 . Run the following procedure three times to move all members from `V1_ONLY` to `V2_ONLY`. If the procedure fails, read the error message and resolve the issue manually.
 One possible reason for failure is that some members might have had inconsistent `dbms.cluster.discovery.version` settings initially.
 Refer to the previous section for guidance on debugging and fixing issues.
++
 [source,cypher]
 ----
 CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
 ----
 
+. In the last step, set the `dbms.cluster.discovery.version=V2_ONLY` for each member of the cluster, so that the version change is retained after a restart.
 
 == Monitoring the progress and metrics
 

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -415,36 +415,114 @@ CALL dbms.cluster.showParallelDiscoveryState();
 [[discovery-v1-to-v2-semi-automated-procedure]]
 === Semi-automated procedure
 
-Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process
+Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process.
 It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[next section].
 
 . Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section
 . For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
-. Connect to any server using server-side routing
++
+As an example, for those using the list resolver, the settings for all the servers should include:
++
+[source, parameters]
+----
+dbms.cluster.discovery.resolver_type=LIST
+
+dbms.cluster.discovery.endpoints=server01.example.com:5000,server02.example.com:5000,server03.example.com:5000
+dbms.cluster.discovery.v2.endpoints=server01.example.com:6000,server02.example.com:6000,server03.example.com:6000
+----
++
+. In Cypher Shell, connect to the `system` database of any server
 +
 [source,cypher]
 ----
-./cypher-shell -a neo4j://localhost:7691 -d system
+./cypher-shell -a bolt://localhost:7683 -d system
 ----
-
-. Run the following procedure three times to move all members from `V1_ONLY` to `V2_ONLY`.
+. Run the procedure:
++
+[source,cypher]
+----
+CALL dbms.cluster.showParallelDiscoveryState();
+----
++
+The output indicates mode `V1_ONLY`, i.e., only v1 is running on this server.
++
+.Expected result
+[queryresult]
+----
++-------------------------------------------------------------+
+| mode      | stateComparison | v1ServerCount | v2ServerCount |
++-------------------------------------------------------------+
+| "V1_ONLY" | "N/A"           | "3"           | "N/A"         |
++-------------------------------------------------------------+
+----
+. Run the following procedure to turn on `V2` in the background for all servers, but keep `V1` running in the foreground.
+If the procedure fails, read the error message and resolve the issue manually.
+One possible reason for failure is that some members might have had inconsistent `dbms.cluster.discovery.version` settings initially.
 +
 [source,cypher]
 ----
 CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
 ----
-After each call `internal.dbms.cluster.moveToNextDiscoveryVersion()` you need to make sure that `dbms.cluster.showParallelDiscoveryState()` display `Matching` in the `stateComparison` column.
-If they are not, wait and try again till matching.
-
-The output should display `Matching` in the `stateComparison` column.
-If they are not, wait and try again till matching.
-
-If the procedure fails, read the error message and resolve the issue manually.
-One possible reason for failure is that some members might have had inconsistent `dbms.cluster.discovery.version` settings initially.
-Refer to the next section for guidance on debugging and fixing issues.
-
-. To check that the migration was successful, you can execute `CALL dbms.cluster.showParallelDiscoveryState()` on all members of the cluster. You should see that V2_ONLY is the current version.
+. Check the state again:
 +
+[source,cypher]
+----
+CALL dbms.cluster.showParallelDiscoveryState();
+----
++
+Now the returned mode for this server must be `V1_OVER_V2` and the `stateComparison` must show that the states are matching.
+If they are not, wait and try again till matching.
++
+.Expected result
+[queryresult]
+----
++----------------------------------------------------------------+
+| mode         | stateComparison | v1ServerCount | v2ServerCount |
++----------------------------------------------------------------+
+| "V1_OVER_V2" | "Matching"      | "3"           | "3"           |
++----------------------------------------------------------------+
+----
+. Run the once again the following procedure to turn on `V1` in the background for all servers, but keep `V2` running in the foreground.
++
+[source,cypher]
+----
+CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
+----
+. Check that transition to `V2_OVER_V1` was successful:
++
+[source,cypher]
+----
+CALL dbms.cluster.showParallelDiscoveryState();
+----
++
+Now the returned mode for this server must be `V2_OVER_V1` and the `stateComparison` must show that the states are matching.
+If they are not, wait and try again till matching.
++
+.Expected result
+[queryresult]
+----
++----------------------------------------------------------------+
+| mode         | stateComparison | v1ServerCount | v2ServerCount |
++----------------------------------------------------------------+
+| "V2_OVER_V1" | "Matching"      | "3"           | "3"           |
++----------------------------------------------------------------+
+----
+. Finally, turn off `V1` by running the following procedure:
++
+[source,cypher]
+----
+CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
+----
+. Check that transition to `V2_ONLY` was successful:
++
+[source,cypher]
+----
+CALL dbms.cluster.showParallelDiscoveryState();
+----
++
+Note that stateComparison is `N/A` because you do not have v1 to compare states anymore.
++
+.Expected result
 [queryresult]
 ----
 +-------------------------------------------------------------+
@@ -453,7 +531,16 @@ Refer to the next section for guidance on debugging and fixing issues.
 | "V2_ONLY" | "N/A"           | "N/A"         | "3"           |
 +-------------------------------------------------------------+
 ----
-. In the last step, set the `dbms.cluster.discovery.version=V2_ONLY` for each member of the cluster, so that the version change is retained after a restart.
++
+.Important
+[IMPORTANT]
+====
+Remember to update the _neo4j.conf_ files for all the servers.
+The switching using procedures does not persist anything to disk.
+Therefore, when a server restarts, it starts right back with only v1 running.
+As such, ensure that `dbms.cluster.discovery.version=V2_ONLY`, and that `dbms.cluster.discovery.v2.endpoints` or `dbms.kubernetes.discovery.v2.service_port_name`
+are set as required, so that the servers start with v2 running on the next restart.
+====
 
 [[discovery-v1-to-v2-procedures]]
 === Manual procedures

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -561,7 +561,7 @@ are set as required, so that the servers start with v2 running on the next resta
 [[discovery-v1-to-v2-semi-automated-procedure]]
 === Semi-automated procedure
 
-Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process
+Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process.
 It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[previous section].
 
 . Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -224,7 +224,7 @@ It is important that both `dbms.kubernetes.service_port_name` and `dbms.kubernet
 For more information, see <<clustering-discovery-k8s>>.
 
 [[discovery-v1-to-v2-semi-automated-procedure]]
-=== Moving whole cluster with a procedure
+=== Moving an entire cluster with a procedure
 
 The first way to migrate from discovery service v1 to v2 is to use a semi-automated procedure, which simplifies the migration process.
 It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[next section].

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -331,7 +331,7 @@ CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
 CALL dbms.cluster.showParallelDiscoveryState();
 ----
 +
-Note that stateComparison is `N/A` because you do not have `V1` to compare states anymore.
+Note that `stateComparison` is `N/A` because you do not have `V1` to compare states anymore.
 +
 .Expected result
 [queryresult]

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -226,7 +226,7 @@ For more information, see <<clustering-discovery-k8s>>.
 [[discovery-v1-to-v2-semi-automated-procedure]]
 === Moving whole cluster with a procedure
 
-Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process.
+The simplest way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process.
 It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[next section].
 
 . Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -293,7 +293,7 @@ If they are not, wait and try again till matching.
 | "V1_OVER_V2" | "Matching"      | "3"           | "3"           |
 +----------------------------------------------------------------+
 ----
-. Run the once again the following procedure to turn on `V1` in the background for all servers, but keep `V2` running in the foreground.
+. Once again, run the following procedure to turn on `V1` in the background for all servers, but keep `V2` running in the foreground.
 +
 [source,cypher]
 ----

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -591,7 +591,7 @@ CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
 | "V2_ONLY" | "N/A"           | "N/A"         | "3"           |
 +-------------------------------------------------------------+
 ----
-. In the last step, set the `dbms.cluster.discovery.version=V2_ONLY` for each member of the cluster, so that the version change is retained after a restart.
+. In the last step, add `dbms.cluster.discovery.version=V2_ONLY` to the config file for each member of the cluster, so that the version change is retained after a restart.
 
 == Monitoring the progress and metrics
 

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -224,7 +224,7 @@ It is important that both `dbms.kubernetes.service_port_name` and `dbms.kubernet
 For more information, see <<clustering-discovery-k8s>>.
 
 [[discovery-v1-to-v2-semi-automated-procedure]]
-=== Moving an entire cluster with a procedure
+=== Procedure for moving an entire cluster
 
 The first way to migrate from discovery service v1 to v2 is to use a semi-automated procedure, which simplifies the migration process.
 It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[next section].
@@ -354,7 +354,7 @@ are set as required, so that the servers start with v2 running on the next resta
 ====
 
 [[discovery-v1-to-v2-procedures]]
-=== Running a procedure on each server
+=== Per server procedure
 
 // By using just procedures, the nice thing is that during the user's normal version upgrade, they can also add the new settings required for v2 discovery service.
 // Then, when they are ready to migrate to v2, they can use the procedures and then finally, set the version to 'V2' in the neo4j.conf at the very end - which can just sit there till the next restart

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -272,7 +272,7 @@ One possible reason for failure is that some servers might have had inconsistent
 +
 [source,cypher]
 ----
-CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
+CALL dbms.cluster.moveToNextDiscoveryVersion();
 ----
 . Check the state again:
 +
@@ -297,7 +297,7 @@ If they are not, wait and try again till matching.
 +
 [source,cypher]
 ----
-CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
+CALL dbms.cluster.moveToNextDiscoveryVersion();
 ----
 . Check that transition to `V2_OVER_V1` was successful:
 +
@@ -322,7 +322,7 @@ If they are not, wait and try again till matching.
 +
 [source,cypher]
 ----
-CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
+CALL dbms.cluster.moveToNextDiscoveryVersion();
 ----
 . Check that transition to `V2_ONLY` was successful:
 +

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -268,7 +268,7 @@ The output indicates mode `V1_ONLY`, i.e., only `V1` is running on this server.
 ----
 . Run the following procedure to turn on `V2` in the background for all servers, but keep `V1` running in the foreground.
 If the procedure fails, read the error message and resolve the issue manually.
-One possible reason for failure is that some servers might have had inconsistent xref:configuration/configuration.settings.adoc#config_dbms.cluster.discovery.version[`dbms.cluster.discovery.version`] settings initially.
+One possible reason for failure is that some servers might have had inconsistent xref:configuration/configuration-settings.adoc#config_dbms.cluster.discovery.version[`dbms.cluster.discovery.version`] settings initially.
 +
 [source,cypher]
 ----

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -433,9 +433,9 @@ dbms.cluster.discovery.v2.endpoints=server01.example.com:6000,server02.example.c
 +
 . In Cypher Shell, connect to the `system` database of any server
 +
-[source,cypher]
+[source, shell, role=nocopy noplay]
 ----
-./cypher-shell -a bolt://localhost:7683 -d system
+./cypher-shell -a bolt://localhost:7681 -d system
 ----
 . Run the procedure:
 +
@@ -444,7 +444,7 @@ dbms.cluster.discovery.v2.endpoints=server01.example.com:6000,server02.example.c
 CALL dbms.cluster.showParallelDiscoveryState();
 ----
 +
-The output indicates mode `V1_ONLY`, i.e., only v1 is running on this server.
+The output indicates mode `V1_ONLY`, i.e., only `V1` is running on this server.
 +
 .Expected result
 [queryresult]
@@ -520,7 +520,7 @@ CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
 CALL dbms.cluster.showParallelDiscoveryState();
 ----
 +
-Note that stateComparison is `N/A` because you do not have v1 to compare states anymore.
+Note that stateComparison is `N/A` because you do not have `V1` to compare states anymore.
 +
 .Expected result
 [queryresult]

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -354,7 +354,7 @@ are set as required, so that the servers start with v2 running on the next resta
 ====
 
 [[discovery-v1-to-v2-procedures]]
-=== Per server procedure
+=== Running a procedure on each server
 
 // By using just procedures, the nice thing is that during the user's normal version upgrade, they can also add the new settings required for v2 discovery service.
 // Then, when they are ready to migrate to v2, they can use the procedures and then finally, set the version to 'V2' in the neo4j.conf at the very end - which can just sit there till the next restart

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -200,7 +200,7 @@ From Neo4j 5.23, you can move from the current discovery service v1 to the new v
 The v1 and v2 discovery services are designed to be able to run in parallel.
 They are completely independent of each other, thus allowing you to keep the cluster functioning while switching over from v1 to v2.
 
-There are three ways to move from the current discovery service v1 to the new version v2 depending on the environment and the requirements of the cluster.
+There are four ways to move from the current discovery service v1 to the new version v2 depending on the environment and the requirements of the cluster.
 
 === Preparation
 
@@ -222,6 +222,287 @@ For more information, see <<clustering-discovery-dns>>.
 * If `dbms.cluster.discovery.resolver_type=K8S`, set `dbms.kubernetes.discovery.v2.service_port_name` to the name of the service port used in the Kubernetes service definition for the cluster port.
 It is important that both `dbms.kubernetes.service_port_name` and `dbms.kubernetes.discovery.v2.service_port_name` are set during the operation.
 For more information, see <<clustering-discovery-k8s>>.
+
+[[discovery-v1-to-v2-semi-automated-procedure]]
+=== Moving whole cluster with a procedure
+
+Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process.
+It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[next section].
+
+. Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section
+. For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
++
+As an example, for those using the list resolver, the settings for all the servers should include:
++
+[source, parameters]
+----
+dbms.cluster.discovery.resolver_type=LIST
+
+dbms.cluster.discovery.endpoints=server01.example.com:5000,server02.example.com:5000,server03.example.com:5000
+dbms.cluster.discovery.v2.endpoints=server01.example.com:6000,server02.example.com:6000,server03.example.com:6000
+----
++
+. In Cypher Shell, connect to the `system` database of any server
++
+[source, shell, role=nocopy noplay]
+----
+./cypher-shell -a bolt://localhost:7681 -d system
+----
+. Run the procedure:
++
+[source,cypher]
+----
+CALL dbms.cluster.showParallelDiscoveryState();
+----
++
+The output indicates mode `V1_ONLY`, i.e., only `V1` is running on this server.
++
+.Expected result
+[queryresult]
+----
++-------------------------------------------------------------+
+| mode      | stateComparison | v1ServerCount | v2ServerCount |
++-------------------------------------------------------------+
+| "V1_ONLY" | "N/A"           | "3"           | "N/A"         |
++-------------------------------------------------------------+
+----
+. Run the following procedure to turn on `V2` in the background for all servers, but keep `V1` running in the foreground.
+If the procedure fails, read the error message and resolve the issue manually.
+One possible reason for failure is that some members might have had inconsistent `dbms.cluster.discovery.version` settings initially.
++
+[source,cypher]
+----
+CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
+----
+. Check the state again:
++
+[source,cypher]
+----
+CALL dbms.cluster.showParallelDiscoveryState();
+----
++
+Now the returned mode for this server must be `V1_OVER_V2` and the `stateComparison` must show that the states are matching.
+If they are not, wait and try again till matching.
++
+.Expected result
+[queryresult]
+----
++----------------------------------------------------------------+
+| mode         | stateComparison | v1ServerCount | v2ServerCount |
++----------------------------------------------------------------+
+| "V1_OVER_V2" | "Matching"      | "3"           | "3"           |
++----------------------------------------------------------------+
+----
+. Run the once again the following procedure to turn on `V1` in the background for all servers, but keep `V2` running in the foreground.
++
+[source,cypher]
+----
+CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
+----
+. Check that transition to `V2_OVER_V1` was successful:
++
+[source,cypher]
+----
+CALL dbms.cluster.showParallelDiscoveryState();
+----
++
+Now the returned mode for this server must be `V2_OVER_V1` and the `stateComparison` must show that the states are matching.
+If they are not, wait and try again till matching.
++
+.Expected result
+[queryresult]
+----
++----------------------------------------------------------------+
+| mode         | stateComparison | v1ServerCount | v2ServerCount |
++----------------------------------------------------------------+
+| "V2_OVER_V1" | "Matching"      | "3"           | "3"           |
++----------------------------------------------------------------+
+----
+. Finally, turn off `V1` by running the following procedure:
++
+[source,cypher]
+----
+CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
+----
+. Check that transition to `V2_ONLY` was successful:
++
+[source,cypher]
+----
+CALL dbms.cluster.showParallelDiscoveryState();
+----
++
+Note that stateComparison is `N/A` because you do not have `V1` to compare states anymore.
++
+.Expected result
+[queryresult]
+----
++-------------------------------------------------------------+
+| mode      | stateComparison | v1ServerCount | v2ServerCount |
++-------------------------------------------------------------+
+| "V2_ONLY" | "N/A"           | "N/A"         | "3"           |
++-------------------------------------------------------------+
+----
++
+.Important
+[IMPORTANT]
+====
+Remember to update the _neo4j.conf_ files for all the servers.
+The switching using procedures does not persist anything to disk.
+Therefore, when a server restarts, it starts right back with only v1 running.
+As such, ensure that `dbms.cluster.discovery.version=V2_ONLY`, and that `dbms.cluster.discovery.v2.endpoints` or `dbms.kubernetes.discovery.v2.service_port_name`
+are set as required, so that the servers start with v2 running on the next restart.
+====
+
+[[discovery-v1-to-v2-procedures]]
+=== Per server procedure
+
+// By using just procedures, the nice thing is that during the user's normal version upgrade, they can also add the new settings required for v2 discovery service.
+// Then, when they are ready to migrate to v2, they can use the procedures and then finally, set the version to 'V2' in the neo4j.conf at the very end - which can just sit there till the next restart
+// so no lighthouse-specific server restarts are required if all is done correctly.
+//Note that the settings detailed above must first be set and the servers restarted to allow the settings to take effect.
+
+[IMPORTANT]
+====
+If the cluster procedure had problems, or you need to change individual servers to resolve an issue, this approach will let you do so.
+====
+
+. For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
++
+As an example, for those using the list resolver, the settings for all the servers should include:
++
+[source, parameters]
+----
+dbms.cluster.discovery.resolver_type=LIST
+
+dbms.cluster.discovery.endpoints=server01.example.com:5000,server02.example.com:5000,server03.example.com:5000
+dbms.cluster.discovery.v2.endpoints=server01.example.com:6000,server02.example.com:6000,server03.example.com:6000
+----
++
+. In Cypher Shell, connect to the `system` database of server01 using `bolt://`.
+It is important to connect via `bolt://` because otherwise the procedure might be routed and executed not on the intended server.
++
+[source, shell, role=nocopy noplay]
+----
+./cypher-shell -a bolt://localhost:7681 -d system
+----
+
+. Run the procedure:
++
+[source,cypher]
+----
+CALL dbms.cluster.showParallelDiscoveryState();
+----
++
+The output indicates mode `V1_ONLY`, i.e., only v1 is running on this server.
++
+.Expected result
+[queryresult]
+----
++-------------------------------------------------------------+
+| mode      | stateComparison | v1ServerCount | v2ServerCount |
++-------------------------------------------------------------+
+| "V1_ONLY" | "N/A"           | "3"           | "N/A"         |
++-------------------------------------------------------------+
+----
+
+. Run the following procedure to turn on v2 in the background, but keep v1 running in the foreground:
++
+[source,cypher]
+----
+CALL dbms.cluster.switchDiscoveryServiceVersion("V1_OVER_V2");
+----
+
+. Check the state again:
++
+[source,cypher]
+----
+CALL dbms.cluster.showParallelDiscoveryState();
+----
++
+Now the returned mode for this server must be `V1_OVER_V2` and the `stateComparison` must show that the states are not matching yet.
++
+.Expected result
+[queryresult]
+----
++-------------------------------------------------------------------------------------------------------+
+| mode         | stateComparison                                        | v1ServerCount | v2ServerCount |
++-------------------------------------------------------------------------------------------------------+
+| "V1_OVER_V2" | "States are not matching after PT1M9.518S: (score:18)" | "3"           | "1"           |
++-------------------------------------------------------------------------------------------------------+
+----
++
+The score is a measure of how different the states are.
+`serverCounts` displays how many servers can be found by v1 and v2 of the discovery service, respectively.
+The score is 0 when the states are matching.
+When some members are running just one of the discovery services (v1 or v2) and other members run both, the score stays permanently high.
+This is no reason for worry.
+
+
+. To fulfill this convergence, in different terminals, connect to server02 and server03 via `bolt://` and repeat steps 3 and 4 on both of them.
+
+. Check the state on all servers again.
+It should show that the states are `Matching`.
+Both `serverCounts` should be 3.
++
+.Expected result
+[queryresult]
+----
++----------------------------------------------------------------+
+| mode         | stateComparison | v1ServerCount | v2ServerCount |
++----------------------------------------------------------------+
+| "V1_OVER_V2" | "Matching"      | "3"           | "3"           |
++----------------------------------------------------------------+
+----
+
+. On all three servers, run:
++
+[source,cypher]
+----
+CALL dbms.cluster.switchDiscoveryServiceVersion("V2_OVER_V1");
+----
++
+At this point, v2 is the service that is running the cluster, with v1 running in the background.
++
+.Expected result
+[queryresult]
+----
++----------------------------------------------------------------+
+| mode         | stateComparison | v1ServerCount | v2ServerCount |
++----------------------------------------------------------------+
+| "V2_OVER_V1" | "Matching"      | "3"           | "3"           |
++----------------------------------------------------------------+
+----
+
+
+. Finally, turn off v1 by running the following procedure on all three servers:
++
+[source,cypher]
+----
+CALL dbms.cluster.switchDiscoveryServiceVersion("V2_ONLY");
+----
+
+.  Verify that `CALL dbms.cluster.showParallelDiscoveryState();` now shows `V2_ONLY` running.
+Note that `stateComparison` is `N/A` because you do not have v1 to compare states anymore.
++
+.Expected result
+[queryresult]
+----
++-------------------------------------------------------------+
+| mode      | stateComparison | v1ServerCount | v2ServerCount |
++-------------------------------------------------------------+
+| "V2_ONLY" | "N/A"           | "N/A"         | "3"           |
++-------------------------------------------------------------+
+----
++
+.Important
+[IMPORTANT]
+====
+Remember to update the _neo4j.conf_ files for all the servers.
+The switching using procedures does not persist anything to disk.
+Therefore, when a server restarts, it starts right back with only v1 running.
+As such, ensure that `dbms.cluster.discovery.version=V2_ONLY`, and that `dbms.cluster.discovery.v2.endpoints` or `dbms.kubernetes.discovery.v2.service_port_name`
+are set as required, so that the servers start with v2 running on the next restart.
+====
 
 [[discovery-v1-to-v2-in-place]]
 === In-place rolling
@@ -411,282 +692,6 @@ CALL dbms.cluster.showParallelDiscoveryState();
 | "V2_ONLY" | "N/A"           | "N/A"         | "3"           |
 +-------------------------------------------------------------+
 ----
-
-[[discovery-v1-to-v2-semi-automated-procedure]]
-=== Semi-automated procedure
-
-Another way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process.
-It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[next section].
-
-. Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section
-. For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
-+
-As an example, for those using the list resolver, the settings for all the servers should include:
-+
-[source, parameters]
-----
-dbms.cluster.discovery.resolver_type=LIST
-
-dbms.cluster.discovery.endpoints=server01.example.com:5000,server02.example.com:5000,server03.example.com:5000
-dbms.cluster.discovery.v2.endpoints=server01.example.com:6000,server02.example.com:6000,server03.example.com:6000
-----
-+
-. In Cypher Shell, connect to the `system` database of any server
-+
-[source, shell, role=nocopy noplay]
-----
-./cypher-shell -a bolt://localhost:7681 -d system
-----
-. Run the procedure:
-+
-[source,cypher]
-----
-CALL dbms.cluster.showParallelDiscoveryState();
-----
-+
-The output indicates mode `V1_ONLY`, i.e., only `V1` is running on this server.
-+
-.Expected result
-[queryresult]
-----
-+-------------------------------------------------------------+
-| mode      | stateComparison | v1ServerCount | v2ServerCount |
-+-------------------------------------------------------------+
-| "V1_ONLY" | "N/A"           | "3"           | "N/A"         |
-+-------------------------------------------------------------+
-----
-. Run the following procedure to turn on `V2` in the background for all servers, but keep `V1` running in the foreground.
-If the procedure fails, read the error message and resolve the issue manually.
-One possible reason for failure is that some members might have had inconsistent `dbms.cluster.discovery.version` settings initially.
-+
-[source,cypher]
-----
-CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
-----
-. Check the state again:
-+
-[source,cypher]
-----
-CALL dbms.cluster.showParallelDiscoveryState();
-----
-+
-Now the returned mode for this server must be `V1_OVER_V2` and the `stateComparison` must show that the states are matching.
-If they are not, wait and try again till matching.
-+
-.Expected result
-[queryresult]
-----
-+----------------------------------------------------------------+
-| mode         | stateComparison | v1ServerCount | v2ServerCount |
-+----------------------------------------------------------------+
-| "V1_OVER_V2" | "Matching"      | "3"           | "3"           |
-+----------------------------------------------------------------+
-----
-. Run the once again the following procedure to turn on `V1` in the background for all servers, but keep `V2` running in the foreground.
-+
-[source,cypher]
-----
-CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
-----
-. Check that transition to `V2_OVER_V1` was successful:
-+
-[source,cypher]
-----
-CALL dbms.cluster.showParallelDiscoveryState();
-----
-+
-Now the returned mode for this server must be `V2_OVER_V1` and the `stateComparison` must show that the states are matching.
-If they are not, wait and try again till matching.
-+
-.Expected result
-[queryresult]
-----
-+----------------------------------------------------------------+
-| mode         | stateComparison | v1ServerCount | v2ServerCount |
-+----------------------------------------------------------------+
-| "V2_OVER_V1" | "Matching"      | "3"           | "3"           |
-+----------------------------------------------------------------+
-----
-. Finally, turn off `V1` by running the following procedure:
-+
-[source,cypher]
-----
-CALL internal.dbms.cluster.moveToNextDiscoveryVersion();
-----
-. Check that transition to `V2_ONLY` was successful:
-+
-[source,cypher]
-----
-CALL dbms.cluster.showParallelDiscoveryState();
-----
-+
-Note that stateComparison is `N/A` because you do not have `V1` to compare states anymore.
-+
-.Expected result
-[queryresult]
-----
-+-------------------------------------------------------------+
-| mode      | stateComparison | v1ServerCount | v2ServerCount |
-+-------------------------------------------------------------+
-| "V2_ONLY" | "N/A"           | "N/A"         | "3"           |
-+-------------------------------------------------------------+
-----
-+
-.Important
-[IMPORTANT]
-====
-Remember to update the _neo4j.conf_ files for all the servers.
-The switching using procedures does not persist anything to disk.
-Therefore, when a server restarts, it starts right back with only v1 running.
-As such, ensure that `dbms.cluster.discovery.version=V2_ONLY`, and that `dbms.cluster.discovery.v2.endpoints` or `dbms.kubernetes.discovery.v2.service_port_name`
-are set as required, so that the servers start with v2 running on the next restart.
-====
-
-[[discovery-v1-to-v2-procedures]]
-=== Manual procedures
-
-// By using just procedures, the nice thing is that during the user's normal version upgrade, they can also add the new settings required for v2 discovery service.
-// Then, when they are ready to migrate to v2, they can use the procedures and then finally, set the version to 'V2' in the neo4j.conf at the very end - which can just sit there till the next restart
-// so no lighthouse-specific server restarts are required if all is done correctly.
-//Note that the settings detailed above must first be set and the servers restarted to allow the settings to take effect.
-
-. For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.
-+
-As an example, for those using the list resolver, the settings for all the servers should include:
-+
-[source, parameters]
-----
-dbms.cluster.discovery.resolver_type=LIST
-
-dbms.cluster.discovery.endpoints=server01.example.com:5000,server02.example.com:5000,server03.example.com:5000
-dbms.cluster.discovery.v2.endpoints=server01.example.com:6000,server02.example.com:6000,server03.example.com:6000
-----
-+
-. In Cypher Shell, connect to the `system` database of server01 using `bolt://`.
-It is important to connect via `bolt://` because otherwise the procedure might be routed and executed not on the intended server.
-+
-[source, shell, role=nocopy noplay]
-----
-./cypher-shell -a bolt://localhost:7681 -d system
-----
-
-. Run the procedure:
-+
-[source,cypher]
-----
-CALL dbms.cluster.showParallelDiscoveryState();
-----
-+
-The output indicates mode `V1_ONLY`, i.e., only v1 is running on this server.
-+
-.Expected result
-[queryresult]
-----
-+-------------------------------------------------------------+
-| mode      | stateComparison | v1ServerCount | v2ServerCount |
-+-------------------------------------------------------------+
-| "V1_ONLY" | "N/A"           | "3"           | "N/A"         |
-+-------------------------------------------------------------+
-----
-
-. Run the following procedure to turn on v2 in the background, but keep v1 running in the foreground:
-+
-[source,cypher]
-----
-CALL dbms.cluster.switchDiscoveryServiceVersion("V1_OVER_V2");
-----
-
-. Check the state again:
-+
-[source,cypher]
-----
-CALL dbms.cluster.showParallelDiscoveryState();
-----
-+
-Now the returned mode for this server must be `V1_OVER_V2` and the `stateComparison` must show that the states are not matching yet.
-+
-.Expected result
-[queryresult]
-----
-+-------------------------------------------------------------------------------------------------------+
-| mode         | stateComparison                                        | v1ServerCount | v2ServerCount |
-+-------------------------------------------------------------------------------------------------------+
-| "V1_OVER_V2" | "States are not matching after PT1M9.518S: (score:18)" | "3"           | "1"           |
-+-------------------------------------------------------------------------------------------------------+
-----
-+
-The score is a measure of how different the states are.
-`serverCounts` displays how many servers can be found by v1 and v2 of the discovery service, respectively.
-The score is 0 when the states are matching.
-When some members are running just one of the discovery services (v1 or v2) and other members run both, the score stays permanently high.
-This is no reason for worry.
-
-
-. To fulfill this convergence, in different terminals, connect to server02 and server03 via `bolt://` and repeat steps 3 and 4 on both of them.
-
-. Check the state on all servers again.
-It should show that the states are `Matching`.
-Both `serverCounts` should be 3.
-+
-.Expected result
-[queryresult]
-----
-+----------------------------------------------------------------+
-| mode         | stateComparison | v1ServerCount | v2ServerCount |
-+----------------------------------------------------------------+
-| "V1_OVER_V2" | "Matching"      | "3"           | "3"           |
-+----------------------------------------------------------------+
-----
-
-. On all three servers, run:
-+
-[source,cypher]
-----
-CALL dbms.cluster.switchDiscoveryServiceVersion("V2_OVER_V1");
-----
-+
-At this point, v2 is the service that is running the cluster, with v1 running in the background.
-+
-.Expected result
-[queryresult]
-----
-+----------------------------------------------------------------+
-| mode         | stateComparison | v1ServerCount | v2ServerCount |
-+----------------------------------------------------------------+
-| "V2_OVER_V1" | "Matching"      | "3"           | "3"           |
-+----------------------------------------------------------------+
-----
-
-
-. Finally, turn off v1 by running the following procedure on all three servers:
-+
-[source,cypher]
-----
-CALL dbms.cluster.switchDiscoveryServiceVersion("V2_ONLY");
-----
-
-.  Verify that `CALL dbms.cluster.showParallelDiscoveryState();` now shows `V2_ONLY` running.
-Note that `stateComparison` is `N/A` because you do not have v1 to compare states anymore.
-+
-.Expected result
-[queryresult]
-----
-+-------------------------------------------------------------+
-| mode      | stateComparison | v1ServerCount | v2ServerCount |
-+-------------------------------------------------------------+
-| "V2_ONLY" | "N/A"           | "N/A"         | "3"           |
-+-------------------------------------------------------------+
-----
-+
-.Important
-[IMPORTANT]
-====
-Remember to update the _neo4j.conf_ files for all the servers.
-The switching using procedures does not persist anything to disk.
-Therefore, when a server restarts, it starts right back with only v1 running.
-As such, ensure that `dbms.cluster.discovery.version=V2_ONLY`, and that `dbms.cluster.discovery.v2.endpoints` or `dbms.kubernetes.discovery.v2.service_port_name`
-are set as required, so that the servers start with v2 running on the next restart.
-====
 
 == Monitoring the progress and metrics
 

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -226,7 +226,7 @@ For more information, see <<clustering-discovery-k8s>>.
 [[discovery-v1-to-v2-semi-automated-procedure]]
 === Moving whole cluster with a procedure
 
-The simplest way to migrate from Discovery Service `V1` to `V2` is to use a semi-automated procedure, which simplifies the migration process.
+The first way to migrate from discovery service v1 to v2 is to use a semi-automated procedure, which simplifies the migration process.
 It automates the approach described in the xref:clustering/setup/discovery.adoc#discovery-v1-to-v2-procedures[next section].
 
 . Make sure that server side routing is enabled as detailed in xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] section

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -363,7 +363,7 @@ are set as required, so that the servers start with v2 running on the next resta
 
 [IMPORTANT]
 ====
-If the cluster procedure had problems, or you need to change individual servers to resolve an issue, this approach will let you do so.
+If the semi-automated procedure fails, or you need to change individual servers to resolve an issue, this approach will let you do so.
 ====
 
 . For all the servers, ensure that new settings are updated to the configuration as detailed the xref:clustering/setup/discovery.adoc#_preparation[Preparation] section.

--- a/modules/ROOT/pages/reference/procedures.adoc
+++ b/modules/ROOT/pages/reference/procedures.adoc
@@ -293,6 +293,11 @@ In 4.2, signature changed to `db.listLocks() :: (mode :: STRING, resourceType ::
 | label:yes[]
 | label:new[Introduced in 5.22] label:admin-only[]
 
+| xref:reference/procedures.adoc#procedure_dbms_cluster_movetonextdiscoveryversion[`dbms.cluster.moveToNextDiscoveryVersion()`]
+| label:no[]
+| label:yes[]
+| label:new[Introduced in 5.26] label:admin-only[]
+
 | xref:reference/procedures.adoc#procedure_dbms_cluster_deallocateDatabaseFromServer[`dbms.cluster.deallocateDatabaseFromServer()`]
 | label:no[]
 | label:yes[]
@@ -1909,6 +1914,20 @@ m|DBMS
 a| Compare the states of Discovery service V1 and Discovery service V2.
 | Signature
 m| dbms.cluster.showParallelDiscoveryState() :: (mode :: STRING, stateComparison :: STRING, v1ServerCount :: STRING, v2ServerCount :: STRING)
+| Mode
+m|DBMS
+|===
+
+[[procedure_dbms_cluster_movetonextdiscoveryversion]]
+[role=label--enterprise-edition label--new-5.26 label--admin-only ]
+.dbms.cluster.moveToNextDiscoveryVersion()
+[cols="<15s,<85"]
+|===
+| Description
+a| The procedure triggers a switch to the next discovery service version for all known members of the cluster (as listed in the system database and discovery).
+For example, if the current member's discovery version is V1_ONLY, it will switch all members to V1_OVER_V2. In case of failure, the user must manually resolve the issue.
+| Signature
+m| dbms.cluster.moveToNextDiscoveryVersion()
 | Mode
 m|DBMS
 |===


### PR DESCRIPTION
Before publishing the docs the internal prefix from the procedure path needs to be removed