### PR TITLE
Docker secrets should only support neo4j variables (#1917)

### DIFF
--- a/modules/ROOT/pages/docker/docker-compose-standalone.adoc
+++ b/modules/ROOT/pages/docker/docker-compose-standalone.adoc
@@ -87,7 +87,10 @@ secrets:
     file: ./neo4j_auth.txt # <5>
 ----
 <1> Mount the _/$HOME/neo4j/<..>:_ directories to local directories on your host machine to store logs, configuration, data, and plugins.
-<2> Path to the file where the value for the `NEO4J_AUTH` environment variable can be found.
+<2> Path to the secret (`neo4j_auth_file`) containing the `neo4j` username and password.
+The secret value is read from the file specified in the `file` attribute of the `neo4j_auth_file` secret.
+Multiple secrets can be defined in the `secrets` section of the `neo4j` service.
+Secrets only support environment variables starting with `NEO4J_` and ending with `_FILE`.
 <3> The name of the secret, for example `neo4j_auth_file`.
 <4> Path to the _neo4j_auth.txt_ file.
 <5> The name of the secret in the `neo4j` service.


### PR DESCRIPTION
[Trello](https://trello.com/c/nlvbN50T/540-change-the-docker-secrets-feature-to-limit-the-usage-of-env-vars-that-are-prefixed-with-neo4j?filter=*)
Cherry-picked from #1917 