### PR TITLE
Allow database names to start with a digit

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -812,8 +812,7 @@ m|+++0+++
 |Description
 a|Names of the databases allowed on this server; all others are denied. Empty means all are allowed. This configuration can be overridden when enabling the server or altered at runtime without changing this setting. Exclusive with `server.initial_denied_databases`.
 |Valid values
-a|A comma-separated set where each element is a valid database name.
-Database naming rules are described in xref:database-administration/standard-databases/naming-databases.adoc[Naming rules for databases]
+a|A comma-separated set where each element is a valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character or number but not with the name `system`.
 |Default value
 m|++++++
 |===
@@ -829,8 +828,7 @@ m|++++++
 |Description
 a|Names of the databases not allowed on this server. Empty means nothing is denied. This configuration can be overridden when enabling the server or altered at runtime without changing this setting. Exclusive with `server.initial_allowed_databases`.
 |Valid values
-a|A comma-separated set where each element is a valid database name.
-Database naming rules are described in xref:database-administration/standard-databases/naming-databases.adoc[Naming rules for databases]
+a|A comma-separated set where each element is a valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character or number but not with the name `system`.
 |Default value
 m|++++++
 |===
@@ -2185,8 +2183,7 @@ Once it is created, the setting is not valid anymore.
 
 To set the default database, use the xref:/clustering/databases.adoc#cluster-default-database[`dbms.setDefaultDatabase()`] procedure instead.
 |Valid values
-a|A valid database name.
-Database naming rules are described in xref:database-administration/standard-databases/naming-databases.adoc[Naming rules for databases]
+a|A valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character or number but not with the name system.
 |Default value
 m|+++neo4j+++
 |===
@@ -5004,8 +5001,7 @@ m|+++false+++
 |Description
 a|List of databases for which to prevent write queries. Databases not included in this list maybe read_only anyway depending upon the value of <<config_server.databases.default_to_read_only,server.databases.default_to_read_only>>.
 |Valid values
-a| A comma-separated set where each element is a valid database name.
-Database naming rules are described in xref:database-administration/standard-databases/naming-databases.adoc[Naming rules for databases]
+a| A comma-separated set where each element is a valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character or number but not with the name system.
 |Default value
 m|++++++
 |===
@@ -5021,8 +5017,7 @@ m|++++++
 |Description
 a|List of databases for which to allow write queries. Databases not included in this list will allow write queries anyway, unless <<config_server.databases.default_to_read_only,server.databases.default_to_read_only>> is set to true.
 |Valid values
-a|A comma-separated set where each element is a valid database name.
-Database naming rules are described in xref:database-administration/standard-databases/naming-databases.adoc[Naming rules for databases]
+a|A comma-separated set where each element is a valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character or number but not with the name system.
 |Default value
 m|++++++
 |===

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -812,7 +812,8 @@ m|+++0+++
 |Description
 a|Names of the databases allowed on this server; all others are denied. Empty means all are allowed. This configuration can be overridden when enabling the server or altered at runtime without changing this setting. Exclusive with `server.initial_denied_databases`.
 |Valid values
-a|A comma-separated set where each element is a valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name `system`.
+a|A comma-separated set where each element is a valid database name.
+Database naming rules are described in xref:database-administration/standard-databases/naming-databases.adoc[Naming rules for databases]
 |Default value
 m|++++++
 |===
@@ -828,7 +829,8 @@ m|++++++
 |Description
 a|Names of the databases not allowed on this server. Empty means nothing is denied. This configuration can be overridden when enabling the server or altered at runtime without changing this setting. Exclusive with `server.initial_allowed_databases`.
 |Valid values
-a|A comma-separated set where each element is a valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name `system`.
+a|A comma-separated set where each element is a valid database name.
+Database naming rules are described in xref:database-administration/standard-databases/naming-databases.adoc[Naming rules for databases]
 |Default value
 m|++++++
 |===
