### PR TITLE
Deprecate `seedConfig`, and `seedCredentials`

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -113,7 +113,9 @@ For details about enrichment mode, see link:{neo4j-docs-base-uri}/cdc/current/ge
 | `storeFormat`
 | `aligned` \| `standard` \| `high_limit` \| `block`
 |
-Defines the store format if the database created is new. `high_limit` and `standard` formats are deprecated from 5.23. For more information on store formats see xref::database-internals/store-formats.adoc[Store formats].
+Defines the store format if the database created is new.
+`high_limit` and `standard` formats are deprecated from 5.23.
+For more information on store formats, see xref::database-internals/store-formats.adoc[Store formats].
 
 If the store is seeded with `seedURI`, `existingDataSeedInstance` or `existingDataSeedServer`, or if the command is used to mount pre-existing store files already present on the disk, they will retain their current store format without any modifications.
 |===

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -97,14 +97,14 @@ Defines an identical seed from an external source which will be used to seed all
 | Comma-separated list of configuration values.
 |
 Defines additional configuration specified by comma-separated `name=value` pairs that might be required by certain seed providers.
-From 5.26 it is recommended to use the `CloudSeedProvider` seed provider which does not require this configuration when seeding from cloud storage.
+From 5.26, it is recommended to use the `CloudSeedProvider` seed provider, which does not require this configuration when seeding from cloud storage.
 For more information see xref::clustering/databases.adoc#_cloud_seed_provider[CloudSeedProvider].
 
 | `seedCredentials` label:deprecated[Deprecated in 5.26]
 | credentials
 |
 Defines credentials that need to be passed into certain seed providers.
-From 5.26 it is recommended to use the `CloudSeedProvider` seed provider which does not require this configuration when seeding from cloud storage.
+From 5.26, it is recommended to use the `CloudSeedProvider` seed provider, which does not require this configuration when seeding from cloud storage.
 For more information see xref::clustering/databases.adoc#_cloud_seed_provider[CloudSeedProvider].
 
 | `txLogEnrichment`

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -97,11 +97,14 @@ Defines an identical seed from an external source which will be used to seed all
 | Comma-separated list of configuration values.
 |
 Defines additional configuration specified by comma-separated `name=value` pairs that might be required by certain seed providers.
-
+From 5.26 it is recommended to use the `CloudSeedProvider` seed provider which does not require this configuration when seeding from cloud storage.
+For more information see xref::clustering/databases.adoc#_seed_providers[Seed providers].
 | `seedCredentials` label:deprecated[Deprecated in 5.26]
 | credentials
 |
 Defines credentials that need to be passed into certain seed providers.
+From 5.26 it is recommended to use the `CloudSeedProvider` seed provider which does not require this configuration when seeding from cloud storage.
+For more information see xref::clustering/databases.adoc#_seed_providers[Seed providers].
 
 | `txLogEnrichment`
 | `FULL` \| `DIFF` \| `OFF`

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -98,13 +98,13 @@ Defines an identical seed from an external source which will be used to seed all
 |
 Defines additional configuration specified by comma-separated `name=value` pairs that might be required by certain seed providers.
 From 5.26 it is recommended to use the `CloudSeedProvider` seed provider which does not require this configuration when seeding from cloud storage.
-For more information see xref::clustering/databases.adoc#_seed_providers[Seed providers].
+For more information see xref::clustering/databases.adoc#_cloud_seed_provider[CloudSeedProvider].
 | `seedCredentials` label:deprecated[Deprecated in 5.26]
 | credentials
 |
 Defines credentials that need to be passed into certain seed providers.
 From 5.26 it is recommended to use the `CloudSeedProvider` seed provider which does not require this configuration when seeding from cloud storage.
