### PR TITLE
Add deprecations and FileSeedProvider

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -592,7 +592,8 @@ Where `accessKey` and `secretKey` are provided by AWS.
 | `\https://myhttp.com/backups/backup1.backup`
 
 | `s3:`
-| `S3SeedProvider` label:deprecated[deprecated in 5.26], `CloudSeedProvider` label:new[introduced in 5.25] 
+| `S3SeedProvider` label:deprecated[Deprecated in 5.26], +
+`CloudSeedProvider` label:new[Introduced in 5.25] 
 | `s3://mybucket/backups/backup1.backup`
 
 | `gs:`

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -601,7 +601,7 @@ Where `accessKey` and `secretKey` are provided by AWS.
 | `gs://mybucket/backups/backup1.backup`
 
 | `azb:`
-| `CloudSeedProvider` label:new[introduced in 5.25] 
+| `CloudSeedProvider` label:new[Introduced in 5.25] 
 | `azb://mystorageaccount.blob/backupscontainer/backup1.backup`
 |===
 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -575,7 +575,8 @@ Where `accessKey` and `secretKey` are provided by AWS.
 | URI example
 
 | `file:`
-| `URLConnectionSeedProvider` label:deprecated[deprecated in 5.26], `FileSeedProvider` label:new[introduced in 5.26] 
+| `URLConnectionSeedProvider` label:deprecated[Deprecated in 5.26], +
+`FileSeedProvider` label:new[Introduced in 5.26] 
 | `file:/tmp/backup1.backup`
 
 | `ftp:`

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -482,7 +482,7 @@ The `URLConnectionSeedProvider` supports the following:
 
 
 
-The `CloudSeedProvider` label:new[introduced in 5.25] supports:
+label:new[Introduced in 5.25], the `CloudSeedProvider` supports:
 
 ** `s3:` 
 ** `gs:` 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -469,7 +469,7 @@ To determine the cause of the problem, it is recommended to look at the `debug.l
 
 ==== Seed providers
 
-The `FileSeedProvider` label:new[introduced in 5.26] supports:
+label:new[Introduced in 5.26], the `FileSeedProvider`  supports:
 
 ** `file:` 
 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -475,7 +475,7 @@ The `FileSeedProvider` label:new[introduced in 5.26] supports:
 
 The `URLConnectionSeedProvider` supports the following:
 
-** `file:` label:deprecated[deprecated in 5.26]
+** `file:` label:deprecated[Deprecated in 5.26]
 ** `ftp:`
 ** `http:`
 ** `https:`

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -597,7 +597,7 @@ Where `accessKey` and `secretKey` are provided by AWS.
 | `s3://mybucket/backups/backup1.backup`
 
 | `gs:`
-| `CloudSeedProvider` label:new[introduced in 5.25] 
+| `CloudSeedProvider` label:new[Introduced in 5.25] 
 | `gs://mybucket/backups/backup1.backup`
 
 | `azb:`

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -533,7 +533,7 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAcco
 
 The `S3SeedProvider` supports:
 