@@ -2183,7 +2185,8 @@ Once it is created, the setting is not valid anymore.
 
 To set the default database, use the xref:/clustering/databases.adoc#cluster-default-database[`dbms.setDefaultDatabase()`] procedure instead.
 |Valid values
-a|A valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name system.
+a|A valid database name.
+Database naming rules are described in xref:database-administration/standard-databases/naming-databases.adoc[Naming rules for databases]
 |Default value
 m|+++neo4j+++
 |===
@@ -5001,7 +5004,8 @@ m|+++false+++
 |Description
 a|List of databases for which to prevent write queries. Databases not included in this list maybe read_only anyway depending upon the value of <<config_server.databases.default_to_read_only,server.databases.default_to_read_only>>.
 |Valid values
-a| A comma-separated set where each element is a valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name system.
+a| A comma-separated set where each element is a valid database name.
+Database naming rules are described in xref:database-administration/standard-databases/naming-databases.adoc[Naming rules for databases]
 |Default value
 m|++++++
 |===
@@ -5017,7 +5021,8 @@ m|++++++
 |Description
 a|List of databases for which to allow write queries. Databases not included in this list will allow write queries anyway, unless <<config_server.databases.default_to_read_only,server.databases.default_to_read_only>> is set to true.
 |Valid values
-a|A comma-separated set where each element is a valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name system.
+a|A comma-separated set where each element is a valid database name.
+Database naming rules are described in xref:database-administration/standard-databases/naming-databases.adoc[Naming rules for databases]
 |Default value
 m|++++++
 |===

--- a/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
@@ -18,7 +18,7 @@ Support for database names starting with a numeric character is available from N
 [NOTE]
 ====
 The `-` (dash) and `.` (dot) characters are not legal in Cypher variables.
-Names containing a `-` or tha begin with a numeric character must be enclosed within backticks.
+Names containing a `-` or that begin with a numeric character must be enclosed within backticks.
 For example, `CREATE DATABASE ++`main-db`++` is a valid database name.
 Database names are the only identifier for which dots do not need to be quoted.
 For example `main.db` is a valid database name.

--- a/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
@@ -9,7 +9,7 @@ Naming rules for databases are as follows:
 
 * Length must be between 3 and 63 characters.
 * The first character of a name must be an ASCII alphabetic or numeric character.
-Support for database names starting with a numeric character was added in 2025.1.
+Support for database names starting with a numeric character is available from Neo4j 2025.01.
 * Subsequent characters must be ASCII alphabetic or numeric characters, dots or dashes; `[a..z][0..9].-`.
 * Names cannot end with dots or dashes.
 * Names are case-insensitive and normalized to lowercase.

--- a/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
@@ -8,7 +8,8 @@ See link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/naming[Cypher
 Naming rules for databases are as follows:
 
 * Length must be between 3 and 63 characters.
-* The first character of a name must be an ASCII alphabetic character.
+* The first character of a name must be an ASCII alphabetic or numeric character.
+Support for database names starting with a numeric character was added in 2025.1.
 * Subsequent characters must be ASCII alphabetic or numeric characters, dots or dashes; `[a..z][0..9].-`.
 * Names cannot end with dots or dashes.
 * Names are case-insensitive and normalized to lowercase.
@@ -17,7 +18,7 @@ Naming rules for databases are as follows:
 [NOTE]
 ====
 The `-` (dash) and `.` (dot) characters are not legal in Cypher variables.
-Names with a `-` in them must be enclosed within backticks.
+Names containing a `-` or tha begin with a numeric character must be enclosed within backticks.
 For example, `CREATE DATABASE ++`main-db`++` is a valid database name.
 Database names are the only identifier for which dots do not need to be quoted.
 For example `main.db` is a valid database name.


### PR DESCRIPTION
We have relaxed the database naming rules to allow a database name to start with a digit. Update docs to reflect this.

See also https://github.com/neo-technology/neo4j/pull/28262