### PR TITLE
Using quoting instead of escaping with backticks

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/dbms-administration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/dbms-administration.adoc
@@ -2069,9 +2069,9 @@ In this case, `+*+` means 0 or more characters, and `?` matches exactly one char
 ====
 The name-globbing is subject to the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/naming/[Cypher Manual -> Naming rules and recommendations], with the exception that it may include dots, stars, and question marks without the need for escaping using backticks.
 
-Each part of the name-globbing separated by dots may be individually escaped.
+Each part of the name-globbing separated by dots may be individually quoted.
 For example, `++mine.`procedureWith%`++` is allowed, but not `++mine.procedure`With%`++`.
-Also, note that wildcard characters behave as wildcards even when escaped.
+Also, note that wildcard characters behave as wildcards even when quoted.
 For example, using `++`*`++` is equivalent to using `+*+`, and thus allows executing all functions or procedures and not only the procedure or function named `+*+`.
 ====
 
@@ -2134,7 +2134,7 @@ Users with the role `globbing6` can run procedures `mine.public.with#Special§Ch
 
 [NOTE]
 ====
-The name-globbing may be fully or partially escaped.
+The name-globbing may be fully or partially quoted.
 Both `+*+` and `+?+` are interpreted as wildcards in both cases.
 ====
 

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -42,7 +42,7 @@ neo4j-admin database copy [-h] [--copy-schema] [--expand-commands] [--force] [--
 === Description
 
 This command will create a copy of a database.
-If your labels, properties, or relationships contain dots or commas, you can use ` to escape them, e.g. `My,label`. property .
+If your labels, properties, or relationships contain dots or commas, you can use backticks to quote them, e.g. ``My,label``, ``My.property``.
 A file named _<database-name>-schema.cypher_, containing the schema commands needed to recreate indexes/constraints on the copy, will be created.
 
 From Neo4j 5.20 onwards, you can use the `--copy-schema` option to automatically copy the schema.

--- a/modules/ROOT/pages/database-administration/aliases/manage-aliases-composite-databases.adoc
+++ b/modules/ROOT/pages/database-administration/aliases/manage-aliases-composite-databases.adoc
@@ -216,9 +216,9 @@ SHOW DATABASE garden YIELD name, type, constituents
 Naming database aliases in composite databases follows the same rule as xref:database-administration/aliases/naming-aliases.adoc[naming aliases for standard databases].
 However, when it comes to escaping names using backticks, there are some additional things to consider:
 
-=== Escaping database alias and composite database names
+=== Quoting database alias and composite database names
 
-The composite database name and the database alias name need to be escaped individually.
+The composite database name and the database alias name need to be quoted individually.
 Backticks may be added regardless of whether the name contains special characters or not, so it is good practice to always backtick both names, e.g.  `++`composite`++.++`alias`++`.
 
 The following example creates a database alias named `my alias with spaces` as a constituent in the composite database named `my-composite-database-with-dashes`:
@@ -236,7 +236,7 @@ CREATE DATABASE `northwind-graph`;
 CREATE ALIAS `my-composite-database-with-dashes`.`my alias with spaces` FOR DATABASE `northwind-graph`
 ----
 
-When not escaped individually, a database alias with the full name `my alias with.dots and spaces` gets created instead:
+When not quoted individually, a database alias with the full name `my alias with.dots and spaces` gets created instead:
 
 .Query
 [source, cypher]
@@ -249,7 +249,7 @@ CREATE ALIAS `my alias with.dots and spaces` FOR DATABASE `northwind-graph`
 //Examples where dots are not separators between composite name and alias name are impossible to test, because the right escaping cannot be inferred automatically.
 
 Database alias names may also include dots.
-Though these always need to be escaped in order to avoid ambiguity with the composite database and database alias split character.
+Though these always need to be quoted in order to avoid ambiguity with the composite database and database alias split character.
 
 .Query
 [source, cypher, role=test-skip]
