### PR TITLE
Add clarification that database field depends on the security event

### DIFF
--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -727,6 +727,7 @@ The following information is available in the JSON format:
 
 | database
 | The database name the command is executed on.
+This field depends on the security event.
 
 | username
 | The user connected to the security event.

--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -727,7 +727,7 @@ The following information is available in the JSON format:
 
 | database
 | The database name the command is executed on.
-This field depends on the security event.
+This field is optional and thus will not be populated for all security events.
 
 | username
 | The user connected to the security event.


### PR DESCRIPTION
[Trello card](https://trello.com/c/e1PTFRXS/469-logging-of-databasename-for-securitylog-is-not-for-all-events#)