-** `s3:` label:deprecated[deprecated in 5.26] 
+** `s3:` label:deprecated[Deprecated in 5.26] 
 
 
 [NOTE]

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -469,50 +469,23 @@ To determine the cause of the problem, it is recommended to look at the `debug.l
 
 ==== Seed providers
 
+The `FileSeedProvider` label:new[introduced in 5.26] supports:
+
+** `file:` 
+
 The `URLConnectionSeedProvider` supports the following:
 
-** `file:`
+** `file:` label:deprecated[deprecated in 5.26]
 ** `ftp:`
 ** `http:`
 ** `https:`
 
-The `S3SeedProvider` supports:
 
-** `s3:`
 
-[NOTE]
-====
-Neo4j 5 comes bundled with necessary libraries for AWS S3 connectivity.
-Therefore, if you use `S3SeedProvider`,`aws cli` is not required but can be used with the `CloudSeedProvider`.
-====
+The `CloudSeedProvider` label:new[introduced in 5.25] supports:
 
-The `S3SeedProvider` requires additional configuration.
-This is specified with the `seedConfig` option.
-This option expects a comma-separated list of configurations.
-Each configuration value is specified as a name followed by `=` and the value, as such:
-
-[source, cypher, role="noplay"]
-----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedConfig: 'region=eu-west-1' }
-----
-
-`S3SeedProvider` also requires passing in credentials.
-These are specified with the `seedCredentials` option.
-Seed credentials are securely passed from the Cypher command to each server hosting the database.
-For this to work, Neo4j on each server in the cluster must be configured with identical keystores.
-This is identical to the configuration required by remote aliases, see xref:database-administration/aliases/remote-database-alias-configuration.adoc#remote-alias-config-DBMS_admin-A[Configuration of DBMS with remote database alias].
-If this configuration is not performed, the `seedCredentials` option fails.
-
-[source, cypher, role="noplay"]
-----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedConfig: 'region=eu-west-1', seedCredentials: [accessKey];[secretKey] }
-----
-Where `accessKey` and `secretKey` are provided by AWS.
-
-The `CloudSeedProvider` supports:
-
-** `s3:`
-** `gs:`
+** `s3:` 
+** `gs:` 
 ** `azb:`
 
 [.tabbed-example]
@@ -558,6 +531,40 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAcco
 ======
 =====
 
+The `S3SeedProvider` supports:
+
+** `s3:` label:deprecated[deprecated in 5.26] 
+
+
+[NOTE]
+====
+Neo4j 5 comes bundled with necessary libraries for AWS S3 connectivity.
+Therefore, if you use `S3SeedProvider`,`aws cli` is not required but can be used with the `CloudSeedProvider`.
+====
+
+The `S3SeedProvider` requires additional configuration.
+This is specified with the `seedConfig` option.
+This option expects a comma-separated list of configurations.
+Each configuration value is specified as a name followed by `=` and the value, as such:
+
+[source, cypher, role="noplay"]
+----
+CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedConfig: 'region=eu-west-1' }
+----
+
+`S3SeedProvider` also requires passing in credentials.
+These are specified with the `seedCredentials` option.
+Seed credentials are securely passed from the Cypher command to each server hosting the database.
+For this to work, Neo4j on each server in the cluster must be configured with identical keystores.
+This is identical to the configuration required by remote aliases, see xref:database-administration/aliases/remote-database-alias-configuration.adoc#remote-alias-config-DBMS_admin-A[Configuration of DBMS with remote database alias].
+If this configuration is not performed, the `seedCredentials` option fails.
+
+[source, cypher, role="noplay"]
+----
+CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedConfig: 'region=eu-west-1', seedCredentials: [accessKey];[secretKey] }
+----
+Where `accessKey` and `secretKey` are provided by AWS.
+
 
 ==== Seed provider reference
 
@@ -568,7 +575,7 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAcco
 | URI example
 
 | `file:`
-| `URLConnectionSeedProvider`
+| `URLConnectionSeedProvider` label:deprecated[deprecated in 5.26], `FileSeedProvider` label:new[introduced in 5.26] 
 | `file:/tmp/backup1.backup`
 
 | `ftp:`
@@ -584,15 +591,15 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAcco
 | `\https://myhttp.com/backups/backup1.backup`
 
 | `s3:`
-| `S3SeedProvider`, `CloudSeedProvider`
+| `S3SeedProvider` label:deprecated[deprecated in 5.26], `CloudSeedProvider` label:new[introduced in 5.25] 
 | `s3://mybucket/backups/backup1.backup`
 
 | `gs:`
-| `CloudSeedProvider`
+| `CloudSeedProvider` label:new[introduced in 5.25] 
 | `gs://mybucket/backups/backup1.backup`
 
 | `azb:`
-| `CloudSeedProvider`
+| `CloudSeedProvider` label:new[introduced in 5.25] 
 | `azb://mystorageaccount.blob/backupscontainer/backup1.backup`
 |===
 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -467,11 +467,15 @@ neo4j@neo4j> SHOW DATABASES;
 
 To determine the cause of the problem, it is recommended to look at the `debug.log`.
 
-==== Seed providers
+[[file-seed-provider]]
+==== FileSeedProvider
 
 label:new[Introduced in 5.26], the `FileSeedProvider`  supports:
 
 ** `file:` 
+
+[[url-connection-seed-provider]]
+==== URLConnectionSeedProvider
 
 The `URLConnectionSeedProvider` supports the following:
 
@@ -480,7 +484,8 @@ The `URLConnectionSeedProvider` supports the following:
 ** `http:`
 ** `https:`
 
-
+[[cloud-seed-provider]]
+==== CloudSeedProvider
 
 label:new[Introduced in 5.25], the `CloudSeedProvider` supports:
 
@@ -530,6 +535,9 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAcco
 ----
 ======
 =====
+
+[[s3-seed-provider]]
+==== S3SeedProvider
 
 The `S3SeedProvider` supports:
 


### PR DESCRIPTION
* S3SeedProvider is deprecated as of 5.26
* FileSeedProvider added in 5.26
* file: is deprecated for URLConnectionProvider as of 5.26
* Reorder providers putting S3SeedProvider last