### PR TITLE
fix load command example (#1967)

### DIFF
--- a/modules/ROOT/pages/kubernetes/operations/dump-load.adoc
+++ b/modules/ROOT/pages/kubernetes/operations/dump-load.adoc
@@ -31,7 +31,7 @@ For information about the command syntax, options, and usage, see xref:backup-re
 +
 [source, shell]
 ----
-neo4j-admin database load --expand-commands system --from-path=/backups && neo4j-admin database load --expand-commands neo4j --from-path=/backups
+neo4j-admin database load --expand-commands system --from-path=/backups --overwrite-destination=true && neo4j-admin database load --expand-commands neo4j --from-path=/backups --overwrite-destination=true
 ----
 +
 [TIP]


### PR DESCRIPTION
Cherry-picked from #1967 
without extra flag got:

```
Failed to load database 'system': Database already exists: systemLoad failed for databases: 'system'
Load failed for databases: 'system'
```