### PR TITLE
Rewrite disaster recovery based on recreate and status check

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -268,8 +268,8 @@ Neo4j 5.24 introduces the xref:procedures.adoc#procedure_dbms_cluster_recreateDa
 * To change the database store to a specified backup, while keeping all the associated privileges for the database.
 
 * To make your database write-available again after it has been lost (for example, due to a disaster).
-// See xref:clustering/disaster-recovery.adoc[] for more information.
-
+See xref:clustering/disaster-recovery.adoc[Disaster recovery] for more information.
+ 
 [CAUTION]
 ====
 The recreate procedure works only for real user databases and not for composite databases, or the `system` database.
@@ -468,7 +468,7 @@ SHOW DATABASE foo;
 === Seed from URI
 
 This method seeds all servers with an identical seed from an external source, specified by the URI.
-The seed can either be a full backup, a differential backup (xref:clustering/databases.adoc#cloud-seed-provider[`CloudSeedProvider`], introduced in Neo4j 5.26), or a dump from an existing database. 
+The seed can either be a full backup, a differential backup (xref:clustering/databases.adoc#cloud-seed-provider[`CloudSeedProvider`], introduced in Neo4j 5.26), or a dump from an existing database.
 The sources of seeds are called _seed providers_.
 
 The mechanism is pluggable, allowing new sources of seeds to be supported (see link:https://www.neo4j.com/docs/java-reference/current/extending-neo4j/project-setup/#extending-neo4j-plugin-seed-provider[Java Reference -> Implement custom seed providers] for more information).
@@ -506,7 +506,7 @@ To determine the cause of the problem, it is recommended to look at the `debug.l
 
 label:new[Introduced in 5.26], the `FileSeedProvider`  supports:
 
-** `file:` 
+** `file:`
 
 [[url-connection-seed-provider]]
 ==== URLConnectionSeedProvider
@@ -523,8 +523,8 @@ The `URLConnectionSeedProvider` supports the following:
 
 label:new[Introduced in 5.25], the `CloudSeedProvider` supports:
 
-** `s3:` 
-** `gs:` 
+** `s3:`
+** `gs:`
 ** `azb:`
 
 Starting from Neo4j 5.26, the `CloudSeedProvider` supports using xref:backup-restore/modes.adoc#differential-backup[differential backup] files as seeds.
@@ -539,7 +539,7 @@ include::partial$/aws-s3-overrides.adoc[]
 
 include::partial$/aws-s3-credentials.adoc[]
 
-. Create database from `myBackup.backup`. 
+. Create database from `myBackup.backup`.
 +
 [source,shell, role="nocopy"]
 ----
@@ -552,7 +552,7 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBack
 
 include::partial$/gcs-credentials.adoc[]
 
-. Create database from `myBackup.backup`. 
+. Create database from `myBackup.backup`.
 +
 [source,shell]
 ----
@@ -564,7 +564,7 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'gs:/myBucket/myBack
 
 include::partial$/azb-credentials.adoc[]
 
-. Create database from `myBackup.backup`. 
+. Create database from `myBackup.backup`.
 +
 [source,shell]
 ----
@@ -578,7 +578,7 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAcco
 
 The `S3SeedProvider` supports:
 
-** `s3:` label:deprecated[Deprecated in 5.26] 
+** `s3:` label:deprecated[Deprecated in 5.26]
 
 
 [NOTE]
@@ -621,7 +621,7 @@ Where `accessKey` and `secretKey` are provided by AWS.
 
 | `file:`
 | `URLConnectionSeedProvider` label:deprecated[Deprecated in 5.26], +
-`FileSeedProvider` label:new[Introduced in 5.26] 
+`FileSeedProvider` label:new[Introduced in 5.26]
 | `file:/tmp/backup1.backup`
 
 | `ftp:`
@@ -638,15 +638,15 @@ Where `accessKey` and `secretKey` are provided by AWS.
 
 | `s3:`
 | `S3SeedProvider` label:deprecated[Deprecated in 5.26], +
-`CloudSeedProvider` label:new[Introduced in 5.25] 
+`CloudSeedProvider` label:new[Introduced in 5.25]
 | `s3://mybucket/backups/backup1.backup`
 
 | `gs:`
-| `CloudSeedProvider` label:new[Introduced in 5.25] 
+| `CloudSeedProvider` label:new[Introduced in 5.25]
 | `gs://mybucket/backups/backup1.backup`
 
 | `azb:`
-| `CloudSeedProvider` label:new[Introduced in 5.25] 
+| `CloudSeedProvider` label:new[Introduced in 5.25]
 | `azb://mystorageaccount.blob/backupscontainer/backup1.backup`
 |===
 

--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -82,13 +82,12 @@ The `system` database contains the view of the cluster.
 This includes which servers and databases are present, where they live and how they are configured.
 During a disaster, the view of the cluster might need to change to reflect a new reality, for example by removing lost servers.
 Databases might also need to be recreated to regain write availability.
-Because both of these steps are executed by writing to the `system` database, this is a vital first step during disaster recovery.
+Because both of these steps are executed by modifying the `system` database, making the `system` database write available is a vital first step during disaster recovery.
 
 ==== Example verification
 The `system` database's write availability can be verified by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[Status check] procedure.
 The procedure should be called on all remaining primary allocations of the `system` database, in order to provide the correct view.
-The status check procedure writes a dummy transaction, and therefore the correctness of the procedure depends on the given timeout.
-The default timeout is 1 second, but depending on the network latency in the environment it might need to be extended.
+The default timeout for the procedure is 1 second, but depending on the network latency in the environment it might need to be extended to produce an accurate result.
 If any of the primary `system` allocations report `replicationSuccessful` = `TRUE`, the `system` database is write available.
 Therefore, the desired state has been verified.
 
@@ -96,6 +95,12 @@ Therefore, the desired state has been verified.
 ----
 CALL dbms.cluster.statusCheck(["system"]);
 ----
+
+[NOTE]
+=====
+The write availability of a database configured to have a single primary cannot be checked with the status check, instead check that the primary is allocated on an available server and that it has `currentStatus` = `STARTED`.
+The procedure will still produce an accurate result if all but one primary have been lost during a disaster.
+=====
 
 ==== Path to correct state
 The following steps can be used to regain write availability for the `system` database if it has been lost.
@@ -142,9 +147,9 @@ All servers in the cluster's view are available and enabled.
 ====
 
 A lost server will still be in the `system` database's view of the cluster, but in an unavailable state.
-According to the view of the cluster, these lost servers are still hosting the databases they had before they became lost.
+Furthermore, according to the view of the cluster, these lost servers are still hosting the databases they had before they became lost.
 Therefore, informing the cluster of servers which are lost is not enough.
-The databases hosted on the lost servers also need to be moved onto servers which are actually in the cluster.
+The databases hosted on lost servers also need to be moved onto available servers in the cluster, before the lost servers can be removed.
 
 ==== Example verification
 The cluster's view of servers can be seen by listing the servers, see xref:clustering/servers.adoc#_listing_servers[Listing servers] for more information.
@@ -157,7 +162,7 @@ SHOW SERVERS;
 
 ==== Path to correct state
 The following steps can be used to remove lost servers and add new ones to the cluster.
-That includes moving any potential database allocations from lost servers to available servers in the cluster.
+That includes moving any potential database allocations from lost servers to available servers.
 These steps might also recreate some databases, since a database which has lost a majority of its primary allocations cannot be moved from one server to another.
 
 .Guide
@@ -168,7 +173,6 @@ This prevents new database allocations from being moved to this server.
 . For each `CORDONED` server, make sure a new *unconstrained* server has been added to the cluster to take its place, see xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster] for more information.
 If servers were added in the 'System database write availability' step of this guide, additional servers might not be needed here.
 It is important that the new servers are unconstrained, or deallocating servers might be blocked even though enough servers were added.
-
 +
 [NOTE]
 =====
@@ -177,32 +181,38 @@ However, not adding new servers reduces the capacity of the cluster to handle wo
 Furthermore, it might require the topology for a database to be altered to make deallocating servers and recreating databases possible.
 =====
 
-. Run `SHOW DATABASES`. If a database show `currentStatus`= `offline` this database has been stopped.
-. For each stopped database, start them by running `START DATABASE stopped-db WAIT`.
-// Is it a problem that it might not have started yet here? Should I write a line about making sure it is started before checking the write availability?
-// Cannot use wait here, because we will hang on lost members that are stopped. Should poll for started state on all non-lost members, but there are some situation where we will not be able to start. So how long should they wait here?
+. For each stopped database (`currentStatus`= `offline`), start them by running `START DATABASE stopped-db`.
 This is necessary since stopped databases cannot be moved from one server to another.
-// And since status check doesn't work otherwise.
+Verify that they are in `currentStatus` = `started` on all servers which are not lost before moving to the next step, otherwise they might be recreated unnecessarily.
+If a database fails to start, leave it to be recreated in the next step of this guide.
 +
 [NOTE]
 =====
 A database can be set to `READ-ONLY` before it is started to avoid updates on a database that is desired to be stopped with the following command:
 `ALTER DATABASE database-name SET ACCESS READ ONLY`.
 =====
-. On each server, run `CALL dbms.cluster.statusCheck([])` to check the write availability for all databases on this server, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
-Depending on the environment, consider extending the timeout for this procedure.
+
+. On each server, run `CALL dbms.cluster.statusCheck([])` to check the write availability for all databases running in primary mode on this server, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
+Depending on the network latency in the environment, consider extending the timeout for this procedure to produce an accurate result.
 If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
-. For each database that is not write available, recreate it to move it from lost servers and regain write availability.
-Go to xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information about recreate options.
-If any allocation has `currentStatus` = `QUARANTINED`, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed] or define seeding servers in the recreate procedure using xref:clustering/databases.adoc#specified-servers[Specified seeders] so that problematic allocations are excluded.
-Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
-// What if a quarantined database had the desire to be stopped? Check quarantine before stopped?
 +
 [NOTE]
 =====
-By using recreate with xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], also databases which have lost all allocation can be recreated.
-Otherwise, recreating with xref:clustering/databases.adoc#uri-seed[Backup as seed] must be used for that specific case.
+The write availability of a database configured to have a single primary cannot be checked with the status check, instead check that the primary is allocated on an available server and that it has `currentStatus` = `STARTED`.
+The procedure will still produce an accurate result if all but one primary have been lost during a disaster.
 =====
+
+. For each database that is not write available, recreate it to move it from lost servers and regain write availability.
+Go to xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information about recreate options.
+Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
+If any database has `currentStatus` = `QUARANTINED` on an available server, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
++
+[NOTE]
+=====
+By using recreate with xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], the store will be replaced by the most up-to-date copy according to the cluster's view without manual intervention.
+Furthermore, this option will automatically recreate the database based on a backup if no available allocation can be found.
+=====
+
 . For each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers.
 This will try to move all database allocations from this server to an available server in the cluster.
 +
@@ -211,6 +221,7 @@ This will try to move all database allocations from this server to an available 
 This operation might fail if enough unconstrained servers were not added to the cluster to replace lost servers.
 Another reason is that some available servers are also `CORDONED`.
 =====
+
 . For each deallocating or deallocated server, run `DROP SERVER deallocated-server-id`.
 This removes the server from the cluster's view.
 ====
@@ -221,31 +232,37 @@ This removes the server from the cluster's view.
 
 ==== State
 ====
-All databases are write available.
+All databases which are desired to be started are write available.
 ====
 
 Once this state is verified, disaster recovery is complete.
 However, remember that previously stopped databases might have been started during this process.
-If they are still desired to be in stopped state, run `START DATABASE started-db WAIT`.
+If they are still desired to be in stopped state, run `STOP DATABASE started-db WAIT`.
 
-[NOTE]
+[CAUTION]
 ====
-Remember, recreating a database can take an unbounded amount of time since it may involve copying the store to a new server, as described in xref:clustering/databases.adoc#recreate-databases[Recreate databases].
-Therefore, an allocation with `currentStatus` = `STARTING` might reach the `requestedStatus` given some time.
+Remember, recreating a database takes an unbounded amount of time since it may involve copying the store to a new server, as described in xref:clustering/databases.adoc#recreate-databases[Recreate databases].
+Therefore, an allocation with `currentStatus` = `STARTING` will probably reach the `requestedStatus` given some time.
 ====
 
