### PR TITLE
Add clarification that database field depends on the security event (#1904)

### DIFF
--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -729,6 +729,7 @@ The following information is available in the JSON format:
 
 | database
 | The database name the command is executed on.
+This field is optional and thus will not be populated for all security events.
 
 | username
 | The user connected to the security event.


### PR DESCRIPTION
Cherry-picked from #1904 

[Trello
card](https://trello.com/c/e1PTFRXS/469-logging-of-databasename-for-securitylog-is-not-for-all-events#)