### PR TITLE
remove before version 4.4 (#1862)

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/upload-to-aura.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/upload-to-aura.adoc
@@ -18,9 +18,6 @@ The following table shows the compatibility between the dump/backup version that
 
 | 4.4
 | 4 and 5.latest
-
-| 4.3
-| 4 and 5.latest
 |===
 
 [NOTE]


### PR DESCRIPTION
as per ticket
https://trello.com/c/uUkM9CM5/350-document-change-console-drag-and-drop-import-to-support-version-44-or-above