+[[example-verification]]
 ==== Example verification
 All databases' write availability can be verified by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[Status check] procedure.
 The procedure should be called on all servers in the cluster, in order to provide the correct view.
-The status check procedure writes a dummy transaction, and therefore the correctness of the procedure depends on the given timeout.
-The default timeout is 1 second, but depending on the network latency in the environment it might need to be extended.
+The default timeout for the procedure is 1 second, but depending on the network latency in the environment it might need to be extended to produce an accurate result.
 If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
-Therefore, the desired state has been verified when this is true for all databases.
+Therefore, the desired state has been verified when this is true for all *started* databases.
 
 [source, shell]
 ----
 CALL dbms.cluster.statusCheck([]);
 ----
+
+[NOTE]
+=====
+The write availability of a database configured to have a single primary cannot be checked with the status check, instead check that the primary is allocated on an available server and that it has `currentStatus` = `STARTED`.
+The procedure will still produce an accurate result if all but one primary have been lost during a disaster.
+=====
 
 A stricter verification can be done to verify that all databases are in their desired states on all servers.
 For the stricter check, run `SHOW DATABASES` and verify that `requestedStatus` = `currentStatus` for all database allocations on all servers.
@@ -258,15 +275,22 @@ Recreations might fail for different reasons, but one example is that the checks
 .Guide
 [%collapsible]
 ====
-. Run `CALL dbms.cluster.statusCheck([])` on all servers to identify write unavailable databases, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
+. Identify all write unavailable databases that are desired to be `STARTED` by running `CALL dbms.cluster.statusCheck([])` as described in the xref:clustering/disaster-recovery.adoc#example-verification[Example verification] part of this disaster recovery step.
 . Recreate every database that is not write available and has not been recreated previously, see xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information.
-If any allocation has `currentStatus` = `QUARANTINED`, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed] or define seeding servers in the recreate procedure using xref:clustering/databases.adoc#specified-servers[Specified seeders] so that problematic allocations are excluded.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
+If any database has `currentStatus` = `QUARANTINED` on an available server, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
++
+[NOTE]
+=====
+By using recreate with xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], the store will be replaced by the most up-to-date copy according to the cluster's view without manual intervention.
+Furthermore, this option will automatically recreate the database based on a backup if no available allocation can be found.
+=====
+
 . Run `SHOW DATABASES` and check any recreated databases which are not write available.
 Recreating a database will not complete if one of the following messages is displayed in the message field:
 ** `Seeders ServerId1 and ServerId2 have different checksums for transaction TransactionId. All seeders must have the same checksum for the same append index.`
 ** `Seeders ServerId1 and ServerId2 have incompatible storeIds. All seeders must have compatible storeIds.`
 ** `No store found on any of the seeders ServerId1, ServerId2...`
-. For each database which will not complete recreation, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed] or define seeding servers in the recreate procedure using xref:clustering/databases.adoc#specified-servers[Specified seeders] so that problematic allocations are excluded.
+. For each database which will not complete recreation, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
 
 ====

--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -5,10 +5,9 @@
 
 A database can become unavailable due to issues on different system levels.
 For example, a data center failover may lead to the loss of multiple servers, which may cause a set of databases to become unavailable.
-It is also possible for databases to become quarantined due to a critical failure in the system, which may lead to unavailability even without the loss of servers.
 
 This section contains a step-by-step guide on how to recover _unavailable databases_ that are incapable of serving writes, while still may be able to serve reads.
-However, if a database is not performing as expected for other reasons, this section cannot help.
+However, if a database is unavailable because some members are in a quarantined state or if a database is not performing as expected for other reasons, this section cannot help.
 By following the steps outlined here, you can recover the unavailable databases and make them fully operational with minimal impact on the other databases in the cluster.
 
 [NOTE]
@@ -24,19 +23,25 @@ Databases in clusters follow an allocation strategy.
 This means that they are allocated differently within the cluster and may also have different numbers of primaries and secondaries.
 The consequence of this is that all servers are different in which databases they are hosting.
 Losing a server in a cluster may cause some databases to lose a member while others are unaffected.
-Consequently, in a disaster where multiple servers go down, some databases may keep running with little to no impact, while others may lose all their allocated resources.
+Therefore, in a disaster where multiple servers go down, some databases may keep running with little to no impact, while others may lose all their allocated resources.
 
 == Guide to disaster recovery
 
 There are three main steps to recovering a cluster from a disaster.
 Completing each step, regardless of the disaster scenario, is recommended to ensure the cluster is fully operational.
 
+[NOTE]
+====
+Any potential quarantined databases need to be handled before executing this guide, see xref:database-administration/standard-databases/errors.adoc#quarantine[Quarantined databases] for more information.
+====
+
 . Ensure the `system` database is available in the cluster.
 The `system` database defines the configuration for the other databases; therefore, it is vital to ensure it is available before doing anything else.
 
 . After the `system` database's availability is verified, whether recovered or unaffected by the disaster, recover the lost servers to ensure the cluster's topology meets the requirements.
+This process also starts the managing of databases.
 
-. After the `system` database is available and the cluster's topology is satisfied, you can manage the databases.
+. After the `system` database is available and the cluster's topology is satisfied, start or continue managing databases and verify that they are available.
 
 The steps are described in detail in the following sections.
 
@@ -53,109 +58,131 @@ One way to remedy this is to connect directly to the server using `bolt` instead
 See xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] for more information on the `bolt` scheme.
 ====
 
-=== Restore the `system` database
+[[restore-the-system-database]]
+=== `System` database availability
 
-The first step of recovery is to ensure that the `system` database is available.
+The first step of recovery is to ensure that the `system` database is able to accept writes.
 The `system` database is required for clusters to function properly.
 
-. Start all servers that are _offline_.
-(If a server is unable to start, inspect the logs and contact support personnel.
-The server may have to be considered indefinitely lost.)
-. *Validate the `system` database's availability.*
-.. Run `SHOW DATABASE system`.
-If the response does not contain a writer, the `system` database is unavailable and needs to be recovered, continue to step 3.
-.. Optionally, you can create a temporary user to validate the `system` database's writability by running `CREATE USER 'temporaryUser' SET PASSWORD 'temporaryPassword'`.
-.. Confirm that the temporary user is created as expected, by running `SHOW USERS`, then continue to xref:clustering/disaster-recovery.adoc#recover-servers[Recover servers].
-If not, continue to step 3.
+. Start the Neo4j process on all servers that are _offline_.
+If a server is unable to start, inspect the logs and contact support personnel.
+The server may have to be considered indefinitely lost.
+. Validate the `system` database's write availability by running `CALL dbms.cluster.statusCheck(["system"])` on all remaining system primaries, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
+Depending on the environment, consider extending the timeout for this procedure.
+If any of the system primaries report `replicationSuccessful` = `TRUE`, the system database is write available and does not need to be recovered.
+Therefore, skip to step xref:clustering/disaster-recovery.adoc#recover-servers[Server availability].
+
 +
-. *Restore the `system` database.*
-+
-[NOTE]
-====
-Only do the steps below if the `system` database's availability cannot be validated by the first two steps in this section.
-====
+. Regain availability by restoring the `system` database.
 +
 [NOTE]
 ====
-Recall that the cluster remains fault tolerant, and thus able to serve both reads and writes, as long as a majority of the primaries are available.
-In case of a disaster affecting one or more server(s), but where the majority of servers are still available, it is possible to add a new server to the cluster and recover the `system` database (and any other affected user databases) on it by copying the `system` database (and affected user databases) from one of the available servers.
-This method prevents downtime for the other databases in the cluster.
-If this is the case, ie. if a majority of servers are still available, follow the instructions in <<recover-servers>>.
+Only do the steps below if the `system` database's write availability cannot be validated by the first two steps in this section.
 ====
 +
+
 The following steps create a new `system` database from a backup of the current `system` database.
-This is required since the current `system` database has lost too many members in the server failover.
+This is required since the current `system` database has lost too many members to be able to accept writes.
 
 .. Shut down the Neo4j process on all servers.
 Note that this causes downtime for all databases in the cluster.
 .. On each server, run the following `neo4j-admin` command `bin/neo4j-admin dbms unbind-system-db` to reset the `system` database state on the servers.
-See xref:tools/neo4j-admin/index.adoc#neo4j-admin-commands[`neo4j-admin` commands] for more information.
+See xref:tools/neo4j-admin/index.adoc#neo4j-admin-commands[neo4j-admin commands] for more information.
 .. On each server, run the following `neo4j-admin` command `bin/neo4j-admin database info system` to find out which server is most up-to-date, ie. has the highest last-committed transaction id.
 .. On the most up-to-date server, take a dump of the current `system` database by running `bin/neo4j-admin database dump system --to-path=[path-to-dump]` and store the dump in an accessible location.
-See xref:tools/neo4j-admin/index.adoc#neo4j-admin-commands[`neo4j-admin` commands] for more information.
-.. Ensure there are enough `system` database primaries to create the new `system` database with fault tolerance.
-Either:
-... Add completely new servers (see xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster]) or
-... Change the `system` database mode (`server.cluster.system_database_mode`) on the current `system` database's secondary servers to allow them to be primaries for the new `system` database.
-.. On each server, run `bin/neo4j-admin database load system --from-path=[path-to-dump] --overwrite-destination=true` to load the current `system` database dump.
-.. Ensure that `dbms.cluster.discovery.endpoints` are set correctly on all servers, see xref:clustering/setup/discovery.adoc[Cluster server discovery] for more information.
-.. Return to step 1.
-
-
-[[recover-servers]]
-=== Recover servers
-
-Once the `system` database is available, the cluster can be managed.
-Following the loss of one or more servers, the cluster's view of servers must be updated, ie. the lost servers must be replaced by new servers.
-The steps here identify the lost servers and safely detach them from the cluster.
-
-. Run `SHOW SERVERS`.
-If *all* servers show health `AVAILABLE` and status `ENABLED` continue to xref:clustering/disaster-recovery.adoc#recover-databases[Recover databases].
-. For each `UNAVAILABLE` server, run `CALL dbms.cluster.cordonServer("unavailable-server-id")` on one of the available servers.
-. For each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers.
-. For each server that failed to deallocate with one of the following messages:
-.. `Could not deallocate server(s) 'serverId'. Unable to reallocate 'DatabaseId.\*'. +
-Required topology for 'DatabaseId.*' is 3 primaries and 0 secondaries. +
-Consider running SHOW SERVERS to determine what action is suitable to resolve this issue.`
-+
-or
-+
-`Could not deallocate server(s) `serverId`.
-Database [database] has lost quorum of servers, only found [existing number of primaries] of [expected number of primaries].
-Cannot be safely reallocated.`
-+
-First ensure that there is a backup for the database in question (see xref:backup-restore/online-backup.adoc[Online backup]), and then drop the database by running `DROP DATABASE database-name`.
-Return to step 3.
-.. `Could not deallocate server [server]. Cannot change allocations for database [stopped-db] because it is offline.`
-+
-Try to start the offline database by running `START DATABASE stopped-db WAIT`.
-If it starts successfully, return to step 3.
-Otherwise, ensure that there is a backup for the database before dropping it with `DROP DATABASE stopped-db`.
-Return to step 3.
+See xref:tools/neo4j-admin/index.adoc#neo4j-admin-commands[neo4j-admin commands] for more information.
+.. For every _lost_ server, add a new unconstrained one according to xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster].
 +
 [NOTE]
 ====
