### PR TITLE
Update `server.metrics.filter`, add new 5.26 configuration settings 

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -326,7 +326,7 @@ m|+++1024+++
 |===
 
 
-[role=label--enterprise-edition]
+[role=label--enterprise-edition label--deprecated-5.26]
 [[config_dbms.cluster.catchup.client_inactivity_timeout]]
 === `dbms.cluster.catchup.client_inactivity_timeout`
 
@@ -341,6 +341,20 @@ a|A duration (Valid units are: `ns`, `μs`, `ms`, `s`, `m`, `h` and `d`; default
 m|+++10m+++
 |===
 
+[role=label--enterprise-edition label--new-5.26]
+[[config_dbms.cluster.network.client_inactivity_timeout]]
+=== `dbms.cluster.network.client_inactivity_timeout`
+
+.dbms.cluster.network.client_inactivity_timeout
+[frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
+|===
+|Description
+a|A network request times out if the given duration elapses with no network activity. Every message received by the client from the server extends the timeout duration.
+|Valid values
+a|A duration (Valid units are: `ns`, `μs`, `ms`, `s`, `m`, `h` and `d`; default unit is `s`).
+|Default value
+m|+++10m+++
+|===
 
 [role=label--enterprise-edition label--deprecated-5.23]
 [[config_dbms.cluster.discovery.endpoints]]
@@ -5272,7 +5286,7 @@ Note: this is different from 'db.transaction.timeout' which will timeout the und
 |Valid values
 a|A duration (Valid units are: `ns`, `μs`, `ms`, `s`, `m`, `h` and `d`; default unit is `s`).
 |Default value
-m|+++60s+++
+m|+++1m+++
 |===
 
 

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -3237,7 +3237,7 @@ a|Specifies which metrics should be enabled by using a comma separated list of g
 |Valid values
 a|A comma-separated list where each element is A simple globbing pattern that can use `*` and `?`..
 |Default value
-m|+++*bolt.connections*,*bolt.messages_received*,*bolt.messages_started*,*dbms.pool.bolt.free,*dbms.pool.bolt.total_size,*dbms.pool.bolt.total_used,*dbms.pool.bolt.used_heap,*cluster.raft.is_leader,*cluster.raft.last_leader_message,*cluster.raft.replication_attempt,*cluster.raft.replication_fail,*cluster.raft.last_applied,*cluster.raft.last_appended,*cluster.raft.append_index,*cluster.raft.commit_index,*cluster.raft.applied_index,*cluster.internal.discovery.memberset.left,*cluster.internal.discovery.crdt.gossip_id_data.size,*cluster.internal.discovery.crdt.server_data.size,*cluster.internal.discovery.crdt.database_data.size,*cluster.internal.discovery.crdt.leader_data.size,*cluster.internal.discovery.crdt.total_merge_operations,*cluster.internal.discovery.crdt.total_update_operations,*cluster.internal.discovery.gossip.incoming_queue_size,*cluster.internal.discovery.gossip.total_received_data,*cluster.internal.discovery.gossip.total_sent_data,*cluster.internal.discovery.gossip.uncontactable_members_exist,*check_point.*,*cypher.replan_events,*ids_in_use*,*pool.transaction.*.total_used,*pool.transaction.*.used_heap,*pool.transaction.*.used_native,*store.size*,*transaction.active_read,*transaction.active_write,*transaction.committed*,*transaction.last_committed_tx_id,*transaction.peak_concurrent,*transaction.rollbacks*,*page_cache.hit*,*page_cache.page_faults,*page_cache.usage_ratio,*vm.file.descriptors.count,*vm.gc.time.*,*vm.heap.used,*vm.memory.buffer.direct.used,*vm.memory.pool.g1_eden_space,*vm.memory.pool.g1_old_gen,*vm.pause_time,*vm.thread*,*db.query.execution*,*protocol*+++
+m|+++*bolt.connections*,*bolt.messages_received*,*bolt.messages_started*,*dbms.pool.bolt.free,*dbms.pool.bolt.total_size,*dbms.pool.bolt.total_used,*dbms.pool.bolt.used_heap,*cluster.raft.is_leader,*cluster.raft.last_leader_message,*cluster.raft.replication_attempt,*cluster.raft.replication_fail,*cluster.raft.last_applied,*cluster.raft.last_appended,*cluster.raft.append_index,*cluster.raft.commit_index,*cluster.raft.applied_index,*cluster.internal.discovery.memberset.left,*cluster.internal.discovery.crdt.gossip_id_data.size,*cluster.internal.discovery.crdt.server_data.size,*cluster.internal.discovery.crdt.database_data.size,*cluster.internal.discovery.crdt.leader_data.size,*cluster.internal.discovery.crdt.total_merge_operations,*cluster.internal.discovery.crdt.total_update_operations,*cluster.internal.discovery.gossip.incoming_queue_size,*cluster.internal.discovery.gossip.total_received_data,*cluster.internal.discovery.gossip.total_sent_data,*cluster.internal.discovery.gossip.uncontactable_members_exist,*check_point.*,*cypher.replan_events,*cypher.cache*,*ids_in_use*,*pool.transaction.*.total_used,*pool.transaction.*.used_heap,*pool.transaction.*.used_native,*store.size*,*transaction.active_read,*transaction.active_write,*transaction.committed*,*transaction.last_committed_tx_id,*transaction.peak_concurrent,*transaction.rollbacks*,*page_cache.hit*,*page_cache.page_faults,*page_cache.usage_ratio,*vm.file.descriptors.count,*vm.gc.time.*,*vm.heap.used,*vm.memory.buffer.direct.used,*vm.memory.pool.g1_eden_space,*vm.memory.pool.g1_old_gen,*vm.pause_time,*vm.thread*,*db.query.execution*,*protocol*+++
 |===
 
 
@@ -5258,6 +5258,23 @@ a|A duration (Valid units are: `ns`, `μs`, `ms`, `s`, `m`, `h` and `d`; default
 |Default value
 m|+++30s+++
 |===
+
+[role=label--new-5.26]
+[[config_server.queryapi.transaction_idle_timeout]]
+=== `server.queryapi.transaction_idle_timeout`
+
+.server.queryapi.transaction_idle_timeout
+[frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
+|===
+|Description
+a|Timeout for idle transactions in the Query API. +
+Note: this is different from 'db.transaction.timeout' which will timeout the underlying transaction.
+|Valid values
+a|A duration (Valid units are: `ns`, `μs`, `ms`, `s`, `m`, `h` and `d`; default unit is `s`).
+|Default value
+m|+++60s+++
+|===
+
 
 
 == Transaction log settings


### PR DESCRIPTION
Related to https://github.com/neo-technology/neo4j/pull/27660, https://github.com/neo-technology/neo4j/pull/27785, and https://github.com/neo-technology/neo4j/pull/27962.
These are implemented in 5.26