@@ -279,7 +279,7 @@ CREATE ALIAS some.alias FOR DATABASE `northwind-graph`
 
 === Handling parameters
 
-When using parameters, names cannot be escaped.
+When using parameters, names cannot be quoted.
 When the given parameter includes dots, the first dot will be considered the divider for the composite database.
 
 Consider the query with parameter:
@@ -315,7 +315,7 @@ Consider the same query but with the following parameter:
 Since the first dot will be used as a divider, the command will attempt to create the database alias `withdot.myalias` in the composite database `mycompositedatabase`.
 If `mycompositedatabase` does not exist, the command will create a database alias with the name `mycompositedatabase.withdot.myalias`, which is not part of any composite database.
 
-In these cases, it is recommended to avoid parameters and explicitly escape the composite database name and alias name separately to avoid ambiguity.
+In these cases, it is recommended to avoid parameters and explicitly quote the composite database name and alias name separately to avoid ambiguity.
 
 === Handling parameters
 
@@ -356,4 +356,4 @@ Failed to delete the specified database alias 'foo.bar': Database alias does not
 
 Had the composite database `foo` not existed, the database alias `foo.bar` would have been dropped.
 
-In these cases, it is recommended to avoid parameters and explicitly escape the composite database name and alias name separately to avoid ambiguity.
+In these cases, it is recommended to avoid parameters and explicitly quote the composite database name and alias name separately to avoid ambiguity.

--- a/modules/ROOT/pages/database-administration/aliases/manage-aliases-composite-databases.adoc
+++ b/modules/ROOT/pages/database-administration/aliases/manage-aliases-composite-databases.adoc
@@ -313,7 +313,7 @@ Consider the same query but with the following parameter:
 ----
 
 Since the first dot will be used as a divider, the command will attempt to create the database alias `withdot.myalias` in the composite database `mycompositedatabase`.
-If `mycompositedatabase` doesn't exist, the command will create a database alias with the name `mycompositedatabase.withdot.myalias`, which is not part of any composite database.
+If `mycompositedatabase` does not exist, the command will create a database alias with the name `mycompositedatabase.withdot.myalias`, which is not part of any composite database.
 
 In these cases, it is recommended to avoid parameters and explicitly escape the composite database name and alias name separately to avoid ambiguity.
 

--- a/modules/ROOT/pages/database-administration/aliases/naming-aliases.adoc
+++ b/modules/ROOT/pages/database-administration/aliases/naming-aliases.adoc
@@ -10,9 +10,9 @@ The following naming rules apply:
 * A name is a valid identifier.
 * Name length can be up to 65534 characters.
 * Names cannot end with dots.
-* Unescaped dots signify that the database alias belongs to a composite database, separating the composite database name and the alias name.
+* Unquoted dots signify that the database alias belongs to a composite database, separating the composite database name and the alias name.
 * Names that begin with an underscore or with the prefix `system` are reserved for internal use.
-* Non-alphabetic characters, including numbers, symbols, dots, and whitespace characters, can be used in names, but must be escaped using backticks.
+* Non-alphabetic characters, including numbers, symbols, dots, and whitespace characters, can be used in names, but must be quoted using backticks.
 
 The name restrictions and escaping rules apply to all the different database alias commands.
 

--- a/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
@@ -19,7 +19,7 @@ Naming rules for databases are as follows:
 The `-` (dash) and `.` (dot) characters are not legal in Cypher variables.
 Names with a `-` in them must be enclosed within backticks.
 For example, `CREATE DATABASE ++`main-db`++` is a valid database name.
-Database names are the only identifier for which dots do not need to be escaped.
+Database names are the only identifier for which dots do not need to be quoted.
 For example `main.db` is a valid database name.
 However, this behavior is deprecated due to the difficulty of determining if a dot is part of the database name or a delimiter for a database alias in a composite database.
 ====


### PR DESCRIPTION
This is the only mention of escaping with backticks that I found in the Operations manual.

Cypher Manual PR: https://github.com/neo4j/docs-cypher/pull/1111