-A database can be set to `READ-ONLY`-mode before it is started to avoid updates on a database that is desired to be stopped with the following:
-`ALTER DATABASE database-name SET ACCESS READ ONLY`.
+While recommended to avoid cluster overload, it is not strictly necessary to add servers in this step.
+There is also an option to change the `system` database mode (`server.cluster.system_database_mode`) on secondary allocations to make them primaries for the new `system` database.
+The amount of primaries needed is defined by `dbms.cluster.minimum_initial_system_primaries_count`, see the xref:configuration/configuration-settings.adoc#config_dbms.cluster.minimum_initial_system_primaries_count[Configuration settings] for more information.
+====
++
+.. On each server, run `bin/neo4j-admin database load system --from-path=[path-to-dump] --overwrite-destination=true` to load the current `system` database dump.
+.. Ensure that the discovery settings are correct on all servers, see xref:clustering/setup/discovery.adoc[Cluster server discovery] for more information.
+.. Return to step 1, to start all servers and confirm the `system` database is now available.
+
+
+[[recover-servers]]
+=== Server availability
+
+Once the `system` database is available, the cluster can be managed.
+Following the loss of one or more servers, the cluster's view of servers must be updated, ie. the lost servers must be replaced by new ones.
+The steps here identify the lost servers and safely detach them from the cluster, while recreating any databases that cannot be moved from the lost servers because they have lost availability.
+
+. Run `SHOW SERVERS`.
+If *all* servers show health `AVAILABLE` and status `ENABLED` continue to xref:clustering/disaster-recovery.adoc#recover-databases[Database availability].
+. For each `UNAVAILABLE` server, run `CALL dbms.cluster.cordonServer("unavailable-server-id")` on one of the available servers.
+. For each `CORDONED` server, make sure a new *unconstrained* server has been added to the cluster to take its place, see xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster] for more information.
+If servers were added in the xref:clustering/disaster-recovery.adoc#restore-the-system-database[System database availability] step, the amount of servers that needs to be added in this step is less than the number of `CORDONED` servers.
+
++
+[NOTE]
+====
+While recommended, it is not strictly necessary to add new servers in this step.
+However, not adding new servers reduces the capacity of the cluster to handle work and might require the topology for a database to be altered to make deallocations and recreations possible.
 ====
 
-.. `Could not deallocate server [server]. Reallocation of [database] not possible, no new target found. All existing servers: [existing-servers]. Actual allocated server with mode [mode] is [current-hostings].`
+. For each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers. If all deallocations succeeded, skip to step 6.
+. If any deallocations failed, make them possible by the following steps:
+.. Run `SHOW DATABASES`. If a database show `currentStatus`= `offline` this database has been stopped.
+.. For each stopped database that is allocated on any of the `CORDONED` servers, start them by running `START DATABASE stopped-db WAIT`.
 +
-Add new servers and enable them and then return to step 3, see xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster] for more information.
-. Run `SHOW SERVERS YIELD *` once all enabled servers host the requested databases (`hosting`-field contains exactly the databases in the `requestedHosting` field), and proceed to the next step.
-Note that this may take a few minutes.
+[NOTE]
+====
+A database can be set to `READ-ONLY` before it is started to avoid updates on a database that is desired to be stopped with the following:
+`ALTER DATABASE database-name SET ACCESS READ ONLY`.
+====
+.. Run `CALL dbms.cluster.statusCheck([])` on all servers, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
+Depending on the environment, consider extending the timeout for this procedure.
+If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
+
+.. Recreate every database that is not write available, see xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information.
+Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
++
+[NOTE]
+====
+By using recreate with xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], also databases which have lost all allocation can be recreated.
+Otherwise, recreating with xref:clustering/databases.adoc#uri-seed[Backup as seed] must be used for that specific case.
+====
+.. Return to step 4 to retry deallocating all servers.
 . For each deallocated server, run `DROP SERVER deallocated-server-id`.
-. Return to step 1.
+. Return to step 1 to make sure all servers in the cluster are `AVAILABLE`.
+
 
 [[recover-databases]]
-=== Recover databases
+=== Database availability
 
-Once the `system` database is verified available, and all servers are online, the databases can be managed.
-The steps here aim to make the unavailable databases available.
+Once the `system` database and all servers are available, manage and verify that all databases are in the desired state.
 
-. If you have previously dropped databases as part of this guide, re-create each one from a backup.
-See the xref:database-administration/standard-databases/create-databases.adoc[Create databases] section for more information on how to create a database.
-. Run `SHOW DATABASES`.
-If all databases are in desired states on all servers (`requestedStatus`=`currentStatus`), disaster recovery is complete.
-// . For each database that remains unavailable, refer to <<unavailable-databases, Managing unavailable databases in a cluster>>.
-// Perform the actions required to get the database available then return to step 2.
+. Run `CALL dbms.cluster.statusCheck([])` on all servers, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
+Depending on the environment, consider extending the timeout for this procedure.
+If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
+If all databases are write available, disaster recovery is complete.
++
+[NOTE]
+====
+Remember that previously stopped databases might have been started during this process.
+====
+
+. Recreate every database that is not write available and has not been recreated previously, see xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information.
+Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
+. Run `SHOW DATABASES` and check any recreated databases which are not write available.
+
++
+[NOTE]
+====
+Remember, recreating a database can take an unbounded amount of time since it may involve copying the store to a new server, as described in  xref:clustering/databases.adoc#recreate-databases[Recreate databases].
+Therefore, an allocation with `currentStatus` = `STARTING` might reach the `requestedStatus` given some time.
+====
+Recreating a database will not complete if one of the following messages is displayed in the message field:
+** `Seeders ServerId1 and ServerId2 have different checksums for transaction TransactionId. All seeders must have the same checksum for the same append index.`
+** `Seeders ServerId1 and ServerId2 have incompatible storeIds. All seeders must have compatible storeIds.`
+** `No store found on any of the seeders ServerId1, ServerId2...`
++
+
+. For each database which will not complete recreation, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed] or define seeding servers in the recreate procedure using xref:clustering/databases.adoc#specified-servers[Specified seeders] so that problematic allocations are excluded.
+. Return to step 1 to make sure all databases are in their desired state.
+

--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -7,8 +7,8 @@ A database can become unavailable due to issues on different system levels.
 For example, a data center failover may lead to the loss of multiple servers, which may cause a set of databases to become unavailable.
 
 This section contains a step-by-step guide on how to recover *unavailable databases* that are incapable of serving writes, while possibly still being able to serve reads.
+The guide recovers the unavailable databases and make them fully operational, with minimal impact on the other databases in the cluster.
 However, if a database is not performing as expected for other reasons, this section cannot help.
-By following the steps outlined here, you can recover the unavailable databases and make them fully operational, with minimal impact on the other databases in the cluster.
 
 [CAUTION]
 ====
@@ -53,15 +53,22 @@ Verifying each state before continuing to the next step, regardless of the disas
 
 [NOTE]
 ====
-Before beginning this guide, start the Neo4j process on all servers that are _offline_.
-If a server is unable to start, inspect the logs and contact support personnel.
-The server may have to be considered indefinitely lost.
-====
-
 Disasters may sometimes affect the routing capabilities of the driver and may prevent the use of the `neo4j` scheme for routing.
 One way to remedy this is to connect directly to the server using `bolt` instead of `neo4j`.
 See xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] for more information on the `bolt` scheme.
+====
 
+=== Neo4j process started
+
+==== State
+====
+The Neo4j process is started on all servers which are not _lost_.
+====
+
+==== Path to correct state
+Start the Neo4j process on all servers that are _offline_.
+If a server is unable to start, inspect the logs and contact support personnel.
+The server may have to be considered indefinitely lost.
 
 [[restore-the-system-database]]
 === `System` database write availability
@@ -110,14 +117,14 @@ This causes downtime for all databases in the cluster until the processes are st
 . On each server, run `bin/neo4j-admin database info system` and compare the `lastCommittedTransaction` to find out which server has the most up-to-date copy of the `system` database.
 . On the most up-to-date server, run `bin/neo4j-admin database dump system --to-path=[path-to-dump]` to take a dump of the current `system` database and store it in an accessible location.
 . For every _lost_ server, add a new *unconstrained* one according to xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster].
-It is important that the new servers are unconstrained, or deallocating servers might be blocked even though enough servers were added.
+It is important that the new servers are unconstrained, or deallocating servers in the next step of this guide might be blocked, even though enough servers were added.
 +
 [NOTE]
 =====
 While recommended, it is not strictly necessary to add new servers in this step.
 There is also an option to change the `system` database mode (`server.cluster.system_database_mode`) on secondary allocations to make them primary allocations for the new `system` database.
 The amount of primary allocations needed is defined by `dbms.cluster.minimum_initial_system_primaries_count`, see the xref:configuration/configuration-settings.adoc#config_dbms.cluster.minimum_initial_system_primaries_count[Configuration settings] for more information.
-Not replacing servers can cause cluster overload when databases are moved from lost servers to available ones in the next step of this guide.
+Be aware that not replacing servers can cause cluster overload when databases are moved from lost servers to available ones in the next step of this guide.
 =====
 +
 . On each server, run `bin/neo4j-admin database load system --from-path=[path-to-dump] --overwrite-destination=true` to load the current `system` database dump.
@@ -136,8 +143,8 @@ All servers in the cluster's view are available and enabled.
 
 A lost server will still be in the `system` database's view of the cluster, but in an unavailable state.
 According to the view of the cluster, these lost servers are still hosting the databases they had before they became lost.
-Therefore, removing lost servers is not as easy as informing the `system` database that they are lost.
-It also includes moving requested allocations on the lost servers onto servers which are actually in the cluster, so that those databases' topologies are still satisfied.
+Therefore, informing the cluster of servers which are lost is not enough.
+The databases hosted on the lost servers also need to be moved onto servers which are actually in the cluster.
 
 ==== Example verification
 The cluster's view of servers can be seen by listing the servers, see xref:clustering/servers.adoc#_listing_servers[Listing servers] for more information.
@@ -150,7 +157,7 @@ SHOW SERVERS;
 
 ==== Path to correct state
 The following steps can be used to remove lost servers and add new ones to the cluster.
-They include moving any potential database allocations from lost servers to available servers in the cluster.
+That includes moving any potential database allocations from lost servers to available servers in the cluster.
 These steps might also recreate some databases, since a database which has lost a majority of its primary allocations cannot be moved from one server to another.
 
 .Guide
@@ -170,19 +177,8 @@ However, not adding new servers reduces the capacity of the cluster to handle wo
 Furthermore, it might require the topology for a database to be altered to make deallocating servers and recreating databases possible.
 =====
 
-// ? from here
-. For each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers.
-This will try to move all database allocations from this server to an available server in the cluster.
-Once a server is `DEALLOCATED`, all allocated user databases on this server has been moved successfully.
-+
-[NOTE]
-=====
-Remember, moving databases can take an unbounded amount of time since it involves copying the store to a new server.
-Therefore, an allocation with `currentStatus` = `DEALLOCATING` should reach the `requestedStatus` = `DEALLOCATED` given some time.
-=====
-. If any deallocations failed, make them possible by executing the following steps:
-.. Run `SHOW DATABASES`. If a database show `currentStatus`= `offline` this database has been stopped.
-.. For each stopped database that has at least one allocation on any of the `CORDONED` servers, start them by running `START DATABASE stopped-db WAIT`.
+. Run `SHOW DATABASES`. If a database show `currentStatus`= `offline` this database has been stopped.
+. For each stopped database that has at least one allocation on any of the `CORDONED` servers, start them by running `START DATABASE stopped-db WAIT`.
 This is necessary since stopped databases cannot be moved from one server to another.
 +
 [NOTE]
@@ -190,12 +186,12 @@ This is necessary since stopped databases cannot be moved from one server to ano
 A database can be set to `READ-ONLY` before it is started to avoid updates on a database that is desired to be stopped with the following command:
 `ALTER DATABASE database-name SET ACCESS READ ONLY`.
 =====
-.. On each server, run `CALL dbms.cluster.statusCheck([])` to check the write availability for all databases on this server, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
+. On each server, run `CALL dbms.cluster.statusCheck([])` to check the write availability for all databases on this server, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
 Depending on the environment, consider extending the timeout for this procedure.
 If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
-
-.. For each database that is not write available, recreate it to move it from lost servers and regain write availability.
+. For each database that is not write available, recreate it to move it from lost servers and regain write availability.
 Go to xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information about recreate options.
+If any allocation has `currentStatus` = `QUARANTINED`, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed] or define seeding servers in the recreate procedure using xref:clustering/databases.adoc#specified-servers[Specified seeders] so that problematic allocations are excluded.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
 +
 [NOTE]
@@ -203,11 +199,16 @@ Remember to make sure there are recent backups for the databases before recreati
 By using recreate with xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], also databases which have lost all allocation can be recreated.
 Otherwise, recreating with xref:clustering/databases.adoc#uri-seed[Backup as seed] must be used for that specific case.
 =====
