### PR TITLE
Update the example key-value pair to use / instead of : (#1914)

### DIFF
--- a/modules/ROOT/pages/docker/docker-compose-standalone.adoc
+++ b/modules/ROOT/pages/docker/docker-compose-standalone.adoc
@@ -56,7 +56,7 @@ You can instead store your credentials in files and use them in your _docker-com
 +
 [source,text,subs="attributes"]
 ----
-neo4j:your_password
+neo4j/your_password
 ----
 . Prepare your _docker-compose.yml_ file using the following example.
 For more information, see the Docker Compose official documentation on https://docs.docker.com/compose/compose-file/#service-configuration-reference[Docker Compose specification].


### PR DESCRIPTION
Cherry-picked from #1914 