-For more information see xref::clustering/databases.adoc#_seed_providers[Seed providers].
+For more information see xref::clustering/databases.adoc#_cloud_seed_provider[CloudSeedProvider].
 
 | `txLogEnrichment`
 | `FULL` \| `DIFF` \| `OFF`

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -98,14 +98,14 @@ Defines an identical seed from an external source which will be used to seed all
 |
 Defines additional configuration specified by comma-separated `name=value` pairs that might be required by certain seed providers.
 From 5.26, it is recommended to use the `CloudSeedProvider` seed provider, which does not require this configuration when seeding from cloud storage.
-For more information see xref::clustering/databases.adoc#_cloud_seed_provider[CloudSeedProvider].
+For more information see xref::clustering/databases.adoc#cloud-seed-provider[CloudSeedProvider].
 
 | `seedCredentials` label:deprecated[Deprecated in 5.26]
 | credentials
 |
 Defines credentials that need to be passed into certain seed providers.
 From 5.26, it is recommended to use the `CloudSeedProvider` seed provider, which does not require this configuration when seeding from cloud storage.
-For more information see xref::clustering/databases.adoc#_cloud_seed_provider[CloudSeedProvider].
+For more information see xref::clustering/databases.adoc#cloud-seed-provider[CloudSeedProvider].
 
 | `txLogEnrichment`
 | `FULL` \| `DIFF` \| `OFF`

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -93,12 +93,12 @@ The server ID can be found in the `serverId` column after running `SHOW SERVERS`
 |
 Defines an identical seed from an external source which will be used to seed all servers.
 
-| `seedConfig` label:deprecated[Deprecated in 5.25]
+| `seedConfig` label:deprecated[Deprecated in 5.26]
 | Comma-separated list of configuration values.
 |
 Defines additional configuration specified by comma-separated `name=value` pairs that might be required by certain seed providers.
 
-| `seedCredentials` label:deprecated[Deprecated in 5.25]
+| `seedCredentials` label:deprecated[Deprecated in 5.26]
 | credentials
 |
 Defines credentials that need to be passed into certain seed providers.

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -93,12 +93,12 @@ The server ID can be found in the `serverId` column after running `SHOW SERVERS`
 |
 Defines an identical seed from an external source which will be used to seed all servers.
 
-| `seedConfig`
+| `seedConfig` label:deprecated[Deprecated in 5.25]
 | Comma-separated list of configuration values.
 |
 Defines additional configuration specified by comma-separated `name=value` pairs that might be required by certain seed providers.
 
-| `seedCredentials`
+| `seedCredentials` label:deprecated[Deprecated in 5.25]
 | credentials
 |
 Defines credentials that need to be passed into certain seed providers.
@@ -113,7 +113,8 @@ For details about enrichment mode, see link:{neo4j-docs-base-uri}/cdc/current/ge
 | `storeFormat`
 | `aligned` \| `standard` \| `high_limit` \| `block`
 |
-Defines the store format if the database created is new.
+Defines the store format if the database created is new. `high_limit` and `standard` formats are deprecated from 5.23. For more information on store formats see xref::database-internals/store-formats.adoc[Store formats].
+
 If the store is seeded with `seedURI`, `existingDataSeedInstance` or `existingDataSeedServer`, or if the command is used to mount pre-existing store files already present on the disk, they will retain their current store format without any modifications.
 |===
 

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -99,6 +99,7 @@ Defines an identical seed from an external source which will be used to seed all
 Defines additional configuration specified by comma-separated `name=value` pairs that might be required by certain seed providers.
 From 5.26 it is recommended to use the `CloudSeedProvider` seed provider which does not require this configuration when seeding from cloud storage.
 For more information see xref::clustering/databases.adoc#_cloud_seed_provider[CloudSeedProvider].
+
 | `seedCredentials` label:deprecated[Deprecated in 5.26]
 | credentials
 |


### PR DESCRIPTION
Also add a note about deprecated store formats

We may need to add some more details about the deprecations once clustering get to look at it. 

Depends on: https://github.com/neo4j/docs-operations/pull/1909