-.. Return to step 3 to retry deallocating all servers.
-. For each deallocated server, run `DROP SERVER deallocated-server-id`.
-This safely removes the server from the cluster's view.
-
-// ? to here really
+. For each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers.
+This will try to move all database allocations from this server to an available server in the cluster.
++
+[NOTE]
+=====
+This operation might fail if enough unconstrained servers were not added to the cluster to replace lost servers.
+Another reason is that some available servers are also `CORDONED`.
+=====
+. For each deallocating or deallocated server, run `DROP SERVER deallocated-server-id`.
+This removes the server from the cluster's view.
 ====
 
 
@@ -242,7 +243,7 @@ Therefore, the desired state has been verified when this is true for all databas
 CALL dbms.cluster.statusCheck([]);
 ----
 
-A stricter verification could be done to verify if all databases are in desired states on all servers.
+A stricter verification can be done to verify that all databases are in their desired states on all servers.
 For the stricter check, run `SHOW DATABASES` and verify that `requestedStatus` = `currentStatus` for all database allocations on all servers.
 
 ==== Path to correct state
@@ -255,6 +256,7 @@ Recreations might fail for different reasons, but one example is that the checks
 ====
 . Run `CALL dbms.cluster.statusCheck([])` on all servers to identify write unavailable databases, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
 . Recreate every database that is not write available and has not been recreated previously, see xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information.
+If any allocation has `currentStatus` = `QUARANTINED`, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed] or define seeding servers in the recreate procedure using xref:clustering/databases.adoc#specified-servers[Specified seeders] so that problematic allocations are excluded.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
 . Run `SHOW DATABASES` and check any recreated databases which are not write available.
 Recreating a database will not complete if one of the following messages is displayed in the message field:

--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -6,47 +6,47 @@
 A database can become unavailable due to issues on different system levels.
 For example, a data center failover may lead to the loss of multiple servers, which may cause a set of databases to become unavailable.
 
-This section contains a step-by-step guide on how to recover _unavailable databases_ that are incapable of serving writes, while still may be able to serve reads.
+This section contains a step-by-step guide on how to recover *unavailable databases* that are incapable of serving writes, while possibly still being able to serve reads.
 However, if a database is not performing as expected for other reasons, this section cannot help.
-By following the steps outlined here, you can recover the unavailable databases and make them fully operational with minimal impact on the other databases in the cluster.
+By following the steps outlined here, you can recover the unavailable databases and make them fully operational, with minimal impact on the other databases in the cluster.
 
-[NOTE]
+[CAUTION]
 ====
-If *all* servers in a Neo4j cluster are lost in a data center failover, it is not possible to recover the current cluster.
-You have to create a new cluster and restore the databases.
-See xref:clustering/setup/deploy.adoc[Deploy a basic cluster] and xref:clustering/databases.adoc#cluster-seed[Seed a database] for more information.
+If *all* servers in a Neo4j cluster are lost in a disaster, it is not possible to recover the current cluster.
+You have to create a new cluster and restore the databases, see xref:clustering/setup/deploy.adoc[Deploy a basic cluster] and xref:clustering/databases.adoc#cluster-seed[Seed a database] for more information.
 ====
 
 == Faults in clusters
 
 Databases in clusters follow an allocation strategy.
 This means that they are allocated differently within the cluster and may also have different numbers of primaries and secondaries.
-Furthermore, some databases may not be allowed to be allocated to some servers because of user defined strategies.
-The consequence of this is that all servers may be different in which databases they are hosting and are allowed to host.
+The consequence of this is that all servers may be different in which databases they are hosting.
 Losing a server in a cluster may cause some databases to lose a member while others are unaffected.
 Therefore, in a disaster where one or more servers go down, some databases may keep running with little to no impact, while others may lose all their allocated resources.
 
 == Guide structure
+[NOTE]
+====
+In this guide, an _offline_ server is a server that is not running but may be restartable.
+A _lost_ server, however, is a server that is currently not running and cannot be restarted.
+A _write available_ database is able to serve writes, while a _write unavailable_ database is not.
+====
+
 There are three main steps to recovering a cluster from a disaster.
-First, ensure the `system` database is write available i.e. able to accept writes.
-Then, detach any potential lost servers and replace them by new ones.
-Finish disaster recovery by starting or continuing to manage databases and verify that they are available.
+First, ensure the `system` database is write available.
+Then, detach any potential lost servers from the cluster and replace them by new ones.
+Finish disaster recovery by starting or continuing to manage databases and verify that they are write available.
 
-Every step consists of the following four sections:
+Every step consists of the following three sections:
 
-. State that needs to be verified.
-. Example of how the state can be verified.
-. Motivation for why this state is necessary.
-. Path to correct state.
+. A state that needs to be verified, with optional motivation.
+. An example of how the state can be verified.
+. A proposed series of steps to get to the correct state.
 
 [CAUTION]
 ====
 Verifying each state before continuing to the next step, regardless of the disaster scenario, is recommended to ensure the cluster is fully operational.
-
 ====
-
-In this section, an _offline_ server is a server that is not running but may be _restartable_.
-A _lost_ server, however, is a server that is currently not running and cannot be restarted.
 
 
 == Guide to disaster recovery
@@ -68,14 +68,14 @@ See xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] f
 
 ==== State
 ====
-The `system` database is write available, i.e. able to accept writes.
+The `system` database is write available.
 ====
 
-==== Motivation
-The `system` database contains the view of the cluster. This includes which servers and databases are present and how they are configured.
-During a disaster, the goal is to change the view of the cluster, for example by removing and adding servers or recreating databases.
-In order for the view to be updated, the `system` database needs to be write available.
-Therefore, it is vital to ensure it is available so that the next steps are possible to execute.
+The `system` database contains the view of the cluster.
+This includes which servers and databases are present, where they live and how they are configured.
+During a disaster, the view of the cluster might need to change to reflect a new reality, for example by removing lost servers.
+Databases might also need to be recreated to regain write availability.
+Because both of these steps are executed by writing to the `system` database, this is a vital first step during disaster recovery.
 
 ==== Example verification
 The `system` database's write availability can be verified by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[Status check] procedure.
@@ -93,7 +93,7 @@ CALL dbms.cluster.statusCheck(["system"]);
 ==== Path to correct state
 The following steps can be used to regain write availability for the `system` database if it has been lost.
 They create a new `system` database from the most up-to-date copy of the `system` database that can be found in the cluster.
-It is important to get a `system` database that is as up-to-date as possible, so that future commands operate on state that is as correct as possible.
+It is important to get a `system` database that is as up-to-date as possible, so it corresponds to the view before the disaster closely.
 
 .Guide
 [%collapsible]
@@ -110,13 +110,14 @@ This causes downtime for all databases in the cluster until the processes are st
 . On each server, run `bin/neo4j-admin database info system` and compare the `lastCommittedTransaction` to find out which server has the most up-to-date copy of the `system` database.
 . On the most up-to-date server, run `bin/neo4j-admin database dump system --to-path=[path-to-dump]` to take a dump of the current `system` database and store it in an accessible location.
 . For every _lost_ server, add a new *unconstrained* one according to xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster].
-It is important that the new servers are unconstrained, or deallocating servers might be blocked even though enough servers was added.
+It is important that the new servers are unconstrained, or deallocating servers might be blocked even though enough servers were added.
 +
 [NOTE]
 =====
-While recommended to avoid cluster overload, it is not strictly necessary to add servers in this step.
+While recommended, it is not strictly necessary to add new servers in this step.
 There is also an option to change the `system` database mode (`server.cluster.system_database_mode`) on secondary allocations to make them primary allocations for the new `system` database.
 The amount of primary allocations needed is defined by `dbms.cluster.minimum_initial_system_primaries_count`, see the xref:configuration/configuration-settings.adoc#config_dbms.cluster.minimum_initial_system_primaries_count[Configuration settings] for more information.
+Not replacing servers can cause cluster overload when databases are moved from lost servers to available ones in the next step of this guide.
 =====
 +
 . On each server, run `bin/neo4j-admin database load system --from-path=[path-to-dump] --overwrite-destination=true` to load the current `system` database dump.
