### PR TITLE
Add metrics for Raft Snapshots. Attempt/success/fail

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -578,9 +578,9 @@ The deprecated Raft core metrics are replaced accordingly by the Raft metrics in
 |<prefix>.cluster.raft.replication_maybe|Raft Replication maybe count. (counter)
 |<prefix>.cluster.raft.replication_success|The total number of Raft replication requests that have succeeded. (counter)
 |<prefix>.cluster.raft.last_leader_message|The time elapsed since the last message from a leader in milliseconds. Should reset periodically. (gauge)
-|<prefix>.cluster.raft.snapshot_attempt|Downloading of Raft snapshot attempts triggered. (counter)
-|<prefix>.cluster.raft.snapshot_success|Downloading of Raft snapshot successful downloads. (counter)
-|<prefix>.cluster.raft.snapshot_fail|Downloading of Raft snapshot failed downloads. (counter)
+|<prefix>.cluster.raft.snapshot_attempt|Total number of attempts to download Raft snapshots triggered. (counter)
+|<prefix>.cluster.raft.snapshot_success|Total number of successfully downloaded Raft snapshots. (counter)
+|<prefix>.cluster.raft.snapshot_fail|Total number of failed Raft snapshot download attempts. (counter)
 |===
 
 

--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -578,9 +578,9 @@ The deprecated Raft core metrics are replaced accordingly by the Raft metrics in
 |<prefix>.cluster.raft.replication_maybe|Raft Replication maybe count. (counter)
 |<prefix>.cluster.raft.replication_success|The total number of Raft replication requests that have succeeded. (counter)
 |<prefix>.cluster.raft.last_leader_message|The time elapsed since the last message from a leader in milliseconds. Should reset periodically. (gauge)
-|<prefix>.cluster.raft.snapshot_attempt|Downloading of Raft snapshot attempts triggered. (counter)
-|<prefix>.cluster.raft.snapshot_success|Downloading of Raft snapshot successful downloads. (counter)
-|<prefix>.cluster.raft.snapshot_fail|Downloading of Raft snapshot failed downloads. (counter)
+|<prefix>.cluster.raft.snapshot_attempt|Downloading of Raft snapshot attempts triggered. (gauge)
+|<prefix>.cluster.raft.snapshot_success|Downloading of Raft snapshot successful downloads. (gauge)
+|<prefix>.cluster.raft.snapshot_fail|Downloading of Raft snapshot failed downloads. (gauge)
 |===
 
 

--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -578,9 +578,9 @@ The deprecated Raft core metrics are replaced accordingly by the Raft metrics in
 |<prefix>.cluster.raft.replication_maybe|Raft Replication maybe count. (counter)
 |<prefix>.cluster.raft.replication_success|The total number of Raft replication requests that have succeeded. (counter)
 |<prefix>.cluster.raft.last_leader_message|The time elapsed since the last message from a leader in milliseconds. Should reset periodically. (gauge)
-|<prefix>.cluster.raft.snapshot_attempt|Downloading of Raft snapshot attempts triggered. (gauge)
-|<prefix>.cluster.raft.snapshot_success|Downloading of Raft snapshot successful downloads. (gauge)
-|<prefix>.cluster.raft.snapshot_fail|Downloading of Raft snapshot failed downloads. (gauge)
+|<prefix>.cluster.raft.snapshot_attempt|Downloading of Raft snapshot attempts triggered. (counter)
+|<prefix>.cluster.raft.snapshot_success|Downloading of Raft snapshot successful downloads. (counter)
+|<prefix>.cluster.raft.snapshot_fail|Downloading of Raft snapshot failed downloads. (counter)
 |===
 
 

--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -578,6 +578,9 @@ The deprecated Raft core metrics are replaced accordingly by the Raft metrics in
 |<prefix>.cluster.raft.replication_maybe|Raft Replication maybe count. (counter)
 |<prefix>.cluster.raft.replication_success|The total number of Raft replication requests that have succeeded. (counter)
 |<prefix>.cluster.raft.last_leader_message|The time elapsed since the last message from a leader in milliseconds. Should reset periodically. (gauge)
+|<prefix>.cluster.raft.snapshot_attempt|Downloading of Raft snapshot attempts triggered. (counter)
+|<prefix>.cluster.raft.snapshot_success|Downloading of Raft snapshot successful downloads. (counter)
+|<prefix>.cluster.raft.snapshot_fail|Downloading of Raft snapshot failed downloads. (counter)
 |===
 
 


### PR DESCRIPTION
Adding metrics for Raft Snapshot download. See https://github.com/neo-technology/neo4j/pull/28148