### PR TITLE
Remove GZip compression

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -539,7 +539,7 @@ m|+++32768+++
 |===
 
 
-[role=label--enterprise-edition label--changed[Changed in 2025.01]]
+[role=label--enterprise-edition label--changed-2025.01]
 [[config_dbms.cluster.network.supported_compression_algos]]
 === `dbms.cluster.network.supported_compression_algos`
 

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -550,7 +550,7 @@ m|+++32768+++
 a|Network compression algorithms that this instance will allow in negotiation as a comma-separated list. +
 For incoming connections, the algorithms are listed in descending order of preference. An empty list implies no compression. +
 For outgoing connections, this merely specifies the allowed set of algorithms and the preference of the remote peer will be used for making the decision. +
-Allowable values: [Gzip, Snappy, Snappy_validating, LZ4, LZ4_high_compression, LZ_validating, LZ4_high_compression_validating]
+Allowable values: [Snappy, Snappy_validating, LZ4, LZ4_high_compression, LZ_validating, LZ4_high_compression_validating]
 |Valid values
 a|A comma-separated list where each element is a string.
 |Default value

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -539,7 +539,7 @@ m|+++32768+++
 |===
 
 
-[role=label--enterprise-edition]
+[role=label--enterprise-edition label--changed[Changed in 2025.01]]
 [[config_dbms.cluster.network.supported_compression_algos]]
 === `dbms.cluster.network.supported_compression_algos`
 


### PR DESCRIPTION
Gzip was removed from the list of supported compression algorithms.