@@ -133,11 +134,10 @@ The amount of primary allocations needed is defined by `dbms.cluster.minimum_ini
 All servers in the cluster's view are available and enabled.
 ====
 
-==== Motivation
-// different stuffs here
-Following the loss of one or more servers, the cluster's view of servers must be updated.
-This includes moving allocations on the lost servers onto servers which are actually in the cluster
-This includes identifying the lost servers and replacing them by new ones.
+A lost server will still be in the `system` database's view of the cluster, but in an unavailable state.
+According to the view of the cluster, these lost servers are still hosting the databases they had before they became lost.
+Therefore, removing lost servers is not as easy as informing the `system` database that they are lost.
+It also includes moving requested allocations on the lost servers onto servers which are actually in the cluster, so that those databases' topologies are still satisfied.
 
 ==== Example verification
 The cluster's view of servers can be seen by listing the servers, see xref:clustering/servers.adoc#_listing_servers[Listing servers] for more information.
@@ -149,7 +149,9 @@ SHOW SERVERS;
 ----
 
 ==== Path to correct state
-Detach lost servers and add new ones to the cluster
+The following steps can be used to remove lost servers and add new ones to the cluster.
+They include moving any potential database allocations from lost servers to available servers in the cluster.
+These steps might also recreate some databases, since a database which has lost a majority of its primary allocations cannot be moved from one server to another.
 
 .Guide
 [%collapsible]
@@ -158,16 +160,19 @@ Detach lost servers and add new ones to the cluster
 This prevents new database allocations from being moved to this server.
 . For each `CORDONED` server, make sure a new *unconstrained* server has been added to the cluster to take its place, see xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster] for more information.
 If servers were added in the 'System database write availability' step of this guide, additional servers might not be needed here.
+It is important that the new servers are unconstrained, or deallocating servers might be blocked even though enough servers were added.
 
 +
 [NOTE]
 =====
 While recommended, it is not strictly necessary to add new servers in this step.
-However, not adding new servers reduces the capacity of the cluster to handle work and might require the topology for a database to be altered to make deallocations and recreations possible.
+However, not adding new servers reduces the capacity of the cluster to handle work.
+Furthermore, it might require the topology for a database to be altered to make deallocating servers and recreating databases possible.
 =====
 
+// ? from here
 . For each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers.
-This will try to move all database allocations from this server to another server in the cluster.
+This will try to move all database allocations from this server to an available server in the cluster.
 Once a server is `DEALLOCATED`, all allocated user databases on this server has been moved successfully.
 +
 [NOTE]
@@ -178,6 +183,7 @@ Therefore, an allocation with `currentStatus` = `DEALLOCATING` should reach the 
 . If any deallocations failed, make them possible by executing the following steps:
 .. Run `SHOW DATABASES`. If a database show `currentStatus`= `offline` this database has been stopped.
 .. For each stopped database that has at least one allocation on any of the `CORDONED` servers, start them by running `START DATABASE stopped-db WAIT`.
+This is necessary since stopped databases cannot be moved from one server to another.
 +
 [NOTE]
 =====
@@ -188,7 +194,7 @@ A database can be set to `READ-ONLY` before it is started to avoid updates on a 
 Depending on the environment, consider extending the timeout for this procedure.
 If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
 
-.. For each database that is not write available, recreate it to regain write availability.
+.. For each database that is not write available, recreate it to move it from lost servers and regain write availability.
 Go to xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information about recreate options.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
 +
@@ -199,42 +205,62 @@ Otherwise, recreating with xref:clustering/databases.adoc#uri-seed[Backup as see
 =====
 .. Return to step 3 to retry deallocating all servers.
 . For each deallocated server, run `DROP SERVER deallocated-server-id`.
-This safely removes the server from the cluster view.
+This safely removes the server from the cluster's view.
 
+// ? to here really
 ====
 
 
 [[recover-databases]]
 === Database availability
 
-Once the `system` database and all servers are available, manage and verify that all databases are in the desired state.
+==== State
+====
+All databases are write available.
+====
 
-. Run `CALL dbms.cluster.statusCheck([])` on all servers, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
-Depending on the environment, consider extending the timeout for this procedure.
-If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
-If all databases are write available, disaster recovery is complete.
-+
+Once this state is verified, disaster recovery is complete.
+However, remember that previously stopped databases might have been started during this process.
+If they are still desired to be in stopped state, run `START DATABASE started-db WAIT`.
+
 [NOTE]
 ====
-Remember that previously stopped databases might have been started during this process.
+Remember, recreating a database can take an unbounded amount of time since it may involve copying the store to a new server, as described in xref:clustering/databases.adoc#recreate-databases[Recreate databases].
+Therefore, an allocation with `currentStatus` = `STARTING` might reach the `requestedStatus` given some time.
 ====
 
+==== Example verification
+All databases' write availability can be verified by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[Status check] procedure.
+The procedure should be called on all servers in the cluster, in order to provide the correct view.
+The status check procedure writes a dummy transaction, and therefore the correctness of the procedure depends on the given timeout.
+The default timeout is 1 second, but depending on the network latency in the environment it might need to be extended.
+If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
+Therefore, the desired state has been verified when this is true for all databases.
+
+[source, shell]
+----
+CALL dbms.cluster.statusCheck([]);
+----
+
+A stricter verification could be done to verify if all databases are in desired states on all servers.
+For the stricter check, run `SHOW DATABASES` and verify that `requestedStatus` = `currentStatus` for all database allocations on all servers.
+
+==== Path to correct state
+The following steps can be used to make all databases in the cluster write available again.
+They include recreating any databases that are not write available, as well as identifying any recreations which will not complete.
+Recreations might fail for different reasons, but one example is that the checksums does not match for the same transaction on different copies.
+
+.Guide
+[%collapsible]
+====
+. Run `CALL dbms.cluster.statusCheck([])` on all servers to identify write unavailable databases, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
 . Recreate every database that is not write available and has not been recreated previously, see xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
 . Run `SHOW DATABASES` and check any recreated databases which are not write available.
-
-+
-[NOTE]
-====
-Remember, recreating a database can take an unbounded amount of time since it may involve copying the store to a new server, as described in  xref:clustering/databases.adoc#recreate-databases[Recreate databases].
-Therefore, an allocation with `currentStatus` = `STARTING` might reach the `requestedStatus` given some time.
-====
 Recreating a database will not complete if one of the following messages is displayed in the message field:
 ** `Seeders ServerId1 and ServerId2 have different checksums for transaction TransactionId. All seeders must have the same checksum for the same append index.`
 ** `Seeders ServerId1 and ServerId2 have incompatible storeIds. All seeders must have compatible storeIds.`
 ** `No store found on any of the seeders ServerId1, ServerId2...`
-+
-
 . For each database which will not complete recreation, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed] or define seeding servers in the recreate procedure using xref:clustering/databases.adoc#specified-servers[Specified seeders] so that problematic allocations are excluded.
-. Return to step 1 to make sure all databases are in their desired state.
 
+====

--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -1,4 +1,4 @@
-:description: This section describes how to recover databases that have become unavailable.
+:description: This section describes how to recover databases that have become unavailable. How to heal a cluster.
 [role=enterprise-edition]
 [[cluster-recovery]]
 = Disaster recovery
@@ -30,24 +30,24 @@ In this guide the following terms are used:
 
 * An _offline_ server is a server that is not running but may be restartable.
 * A _lost_ server, however, is a server that is currently not running and cannot be restarted.
-* A _write available_ database is able to serve writes, while a _write unavailable_ database is not.
+* A _write-available_ database is able to serve writes, while a _write unavailable_ database is not.
 ====
 
 There are four steps to recovering a cluster from a disaster:
 
 . Start the Neo4j process on all servers which are not _lost_.
-See xref:start-the-neo4j-process[Start the neo4j process] for more information.
-. Make the `system` database write available, so that the cluster can be modified.
-See xref:make-the-system-database-write-available[Make the `system` database write available] for more information.
+See xref:start-the-neo4j-process[Start the Neo4j process] for more information.
+. Make the `system` database able to accept write operations, so that the cluster can be modified.
+See xref:make-the-system-database-write-available[Make the `system` database write-available] for more information.
 . Detach any potential lost servers from the cluster and replace them by new ones.
 See xref:make-servers-available[Make servers available] for more information.
-. Finish disaster recovery by starting or continuing to manage databases and verify that they are write available.
-See xref:make-databases-write-available[Make databases write available] for more information.
+. Finish disaster recovery by starting or continuing to manage databases and verify that they are write-available.
+See xref:make-databases-write-available[Make databases write-available] for more information.
 
 Each step is described in the following three sections:
 
 . Objective -- a state that the cluster needs to be in, with optional motivation.
-. Verifying the state -- An example of how the state can be verified.
+. Verifying the state -- an example of how the state can be verified.
 . Path to correct state -- a proposed series of steps to get to the correct state.
 
 [CAUTION]
@@ -55,7 +55,7 @@ Each step is described in the following three sections:
 Verifying each state before continuing to the next step, regardless of the disaster scenario, is recommended to ensure the cluster is fully operational.
 ====
 
-
+[[disaster-recovery-steps]]
 == Disaster recovery steps
 
 [NOTE]
@@ -69,30 +69,33 @@ See xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] f
 === Start the Neo4j process
 
 ==== Objective
+
 ====
-The Neo4j process is started on all servers which are not _lost_.
+The Neo4j process is started on all servers that are not _lost_.
 ====
 
 ==== Path to correct state
+
 Start the Neo4j process on all servers that are _offline_.
 If a server is unable to start, inspect the logs and contact support personnel.
 The server may have to be considered indefinitely lost.
 
 [[make-the-system-database-write-available]]
-=== Make the `system` database write available
+=== Make the `system` database write-available
 
 ==== Objective
 ====
-The `system` database is write available.
+The `system` database is able to accept write operations.
 ====
 
 The `system` database contains the view of the cluster.
 This includes which servers and databases are present, where they live and how they are configured.
 During a disaster, the view of the cluster might need to change to reflect a new reality, such as removing lost servers.
 Databases might also need to be recreated to regain write availability.
-Because both of these steps are executed by modifying the `system` database, making the `system` database write available is a vital first step during disaster recovery.
+Because both of these steps are executed by modifying the `system` database, making the `system` database write-enabled is a vital first step during disaster recovery.
 
 ==== Verifying the state
+
 The `system` database's write availability can be verified by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[Status check] procedure.
 
 [source, shell]
@@ -107,6 +110,7 @@ Instead, check that the primary is allocated on an available server and that it 
 =====
 
 ==== Path to correct state
+
 Use the following steps to regain write availability for the `system` database if it has been lost.
 They create a new `system` database from the most up-to-date copy of the `system` database that can be found in the cluster.
 It is important to get a `system` database that is as up-to-date as possible, so it corresponds to the view before the disaster closely.
@@ -167,9 +171,9 @@ SHOW SERVERS;
 ----
 
 ==== Path to correct state
-The following steps can be used to remove lost servers and add new ones to the cluster.
-To be able to remove lost servers, any allocations it should host need to be moved to available servers in the cluster.
-This is done in two different ways:
+Use the following steps to remove lost servers and add new ones to the cluster.
+To remove lost servers, any allocations they were hosting must be moved to available servers in the cluster.
+This can be done in two different ways:
 
 * Any allocations that cannot move by themselves require the database to be recreated so that they are forced to move.
 * Any allocations that can move will be instructed to do so by deallocating the server.
@@ -179,8 +183,10 @@ This is done in two different ways:
 ====
 . For each `Unavailable` server, run `CALL dbms.cluster.cordonServer("unavailable-server-id")` on one of the available servers.
 This prevents new database allocations from being moved to this server.
-. For each `Cordoned` server, make sure a new *unconstrained* server has been added to the cluster to take its place, see xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster] for more information.
-If servers were added in the 'System database write availability' step of this guide, additional servers might not be needed here.
+. For each `Cordoned` server, make sure a new *unconstrained* server has been added to the cluster to take its place.
+See xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster] for more information.
++
+If servers were added in the <<make-the-system-database-write-available, Make the `system` database write-available>> step of this guide, additional servers might not be needed here.
 It is important that the new servers are unconstrained, or deallocating servers might be blocked even though enough servers were added.
 +
 [NOTE]
@@ -210,7 +216,7 @@ The status check procedure cannot verify the write availability of a database co
 Instead, check that the primary is allocated on an available server and that it has `currentStatus` = `online` by running `SHOW DATABASES`.
 =====
 
-. For each database that is not write available, recreate it to move it from lost servers and regain write availability.
+. For each database that is not write-available, recreate it to move it from lost servers and regain write availability.
 Go to xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information about recreate options.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
 If any database has `currentStatus` = `quarantined` on an available server, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
@@ -235,11 +241,11 @@ This removes the server from the cluster's view.
 
 
 [[make-databases-write-available]]
-=== Make databases write available
+=== Make databases write-available
 
 ==== Objective
 ====
-All databases that are desired to be started are write available.
+All databases that are desired to be started are write-available.
 ====
 
 Once this state is verified, disaster recovery is complete.
@@ -271,8 +277,8 @@ A stricter verification can be done to verify that all databases are in their de
 For the stricter check, run `SHOW DATABASES` and verify that `requestedStatus` = `currentStatus` for all database allocations on all servers.
 
 ==== Path to correct state
-The following steps can be used to make all databases in the cluster write available again.
-They include recreating any databases that are not write available, as well as identifying any recreations which will not complete.
+Use the following steps to make all databases in the cluster write-available again.
+They include recreating any databases that are not write-capable and identifying any recreations that will not complete.
 Recreations might fail for different reasons, but one example is that the checksums do not match for the same transaction on different servers.
 
 .Guide
@@ -280,7 +286,7 @@ Recreations might fail for different reasons, but one example is that the checks
 ====
 . Identify all write unavailable databases by running `CALL dbms.cluster.statusCheck([])` as described in the xref:clustering/disaster-recovery.adoc#example-verification[Example verification] part of this disaster recovery step.
 Filter out all databases desired to be stopped, so that they are not recreated unnecessarily.
-. Recreate every database that is not write available and has not been recreated previously, see xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information.
+. Recreate every database that is not write-available and has not been recreated previously, see xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
 If any database has `currentStatus` = `quarantined` on an available server, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
 +
@@ -289,7 +295,7 @@ If any database has `currentStatus` = `quarantined` on an available server, recr
 If you recreate databases using xref:clustering/databases.adoc#undefined-servers[undefined servers] or xref:clustering/databases.adoc#undefined-servers-backup[undefined servers with fallback backup], the store might not be recreated as up-to-date as possible in certain edge cases where the `system` database has been restored.
 =====
 
-. Run `SHOW DATABASES` and check any recreated databases which are not write available.
+. Run `SHOW DATABASES` and check any recreated databases that are not write-available.
 Recreating a database will not complete if one of the following messages is displayed in the message field:
 ** `Seeders ServerId1 and ServerId2 have different checksums for transaction TransactionId. All seeders must have the same checksum for the same append index.`
 ** `Seeders ServerId1 and ServerId2 have incompatible storeIds. All seeders must have compatible storeIds.`

--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -7,7 +7,7 @@ A database can become unavailable due to issues on different system levels.
 For example, a data center failover may lead to the loss of multiple servers, which may cause a set of databases to become unavailable.
 
 This section contains a step-by-step guide on how to recover _unavailable databases_ that are incapable of serving writes, while still may be able to serve reads.
-However, if a database is unavailable because some members are in a quarantined state or if a database is not performing as expected for other reasons, this section cannot help.
+However, if a database is not performing as expected for other reasons, this section cannot help.
 By following the steps outlined here, you can recover the unavailable databases and make them fully operational with minimal impact on the other databases in the cluster.
 
 [NOTE]
@@ -21,135 +21,187 @@ See xref:clustering/setup/deploy.adoc[Deploy a basic cluster] and xref:clusterin
 
 Databases in clusters follow an allocation strategy.
 This means that they are allocated differently within the cluster and may also have different numbers of primaries and secondaries.
-The consequence of this is that all servers are different in which databases they are hosting.
+Furthermore, some databases may not be allowed to be allocated to some servers because of user defined strategies.
+The consequence of this is that all servers may be different in which databases they are hosting and are allowed to host.
 Losing a server in a cluster may cause some databases to lose a member while others are unaffected.
-Therefore, in a disaster where multiple servers go down, some databases may keep running with little to no impact, while others may lose all their allocated resources.
+Therefore, in a disaster where one or more servers go down, some databases may keep running with little to no impact, while others may lose all their allocated resources.
+
+== Guide structure
+There are three main steps to recovering a cluster from a disaster.
+First, ensure the `system` database is write available i.e. able to accept writes.
+Then, detach any potential lost servers and replace them by new ones.
+Finish disaster recovery by starting or continuing to manage databases and verify that they are available.
+
+Every step consists of the following four sections:
+
+. State that needs to be verified.
+. Example of how the state can be verified.
+. Motivation for why this state is necessary.
+. Path to correct state.
+
+[CAUTION]
+====
+Verifying each state before continuing to the next step, regardless of the disaster scenario, is recommended to ensure the cluster is fully operational.
+
+====
+
+In this section, an _offline_ server is a server that is not running but may be _restartable_.
+A _lost_ server, however, is a server that is currently not running and cannot be restarted.
+
 
 == Guide to disaster recovery
 
-There are three main steps to recovering a cluster from a disaster.
-Completing each step, regardless of the disaster scenario, is recommended to ensure the cluster is fully operational.
-
 [NOTE]
 ====
-Any potential quarantined databases need to be handled before executing this guide, see xref:database-administration/standard-databases/errors.adoc#quarantine[Quarantined databases] for more information.
+Before beginning this guide, start the Neo4j process on all servers that are _offline_.
+If a server is unable to start, inspect the logs and contact support personnel.
+The server may have to be considered indefinitely lost.
 ====
 
-. Ensure the `system` database is available in the cluster.
-The `system` database defines the configuration for the other databases; therefore, it is vital to ensure it is available before doing anything else.
-
-. After the `system` database's availability is verified, whether recovered or unaffected by the disaster, recover the lost servers to ensure the cluster's topology meets the requirements.
-This process also starts the managing of databases.
-
-. After the `system` database is available and the cluster's topology is satisfied, start or continue managing databases and verify that they are available.
-
-The steps are described in detail in the following sections.
-
-[NOTE]
-====
-In this section, an _offline_ server is a server that is not running but may be _restartable_.
-A _lost_ server, however, is a server that is currently not running and cannot be restarted.
-====
-
-[NOTE]
-====
 Disasters may sometimes affect the routing capabilities of the driver and may prevent the use of the `neo4j` scheme for routing.
 One way to remedy this is to connect directly to the server using `bolt` instead of `neo4j`.
 See xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] for more information on the `bolt` scheme.
-====
+
 
 [[restore-the-system-database]]
-=== `System` database availability
+=== `System` database write availability
 
-The first step of recovery is to ensure that the `system` database is able to accept writes.
-The `system` database is required for clusters to function properly.
+==== State
+====
+The `system` database is write available, i.e. able to accept writes.
+====
 
-. Start the Neo4j process on all servers that are _offline_.
-If a server is unable to start, inspect the logs and contact support personnel.
-The server may have to be considered indefinitely lost.
-. Validate the `system` database's write availability by running `CALL dbms.cluster.statusCheck(["system"])` on all remaining system primaries, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
-Depending on the environment, consider extending the timeout for this procedure.
-If any of the system primaries report `replicationSuccessful` = `TRUE`, the system database is write available and does not need to be recovered.
-Therefore, skip to step xref:clustering/disaster-recovery.adoc#recover-servers[Server availability].
+==== Motivation
+The `system` database contains the view of the cluster. This includes which servers and databases are present and how they are configured.
+During a disaster, the goal is to change the view of the cluster, for example by removing and adding servers or recreating databases.
+In order for the view to be updated, the `system` database needs to be write available.
+Therefore, it is vital to ensure it is available so that the next steps are possible to execute.
 
-+
-. Regain availability by restoring the `system` database.
+==== Example verification
+The `system` database's write availability can be verified by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[Status check] procedure.
+The procedure should be called on all remaining primary allocations of the `system` database, in order to provide the correct view.
+The status check procedure writes a dummy transaction, and therefore the correctness of the procedure depends on the given timeout.
+The default timeout is 1 second, but depending on the network latency in the environment it might need to be extended.
+If any of the primary `system` allocations report `replicationSuccessful` = `TRUE`, the `system` database is write available.
+Therefore, the desired state has been verified.
+
+[source, shell]
+----
+CALL dbms.cluster.statusCheck(["system"]);
+----
+
+==== Path to correct state
+The following steps can be used to regain write availability for the `system` database if it has been lost.
+They create a new `system` database from the most up-to-date copy of the `system` database that can be found in the cluster.
+It is important to get a `system` database that is as up-to-date as possible, so that future commands operate on state that is as correct as possible.
+
+.Guide
+[%collapsible]
+====
+
+[NOTE]
+=====
+This section of the disaster recovery guide uses `neo4j-admin`, for more information about the used commands, see xref:tools/neo4j-admin/index.adoc#neo4j-admin-commands[neo4j-admin commands].
+=====
+
+. Shut down the Neo4j process on all servers.
+This causes downtime for all databases in the cluster until the processes are started again at the end of this section.
+. On each server, run `bin/neo4j-admin dbms unbind-system-db` to reset the `system` database state on the servers.
+. On each server, run `bin/neo4j-admin database info system` and compare the `lastCommittedTransaction` to find out which server has the most up-to-date copy of the `system` database.
+. On the most up-to-date server, run `bin/neo4j-admin database dump system --to-path=[path-to-dump]` to take a dump of the current `system` database and store it in an accessible location.
+. For every _lost_ server, add a new *unconstrained* one according to xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster].
+It is important that the new servers are unconstrained, or deallocating servers might be blocked even though enough servers was added.
 +
 [NOTE]
-====
-Only do the steps below if the `system` database's write availability cannot be validated by the first two steps in this section.
-====
-+
-
-The following steps create a new `system` database from a backup of the current `system` database.
-This is required since the current `system` database has lost too many members to be able to accept writes.
-
-.. Shut down the Neo4j process on all servers.
-Note that this causes downtime for all databases in the cluster.
-.. On each server, run the following `neo4j-admin` command `bin/neo4j-admin dbms unbind-system-db` to reset the `system` database state on the servers.
-See xref:tools/neo4j-admin/index.adoc#neo4j-admin-commands[neo4j-admin commands] for more information.
-.. On each server, run the following `neo4j-admin` command `bin/neo4j-admin database info system` to find out which server is most up-to-date, ie. has the highest last-committed transaction id.
-.. On the most up-to-date server, take a dump of the current `system` database by running `bin/neo4j-admin database dump system --to-path=[path-to-dump]` and store the dump in an accessible location.
-See xref:tools/neo4j-admin/index.adoc#neo4j-admin-commands[neo4j-admin commands] for more information.
-.. For every _lost_ server, add a new unconstrained one according to xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster].
-+
-[NOTE]
-====
+=====
 While recommended to avoid cluster overload, it is not strictly necessary to add servers in this step.
-There is also an option to change the `system` database mode (`server.cluster.system_database_mode`) on secondary allocations to make them primaries for the new `system` database.
-The amount of primaries needed is defined by `dbms.cluster.minimum_initial_system_primaries_count`, see the xref:configuration/configuration-settings.adoc#config_dbms.cluster.minimum_initial_system_primaries_count[Configuration settings] for more information.
-====
+There is also an option to change the `system` database mode (`server.cluster.system_database_mode`) on secondary allocations to make them primary allocations for the new `system` database.
+The amount of primary allocations needed is defined by `dbms.cluster.minimum_initial_system_primaries_count`, see the xref:configuration/configuration-settings.adoc#config_dbms.cluster.minimum_initial_system_primaries_count[Configuration settings] for more information.
+=====
 +
-.. On each server, run `bin/neo4j-admin database load system --from-path=[path-to-dump] --overwrite-destination=true` to load the current `system` database dump.
-.. Ensure that the discovery settings are correct on all servers, see xref:clustering/setup/discovery.adoc[Cluster server discovery] for more information.
-.. Return to step 1, to start all servers and confirm the `system` database is now available.
+. On each server, run `bin/neo4j-admin database load system --from-path=[path-to-dump] --overwrite-destination=true` to load the current `system` database dump.
+. On each server, ensure that the discovery settings are correct, see xref:clustering/setup/discovery.adoc[Cluster server discovery] for more information.
+. Start the Neo4j process on all servers.
+====
 
 
 [[recover-servers]]
 === Server availability
 
-Once the `system` database is available, the cluster can be managed.
-Following the loss of one or more servers, the cluster's view of servers must be updated, ie. the lost servers must be replaced by new ones.
-The steps here identify the lost servers and safely detach them from the cluster, while recreating any databases that cannot be moved from the lost servers because they have lost availability.
+==== State
+====
+All servers in the cluster's view are available and enabled.
+====
 
-. Run `SHOW SERVERS`.
-If *all* servers show health `AVAILABLE` and status `ENABLED` continue to xref:clustering/disaster-recovery.adoc#recover-databases[Database availability].
+==== Motivation
+// different stuffs here
+Following the loss of one or more servers, the cluster's view of servers must be updated.
+This includes moving allocations on the lost servers onto servers which are actually in the cluster
+This includes identifying the lost servers and replacing them by new ones.
+
+==== Example verification
+The cluster's view of servers can be seen by listing the servers, see xref:clustering/servers.adoc#_listing_servers[Listing servers] for more information.
+The state has been verified if *all* servers show `health` = `AVAILABLE` and `status` = `ENABLED`.
+
+[source, cypher]
+----
+SHOW SERVERS;
+----
+
+==== Path to correct state
+Detach lost servers and add new ones to the cluster
+
+.Guide
+[%collapsible]
+====
 . For each `UNAVAILABLE` server, run `CALL dbms.cluster.cordonServer("unavailable-server-id")` on one of the available servers.
+This prevents new database allocations from being moved to this server.
 . For each `CORDONED` server, make sure a new *unconstrained* server has been added to the cluster to take its place, see xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster] for more information.
-If servers were added in the xref:clustering/disaster-recovery.adoc#restore-the-system-database[System database availability] step, the amount of servers that needs to be added in this step is less than the number of `CORDONED` servers.
+If servers were added in the 'System database write availability' step of this guide, additional servers might not be needed here.
 
 +
 [NOTE]
-====
+=====
 While recommended, it is not strictly necessary to add new servers in this step.
 However, not adding new servers reduces the capacity of the cluster to handle work and might require the topology for a database to be altered to make deallocations and recreations possible.
-====
+=====
 
-. For each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers. If all deallocations succeeded, skip to step 6.
-. If any deallocations failed, make them possible by the following steps:
-.. Run `SHOW DATABASES`. If a database show `currentStatus`= `offline` this database has been stopped.
-.. For each stopped database that is allocated on any of the `CORDONED` servers, start them by running `START DATABASE stopped-db WAIT`.
+. For each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers.
+This will try to move all database allocations from this server to another server in the cluster.
+Once a server is `DEALLOCATED`, all allocated user databases on this server has been moved successfully.
 +
 [NOTE]
-====
-A database can be set to `READ-ONLY` before it is started to avoid updates on a database that is desired to be stopped with the following:
+=====
+Remember, moving databases can take an unbounded amount of time since it involves copying the store to a new server.
+Therefore, an allocation with `currentStatus` = `DEALLOCATING` should reach the `requestedStatus` = `DEALLOCATED` given some time.
+=====
+. If any deallocations failed, make them possible by executing the following steps:
+.. Run `SHOW DATABASES`. If a database show `currentStatus`= `offline` this database has been stopped.
+.. For each stopped database that has at least one allocation on any of the `CORDONED` servers, start them by running `START DATABASE stopped-db WAIT`.
++
+[NOTE]
+=====
+A database can be set to `READ-ONLY` before it is started to avoid updates on a database that is desired to be stopped with the following command:
 `ALTER DATABASE database-name SET ACCESS READ ONLY`.
-====
-.. Run `CALL dbms.cluster.statusCheck([])` on all servers, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
+=====
+.. On each server, run `CALL dbms.cluster.statusCheck([])` to check the write availability for all databases on this server, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
 Depending on the environment, consider extending the timeout for this procedure.
 If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
 
-.. Recreate every database that is not write available, see xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information.
+.. For each database that is not write available, recreate it to regain write availability.
+Go to xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information about recreate options.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
 +
 [NOTE]
-====
+=====
 By using recreate with xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], also databases which have lost all allocation can be recreated.
 Otherwise, recreating with xref:clustering/databases.adoc#uri-seed[Backup as seed] must be used for that specific case.
-====
-.. Return to step 4 to retry deallocating all servers.
+=====
+.. Return to step 3 to retry deallocating all servers.
 . For each deallocated server, run `DROP SERVER deallocated-server-id`.
-. Return to step 1 to make sure all servers in the cluster are `AVAILABLE`.
+This safely removes the server from the cluster view.
+
+====
 
 
 [[recover-databases]]

--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -18,30 +18,37 @@ You have to create a new cluster and restore the databases, see xref:clustering/
 
 == Faults in clusters
 
-Databases in clusters follow an allocation strategy.
-This means that they are allocated differently within the cluster and may also have different numbers of primaries and secondaries.
+Databases in clusters may be allocated differently within the cluster and may also have different numbers of primaries and secondaries.
 The consequence of this is that all servers may be different in which databases they are hosting.
 Losing a server in a cluster may cause some databases to lose a member while others are unaffected.
 Therefore, in a disaster where one or more servers go down, some databases may keep running with little to no impact, while others may lose all their allocated resources.
 
-== Guide structure
+== Guide overview
 [NOTE]
 ====
-In this guide, an _offline_ server is a server that is not running but may be restartable.
-A _lost_ server, however, is a server that is currently not running and cannot be restarted.
-A _write available_ database is able to serve writes, while a _write unavailable_ database is not.
+In this guide the following terms are used:
+
+* An _offline_ server is a server that is not running but may be restartable.
+* A _lost_ server, however, is a server that is currently not running and cannot be restarted.
+* A _write available_ database is able to serve writes, while a _write unavailable_ database is not.
 ====
 
-There are three main steps to recovering a cluster from a disaster.
-First, ensure the `system` database is write available.
-Then, detach any potential lost servers from the cluster and replace them by new ones.
-Finish disaster recovery by starting or continuing to manage databases and verify that they are write available.
+There are four steps to recovering a cluster from a disaster:
 
-Every step consists of the following three sections:
+. Start the Neo4j process on all servers which are not _lost_.
+See xref:start-the-neo4j-process[Start the neo4j process] for more information.
+. Make the `system` database write available, so that the cluster can be modified.
+See xref:make-the-system-database-write-available[Make the `system` database write available] for more information.
+. Detach any potential lost servers from the cluster and replace them by new ones.
+See xref:make-servers-available[Make servers available] for more information.
+. Finish disaster recovery by starting or continuing to manage databases and verify that they are write available.
+See xref:make-databases-write-available[Make databases write available] for more information.
 
-. A state that the cluster needs to be in, with optional motivation.
-. An example of how the state can be verified.
-. A proposed series of steps to get to the correct state.
+Each step is described in the following three sections:
+
+. Objective -- a state that the cluster needs to be in, with optional motivation.
+. Verifying the state -- An example of how the state can be verified.
+. Path to correct state -- a proposed series of steps to get to the correct state.
 
 [CAUTION]
 ====
@@ -49,7 +56,7 @@ Verifying each state before continuing to the next step, regardless of the disas
 ====
 
 
-== Guide to disaster recovery
+== Disaster recovery steps
 
 [NOTE]
 ====
@@ -58,7 +65,8 @@ One way to remedy this is to connect directly to the server using `bolt` instead
 See xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] for more information on the `bolt` scheme.
 ====
 
-=== Neo4j process started
+[[start-the-neo4j-process]]
+=== Start the Neo4j process
 
 ==== Objective
 ====
@@ -70,8 +78,8 @@ Start the Neo4j process on all servers that are _offline_.
 If a server is unable to start, inspect the logs and contact support personnel.
 The server may have to be considered indefinitely lost.
 
-[[restore-the-system-database]]
-=== `System` database write availability
+[[make-the-system-database-write-available]]
+=== Make the `system` database write available
 
 ==== Objective
 ====
@@ -80,11 +88,11 @@ The `system` database is write available.
 
 The `system` database contains the view of the cluster.
 This includes which servers and databases are present, where they live and how they are configured.
-During a disaster, the view of the cluster might need to change to reflect a new reality, for example by removing lost servers.
+During a disaster, the view of the cluster might need to change to reflect a new reality, such as removing lost servers.
 Databases might also need to be recreated to regain write availability.
 Because both of these steps are executed by modifying the `system` database, making the `system` database write available is a vital first step during disaster recovery.
 
-==== Example verification
+==== Verifying the state
 The `system` database's write availability can be verified by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[Status check] procedure.
 
 [source, shell]
@@ -94,11 +102,12 @@ CALL dbms.cluster.statusCheck(["system"]);
 
 [NOTE]
 =====
-The write availability of a database configured to have a single primary cannot be checked with the status check, instead check that the primary is allocated on an available server and that it has `currentStatus` = `STARTED`.
+The status check procedure cannot verify the write availability of a database configured to have a single primary.
+Instead, check that the primary is allocated on an available server and that it has `currentStatus` = `online` by running `SHOW DATABASES`.
 =====
 
 ==== Path to correct state
-The following steps can be used to regain write availability for the `system` database if it has been lost.
+Use the following steps to regain write availability for the `system` database if it has been lost.
 They create a new `system` database from the most up-to-date copy of the `system` database that can be found in the cluster.
 It is important to get a `system` database that is as up-to-date as possible, so it corresponds to the view before the disaster closely.
 
@@ -108,7 +117,8 @@ It is important to get a `system` database that is as up-to-date as possible, so
 
 [NOTE]
 =====
-This section of the disaster recovery guide uses `neo4j-admin`, for more information about the used commands, see xref:tools/neo4j-admin/index.adoc#neo4j-admin-commands[neo4j-admin commands].
+This section of the disaster recovery guide uses `neo4j-admin` commands.
+For more information about the used commands, see xref:tools/neo4j-admin/index.adoc#neo4j-admin-commands[neo4j-admin commands].
 =====
 
 . Shut down the Neo4j process on all servers.
@@ -123,7 +133,8 @@ It is important that the new servers are unconstrained, or deallocating servers 
 =====
 While recommended, it is not strictly necessary to add new servers in this step.
 There is also an option to change the `system` database mode (`server.cluster.system_database_mode`) on secondary allocations to make them primary allocations for the new `system` database.
-The amount of primary allocations needed is defined by `dbms.cluster.minimum_initial_system_primaries_count`, see the xref:configuration/configuration-settings.adoc#config_dbms.cluster.minimum_initial_system_primaries_count[Configuration settings] for more information.
+The number of primary allocations needed is defined by `dbms.cluster.minimum_initial_system_primaries_count`.
+See the xref:configuration/configuration-settings.adoc#config_dbms.cluster.minimum_initial_system_primaries_count[Configuration settings] for more information.
 Be aware that not replacing servers can cause cluster overload when databases are moved from lost servers to available ones in the next step of this guide.
 =====
 +
@@ -133,8 +144,8 @@ Be aware that not replacing servers can cause cluster overload when databases ar
 ====
 
 
-[[recover-servers]]
-=== Server availability
+[[make-servers-available]]
+=== Make servers available
 
 ==== Objective
 ====
@@ -146,9 +157,9 @@ Furthermore, according to the view of the cluster, these lost servers are still 
 Therefore, informing the cluster of servers which are lost is not enough.
 The databases hosted on lost servers also need to be moved onto available servers in the cluster, before the lost servers can be removed.
 
-==== Example verification
+==== Verifying the state
 The cluster's view of servers can be seen by listing the servers, see xref:clustering/servers.adoc#_listing_servers[Listing servers] for more information.
-The state has been verified if *all* servers show `health` = `AVAILABLE` and `status` = `ENABLED`.
+The state has been verified if *all* servers show `health` = `Available` and `status` = `Enabled`.
 
 [source, cypher]
 ----
@@ -157,16 +168,18 @@ SHOW SERVERS;
 
 ==== Path to correct state
 The following steps can be used to remove lost servers and add new ones to the cluster.
-To be able to remove lost servers, any allocations it should host needs to be moved to available servers in the cluster.
-This is done in two steps, first any databases that cannot move by themselves needs to be recreated so that they are forced to move.
-Then, any allocations that can move will be told to do so by deallocating the server.
+To be able to remove lost servers, any allocations it should host need to be moved to available servers in the cluster.
+This is done in two different ways:
+
+* Any allocations that cannot move by themselves require the database to be recreated so that they are forced to move.
+* Any allocations that can move will be instructed to do so by deallocating the server.
 
 .Guide
 [%collapsible]
 ====
-. For each `UNAVAILABLE` server, run `CALL dbms.cluster.cordonServer("unavailable-server-id")` on one of the available servers.
+. For each `Unavailable` server, run `CALL dbms.cluster.cordonServer("unavailable-server-id")` on one of the available servers.
 This prevents new database allocations from being moved to this server.
-. For each `CORDONED` server, make sure a new *unconstrained* server has been added to the cluster to take its place, see xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster] for more information.
+. For each `Cordoned` server, make sure a new *unconstrained* server has been added to the cluster to take its place, see xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster] for more information.
 If servers were added in the 'System database write availability' step of this guide, additional servers might not be needed here.
 It is important that the new servers are unconstrained, or deallocating servers might be blocked even though enough servers were added.
 +
@@ -180,7 +193,7 @@ Furthermore, it might require the topology for a database to be altered to make 
 . For each stopped database (`currentStatus`= `offline`), start them by running `START DATABASE stopped-db`.
 This is necessary since stopped databases cannot be deallocated from a server.
 It is also necessary for the status check procedure to accurately indicate if this database should be recreated or not.
-Verify that all allocations are in `currentStatus` = `started` on servers which are not lost before moving to the next step.
+Verify that all allocations are in `currentStatus` = `online` on servers which are not lost before moving to the next step.
 If a database fails to start, leave it to be recreated in the next step of this guide.
 +
 [NOTE]
@@ -193,26 +206,27 @@ A database can be set to `READ-ONLY` before it is started to avoid updates on th
 +
 [NOTE]
 =====
-The write availability of a database configured to have a single primary cannot be checked with the status check, instead check that the primary is allocated on an available server and that it has `currentStatus` = `STARTED`.
+The status check procedure cannot verify the write availability of a database configured to have a single primary.
+Instead, check that the primary is allocated on an available server and that it has `currentStatus` = `online` by running `SHOW DATABASES`.
 =====
 
 . For each database that is not write available, recreate it to move it from lost servers and regain write availability.
 Go to xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information about recreate options.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
-If any database has `currentStatus` = `QUARANTINED` on an available server, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
+If any database has `currentStatus` = `quarantined` on an available server, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
 +
 [CAUTION]
 =====
-By using recreate with xref:clustering/databases.adoc#undefined-servers[Undefined servers] or xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], the store might not be recreated as up-to-date as possible in some edge cases where the system database has been restored.
+If you recreate databases using xref:clustering/databases.adoc#undefined-servers[undefined servers] or xref:clustering/databases.adoc#undefined-servers-backup[undefined servers with fallback backup], the store might not be recreated as up-to-date as possible in certain edge cases where the `system` database has been restored.
 =====
 
-. For each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers.
-This will try to move all database allocations from this server to an available server in the cluster.
+. For each `Cordoned` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers.
+This will move all database allocations from this server to an available server in the cluster.
 +
 [NOTE]
 =====
 This operation might fail if enough unconstrained servers were not added to the cluster to replace lost servers.
-Another reason is that some available servers are also `CORDONED`.
+Another reason is that some available servers are also `Cordoned`.
 =====
 
 . For each deallocating or deallocated server, run `DROP SERVER deallocated-server-id`.
@@ -220,12 +234,12 @@ This removes the server from the cluster's view.
 ====
 
 
-[[recover-databases]]
-=== Database availability
+[[make-databases-write-available]]
+=== Make databases write available
 
 ==== Objective
 ====
-All databases which are desired to be started are write available.
+All databases that are desired to be started are write available.
 ====
 
 Once this state is verified, disaster recovery is complete.
@@ -235,12 +249,12 @@ If they are still desired to be in stopped state, run `STOP DATABASE started-db 
 [CAUTION]
 ====
 Remember, recreating a database takes an unbounded amount of time since it may involve copying the store to a new server, as described in xref:clustering/databases.adoc#recreate-databases[Recreate databases].
