### PR TITLE
Fix the deprecation label for `dbms.cluster.discovery.type` (#1986)

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -455,8 +455,8 @@ m|+++LIST+++
 |===
 
 
-[role="label--enterprise-edition deprecated-5.7"]
-[[conifg_dbms.cluster.discovery.type]]
+[role=label--enterprise-edition label--deprecated-5.7]
+[[config_dbms.cluster.discovery.type]]
 === `dbms.cluster.discovery.type`
 
 .dbms.cluster.discovery.type


### PR DESCRIPTION
Small fix to render the deprecation label for the `dbms.cluster.discovery.type` config 