### PR TITLE
add note about database name in query log

### DIFF
--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -1221,7 +1221,7 @@ Included when xref:configuration/configuration-settings.adoc#config_db.logs.quer
 | Connection details.
 
 | database
-| The database name on which the query is run. This field will be `<none>` if it is not possible to parse and route the query to the correct database.
+| The database name on which the query is run. This field will be `<none>` if the query cannot be parsed and routed to a database.
 
 | executingUser
 | The name of the user executing the query.

--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -1221,7 +1221,7 @@ Included when xref:configuration/configuration-settings.adoc#config_db.logs.quer
 | Connection details.
 
 | database
-| The database name on which the query is run.
+| The database name on which the query is run. This field will be `<none>` if it is not possible to parse and route the query to the correct database.
 
 | executingUser
 | The name of the user executing the query.


### PR DESCRIPTION
In order to know which database the query is targeting, we do some parsing to find if there is a USE-clause (e.g.  `USE db RETURN 1 AS result`).  If the parsing fails, we are not able to figure out what database the query should be run at and therefor the field in the log will be <none>. 

Please let me know if I can improve the documentation with more details, I just don't want to put information to confuse the user even more.