-Therefore, an allocation with `currentStatus` = `STARTING` will probably reach the `requestedStatus` given some time.
+Therefore, an allocation with `currentStatus` = `starting` will probably reach the `requestedStatus` given some time.
 ====
 
 [[example-verification]]
-==== Example verification
-All databases' write availability can be verified by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[Status check] procedure.
+==== Verifying the state
+You can verify all clustered databases' write availability by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[status check] procedure.
 
 [source, shell]
 ----
@@ -249,7 +263,8 @@ CALL dbms.cluster.statusCheck([]);
 
 [NOTE]
 =====
-The write availability of a database configured to have a single primary cannot be checked with the status check, instead check that the primary is allocated on an available server and that it has `currentStatus` = `STARTED`.
+The status check procedure cannot verify the write availability of a database configured to have a single primary.
+Instead, check that the primary is allocated on an available server and that it has `currentStatus` = `online` by running `SHOW DATABASES`.
 =====
 
 A stricter verification can be done to verify that all databases are in their desired states on all servers.
@@ -263,14 +278,15 @@ Recreations might fail for different reasons, but one example is that the checks
 .Guide
 [%collapsible]
 ====
-. Identify all write unavailable databases that are desired to be `STARTED` by running `CALL dbms.cluster.statusCheck([])` as described in the xref:clustering/disaster-recovery.adoc#example-verification[Example verification] part of this disaster recovery step.
+. Identify all write unavailable databases by running `CALL dbms.cluster.statusCheck([])` as described in the xref:clustering/disaster-recovery.adoc#example-verification[Example verification] part of this disaster recovery step.
+Filter out all databases desired to be stopped, so that they are not recreated unnecessarily.
 . Recreate every database that is not write available and has not been recreated previously, see xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
-If any database has `currentStatus` = `QUARANTINED` on an available server, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
+If any database has `currentStatus` = `quarantined` on an available server, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
 +
 [CAUTION]
 =====
-By using recreate with xref:clustering/databases.adoc#undefined-servers[Undefined servers] or xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], the store might not be recreated as up-to-date as possible in some edge cases where the system database has been restored.
+If you recreate databases using xref:clustering/databases.adoc#undefined-servers[undefined servers] or xref:clustering/databases.adoc#undefined-servers-backup[undefined servers with fallback backup], the store might not be recreated as up-to-date as possible in certain edge cases where the `system` database has been restored.
 =====
 
 . Run `SHOW DATABASES` and check any recreated databases which are not write available.

--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -39,7 +39,7 @@ Finish disaster recovery by starting or continuing to manage databases and verif
 
 Every step consists of the following three sections:
 
-. A state that needs to be verified, with optional motivation.
+. A state that the cluster needs to be in, with optional motivation.
 . An example of how the state can be verified.
 . A proposed series of steps to get to the correct state.
 
@@ -60,7 +60,7 @@ See xref:clustering/setup/routing.adoc#clustering-routing[Server-side routing] f
 
 === Neo4j process started
 
-==== State
+==== Objective
 ====
 The Neo4j process is started on all servers which are not _lost_.
 ====
@@ -73,7 +73,7 @@ The server may have to be considered indefinitely lost.
 [[restore-the-system-database]]
 === `System` database write availability
 
-==== State
+==== Objective
 ====
 The `system` database is write available.
 ====
@@ -86,10 +86,6 @@ Because both of these steps are executed by modifying the `system` database, mak
 
 ==== Example verification
 The `system` database's write availability can be verified by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[Status check] procedure.
-The procedure should be called on all remaining primary allocations of the `system` database, in order to provide the correct view.
-The default timeout for the procedure is 1 second, but depending on the network latency in the environment it might need to be extended to produce an accurate result.
-If any of the primary `system` allocations report `replicationSuccessful` = `TRUE`, the `system` database is write available.
-Therefore, the desired state has been verified.
 
 [source, shell]
 ----
@@ -99,7 +95,6 @@ CALL dbms.cluster.statusCheck(["system"]);
 [NOTE]
 =====
 The write availability of a database configured to have a single primary cannot be checked with the status check, instead check that the primary is allocated on an available server and that it has `currentStatus` = `STARTED`.
-The procedure will still produce an accurate result if all but one primary have been lost during a disaster.
 =====
 
 ==== Path to correct state
@@ -141,7 +136,7 @@ Be aware that not replacing servers can cause cluster overload when databases ar
 [[recover-servers]]
 === Server availability
 
-==== State
+==== Objective
 ====
 All servers in the cluster's view are available and enabled.
 ====
@@ -162,8 +157,9 @@ SHOW SERVERS;
 
 ==== Path to correct state
 The following steps can be used to remove lost servers and add new ones to the cluster.
-That includes moving any potential database allocations from lost servers to available servers.
-These steps might also recreate some databases, since a database which has lost a majority of its primary allocations cannot be moved from one server to another.
+To be able to remove lost servers, any allocations it should host needs to be moved to available servers in the cluster.
+This is done in two steps, first any databases that cannot move by themselves needs to be recreated so that they are forced to move.
+Then, any allocations that can move will be told to do so by deallocating the server.
 
 .Guide
 [%collapsible]
@@ -182,24 +178,22 @@ Furthermore, it might require the topology for a database to be altered to make 
 =====
 
 . For each stopped database (`currentStatus`= `offline`), start them by running `START DATABASE stopped-db`.
-This is necessary since stopped databases cannot be moved from one server to another.
-Verify that they are in `currentStatus` = `started` on all servers which are not lost before moving to the next step, otherwise they might be recreated unnecessarily.
+This is necessary since stopped databases cannot be deallocated from a server.
+It is also necessary for the status check procedure to accurately indicate if this database should be recreated or not.
+Verify that all allocations are in `currentStatus` = `started` on servers which are not lost before moving to the next step.
 If a database fails to start, leave it to be recreated in the next step of this guide.
 +
 [NOTE]
 =====
-A database can be set to `READ-ONLY` before it is started to avoid updates on a database that is desired to be stopped with the following command:
+A database can be set to `READ-ONLY` before it is started to avoid updates on the database with the following command:
 `ALTER DATABASE database-name SET ACCESS READ ONLY`.
 =====
 
 . On each server, run `CALL dbms.cluster.statusCheck([])` to check the write availability for all databases running in primary mode on this server, see xref:clustering/monitoring/status-check.adoc#monitoring-replication[Monitoring replication] for more information.
-Depending on the network latency in the environment, consider extending the timeout for this procedure to produce an accurate result.
-If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
 +
 [NOTE]
 =====
 The write availability of a database configured to have a single primary cannot be checked with the status check, instead check that the primary is allocated on an available server and that it has `currentStatus` = `STARTED`.
-The procedure will still produce an accurate result if all but one primary have been lost during a disaster.
 =====
 
 . For each database that is not write available, recreate it to move it from lost servers and regain write availability.
@@ -207,10 +201,9 @@ Go to xref:clustering/databases.adoc#recreate-databases[Recreate databases] for 
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
 If any database has `currentStatus` = `QUARANTINED` on an available server, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
 +
-[NOTE]
+[CAUTION]
 =====
-By using recreate with xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], the store will be replaced by the most up-to-date copy according to the cluster's view without manual intervention.
-Furthermore, this option will automatically recreate the database based on a backup if no available allocation can be found.
+By using recreate with xref:clustering/databases.adoc#undefined-servers[Undefined servers] or xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], the store might not be recreated as up-to-date as possible in some edge cases where the system database has been restored.
 =====
 
 . For each `CORDONED` server, run `DEALLOCATE DATABASES FROM SERVER cordoned-server-id` on one of the available servers.
@@ -230,7 +223,7 @@ This removes the server from the cluster's view.
 [[recover-databases]]
 === Database availability
 
-==== State
+==== Objective
 ====
 All databases which are desired to be started are write available.
 ====
@@ -248,10 +241,6 @@ Therefore, an allocation with `currentStatus` = `STARTING` will probably reach t
 [[example-verification]]
 ==== Example verification
 All databases' write availability can be verified by using the xref:clustering/monitoring/status-check.adoc#monitoring-replication[Status check] procedure.
-The procedure should be called on all servers in the cluster, in order to provide the correct view.
-The default timeout for the procedure is 1 second, but depending on the network latency in the environment it might need to be extended to produce an accurate result.
-If any of the primary allocations for a database report `replicationSuccessful` = `TRUE`, this database is write available.
-Therefore, the desired state has been verified when this is true for all *started* databases.
 
 [source, shell]
 ----
@@ -261,7 +250,6 @@ CALL dbms.cluster.statusCheck([]);
 [NOTE]
 =====
 The write availability of a database configured to have a single primary cannot be checked with the status check, instead check that the primary is allocated on an available server and that it has `currentStatus` = `STARTED`.
-The procedure will still produce an accurate result if all but one primary have been lost during a disaster.
 =====
 
 A stricter verification can be done to verify that all databases are in their desired states on all servers.
@@ -270,7 +258,7 @@ For the stricter check, run `SHOW DATABASES` and verify that `requestedStatus` =
 ==== Path to correct state
 The following steps can be used to make all databases in the cluster write available again.
 They include recreating any databases that are not write available, as well as identifying any recreations which will not complete.
-Recreations might fail for different reasons, but one example is that the checksums does not match for the same transaction on different copies.
+Recreations might fail for different reasons, but one example is that the checksums do not match for the same transaction on different servers.
 
 .Guide
 [%collapsible]
@@ -280,10 +268,9 @@ Recreations might fail for different reasons, but one example is that the checks
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
 If any database has `currentStatus` = `QUARANTINED` on an available server, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed].
 +
-[NOTE]
+[CAUTION]
 =====
-By using recreate with xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], the store will be replaced by the most up-to-date copy according to the cluster's view without manual intervention.
-Furthermore, this option will automatically recreate the database based on a backup if no available allocation can be found.
+By using recreate with xref:clustering/databases.adoc#undefined-servers[Undefined servers] or xref:clustering/databases.adoc#undefined-servers-backup[Undefined servers with fallback backup], the store might not be recreated as up-to-date as possible in some edge cases where the system database has been restored.
 =====
 
 . Run `SHOW DATABASES` and check any recreated databases which are not write available.

--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -178,8 +178,11 @@ Furthermore, it might require the topology for a database to be altered to make 
 =====
 
 . Run `SHOW DATABASES`. If a database show `currentStatus`= `offline` this database has been stopped.
-. For each stopped database that has at least one allocation on any of the `CORDONED` servers, start them by running `START DATABASE stopped-db WAIT`.
+. For each stopped database, start them by running `START DATABASE stopped-db WAIT`.
+// Is it a problem that it might not have started yet here? Should I write a line about making sure it is started before checking the write availability?
+// Cannot use wait here, because we will hang on lost members that are stopped. Should poll for started state on all non-lost members, but there are some situation where we will not be able to start. So how long should they wait here?
 This is necessary since stopped databases cannot be moved from one server to another.
+// And since status check doesn't work otherwise.
 +
 [NOTE]
 =====
@@ -193,6 +196,7 @@ If any of the primary allocations for a database report `replicationSuccessful` 
 Go to xref:clustering/databases.adoc#recreate-databases[Recreate databases] for more information about recreate options.
 If any allocation has `currentStatus` = `QUARANTINED`, recreate them from backup using xref:clustering/databases.adoc#uri-seed[Backup as seed] or define seeding servers in the recreate procedure using xref:clustering/databases.adoc#specified-servers[Specified seeders] so that problematic allocations are excluded.
 Remember to make sure there are recent backups for the databases before recreating them, see xref:backup-restore/online-backup.adoc[Online backup] for more information.
+// What if a quarantined database had the desire to be stopped? Check quarantine before stopped?
 +
 [NOTE]
 =====


### PR DESCRIPTION
This PR rewrites the disaster recovery docs based on the new recreate and status check procedures. 

With regards to the functional changes there are three major things to note. 
1. The recovery of the system database is the same as before, even though the way we check if the system db is write available or not has changed. 
2. The step which removes lost servers now also includes recreating some databases. It was decided this mixing of recovering servers and databases is necessary to get recreate into the guide in the best way we could see. 
3. Previously it was not clear how to handle quarantined databases, even though the guide mentioned them in the intro. Now, it is more explicitly discussed how they are supposed to be handles during disaster recovery.


In the past, we have also gotten feedback that the disaster recovery docs are hard to follow. Therefore, this PR also includes refactoring which introduces a new guide structure. This new structure provides more explanations of why we are asking the user to do a certain thing. 
