### PR TITLE
Add seed restore until section and remove 5.x seed provider info

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -526,8 +526,8 @@ The `CloudSeedProvider` supports:
 ** `gs:` 
 ** `azb:`
 
-The `CloudSeedProvider` supports using xref:backup-restore/modes.adoc#differential-backup[differential backup] files as seeds.
-With the provided differential backup file, the `CloudSeedProvider` searches the directory containing differential backup files for a xref:backup-restore/online-backup.adoc#backup-chain[backup chain] ending at the specified differential backup, and then seeds using this backup chain.
+The `CloudSeedProvider` supports using xref:backup-restore/modes.adoc#differential-backup[differential backups] as seeds.
+With the provided differential backup, the `CloudSeedProvider` searches the directory containing differential backups for a xref:backup-restore/online-backup.adoc#backup-chain[backup chain] ending at the specified differential backup, and then seeds using this backup chain.
 
 [.tabbed-example]
 =====
@@ -571,6 +571,30 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAcco
 ----
 ======
 =====
+
+The `CloudSeedProvider` supports seeding up to a specific date or transaction ID using the `seedRestoreUntil` option.
+
+==== Seed up to a specific date
+
+In order to seed up to a specific date you need to pass the differential backup that contains the data up to that date.
+
+[source,shell]
+----
+CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedRestoreUntil: datetime("2019-06-01T18:40:32.142+0100") }
+----
+
+This will seed the database with transactions committed before the provided timestamp.
+
+==== Seed up to a specific transaction ID
+
+In order to seed up to a specific transaction ID you need to pass the differential backup that contains the data up to that transaction ID.
+
+[source,shell]
+----
+CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedRestoreUntil: 123 }
+----
+
+This will seed the database with transactions up to, but not including, the transaction 123.
 
 ==== Seed provider reference
 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -609,7 +609,7 @@ This will seed the database with transactions up to, but not including transacti
 
 The `S3SeedProvider` supports:
 
-** `s3:`
+** `s3:` label:deprecated[Deprecated in 5.26]
 
 
 [NOTE]

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -517,6 +517,8 @@ The `URLConnectionSeedProvider` supports the following:
 ** `http:`
 ** `https:`
 
+Starting from Neo4j 2025.01, the `URLConnectionSeedProvider` does not support `file`.
+// This is true for both Cypher 5 and Cypher 25.
 [[cloud-seed-provider]]
 ==== CloudSeedProvider
 
@@ -578,7 +580,6 @@ The `CloudSeedProvider` supports seeding up to a specific date or transaction ID
 
 To seed up to a specific date, you need to pass the differential backup, which contains the data up to that date.
 
-** `s3:` label:deprecated[Deprecated in 5.26]
 
 [source,shell]
 ----
@@ -608,7 +609,6 @@ This will seed the database with transactions up to, but not including transacti
 
 | `file:`
 | `FileSeedProvider` +
-`URLConnectionSeedProvider` label:deprecated[Deprecated in 5.26]
 | `file:/tmp/backup1.backup`
 
 | `ftp:`

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -519,6 +519,7 @@ The `URLConnectionSeedProvider` supports the following:
 
 Starting from Neo4j 2025.01, the `URLConnectionSeedProvider` does not support `file`.
 // This is true for both Cypher 5 and Cypher 25.
+
 [[cloud-seed-provider]]
 ==== CloudSeedProvider
 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -576,9 +576,10 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAcco
 ======
 =====
 
-The `CloudSeedProvider` supports seeding up to a specific date or transaction ID using the `seedRestoreUntil` option.
+Starting from Neo4j 2025.01, the `CloudSeedProvider` supports seeding up to a specific date or transaction ID using the `seedRestoreUntil` option.
 
-==== Seed up to a specific date
+[role=label--new-2025.01]
+===== Seed up to a specific date
 
 To seed up to a specific date, you need to pass the differential backup, which contains the data up to that date.
 
@@ -590,7 +591,8 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBack
 
 This will seed the database with transactions committed before the provided timestamp.
 
-==== Seed up to a specific transaction ID
+[role=label--new-2025.01]
+===== Seed up to a specific transaction ID
 
 To seed up to a specific transaction ID, you need to pass the differential backup that contains the data up to that transaction ID.
 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -587,7 +587,7 @@ This will seed the database with transactions committed before the provided time
 
 ==== Seed up to a specific transaction ID
 
-In order to seed up to a specific transaction ID you need to pass the differential backup that contains the data up to that transaction ID.
+To seed up to a specific transaction ID, you need to pass the differential backup that contains the data up to that transaction ID.
 
 [source,shell]
 ----

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -576,7 +576,7 @@ The `CloudSeedProvider` supports seeding up to a specific date or transaction ID
 
 ==== Seed up to a specific date
 
-In order to seed up to a specific date you need to pass the differential backup that contains the data up to that date.
+To seed up to a specific date, you need to pass the differential backup, which contains the data up to that date.
 
 [source,shell]
 ----

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -468,11 +468,11 @@ SHOW DATABASE foo;
 === Seed from URI
 
 This method seeds all servers with an identical seed from an external source, specified by the URI.
-The seed can either be a full backup, a differential backup (xref:clustering/databases.adoc#cloud-seed-provider[`CloudSeedProvider`], introduced in Neo4j 5.26), or a dump from an existing database. 
+The seed can either be a full backup, a differential backup, or a dump from an existing database. 
 The sources of seeds are called _seed providers_.
 
 The mechanism is pluggable, allowing new sources of seeds to be supported (see link:https://www.neo4j.com/docs/java-reference/current/extending-neo4j/project-setup/#extending-neo4j-plugin-seed-provider[Java Reference -> Implement custom seed providers] for more information).
-The product has built-in support for seed from a mounted file system (file), FTP server, HTTP/HTTPS server, Amazon S3, Google Cloud Storage (from Neo4j 5.25), and Azure Cloud Storage (from Neo4j 5.25).
+The product has built-in support for seed from a mounted file system (file), FTP server, HTTP/HTTPS server, Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
 
 [NOTE]
 ====
@@ -504,7 +504,7 @@ To determine the cause of the problem, it is recommended to look at the `debug.l
 [[file-seed-provider]]
 ==== FileSeedProvider
 
-label:new[Introduced in 5.26], the `FileSeedProvider`  supports:
+The `FileSeedProvider`  supports:
 
 ** `file:` 
 
@@ -513,7 +513,6 @@ label:new[Introduced in 5.26], the `FileSeedProvider`  supports:
 
 The `URLConnectionSeedProvider` supports the following:
 
-** `file:` label:deprecated[Deprecated in 5.26]
 ** `ftp:`
 ** `http:`
 ** `https:`
@@ -521,13 +520,13 @@ The `URLConnectionSeedProvider` supports the following:
 [[cloud-seed-provider]]
 ==== CloudSeedProvider
 
-label:new[Introduced in 5.25], the `CloudSeedProvider` supports:
+The `CloudSeedProvider` supports:
 
 ** `s3:` 
 ** `gs:` 
 ** `azb:`
 
-Starting from Neo4j 5.26, the `CloudSeedProvider` supports using xref:backup-restore/modes.adoc#differential-backup[differential backup] files as seeds.
+The `CloudSeedProvider` supports using xref:backup-restore/modes.adoc#differential-backup[differential backup] files as seeds.
 With the provided differential backup file, the `CloudSeedProvider` searches the directory containing differential backup files for a xref:backup-restore/online-backup.adoc#backup-chain[backup chain] ending at the specified differential backup, and then seeds using this backup chain.
 
 [.tabbed-example]
@@ -573,44 +572,6 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAcco
 ======
 =====
 
-[[s3-seed-provider]]
-==== S3SeedProvider
-
-The `S3SeedProvider` supports:
-
-** `s3:` label:deprecated[Deprecated in 5.26] 
-
-
-[NOTE]
-====
-Neo4j 5 comes bundled with necessary libraries for AWS S3 connectivity.
-Therefore, if you use `S3SeedProvider`,`aws cli` is not required but can be used with the `CloudSeedProvider`.
-====
-
-The `S3SeedProvider` requires additional configuration.
-This is specified with the `seedConfig` option.
-This option expects a comma-separated list of configurations.
-Each configuration value is specified as a name followed by `=` and the value, as such:
-
-[source, cypher, role="noplay"]
-----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedConfig: 'region=eu-west-1' }
-----
-
-`S3SeedProvider` also requires passing in credentials.
-These are specified with the `seedCredentials` option.
-Seed credentials are securely passed from the Cypher command to each server hosting the database.
-For this to work, Neo4j on each server in the cluster must be configured with identical keystores.
-This is identical to the configuration required by remote aliases, see xref:database-administration/aliases/remote-database-alias-configuration.adoc#remote-alias-config-DBMS_admin-A[Configuration of DBMS with remote database alias].
-If this configuration is not performed, the `seedCredentials` option fails.
-
-[source, cypher, role="noplay"]
-----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedConfig: 'region=eu-west-1', seedCredentials: [accessKey];[secretKey] }
-----
-Where `accessKey` and `secretKey` are provided by AWS.
-
-
 ==== Seed provider reference
 
 [cols="1,2,2",options="header"]
@@ -620,8 +581,7 @@ Where `accessKey` and `secretKey` are provided by AWS.
 | URI example
 
 | `file:`
-| `URLConnectionSeedProvider` label:deprecated[Deprecated in 5.26], +
-`FileSeedProvider` label:new[Introduced in 5.26] 
+| `FileSeedProvider`
 | `file:/tmp/backup1.backup`
 
 | `ftp:`
@@ -637,16 +597,15 @@ Where `accessKey` and `secretKey` are provided by AWS.
 | `\https://myhttp.com/backups/backup1.backup`
 
 | `s3:`
-| `S3SeedProvider` label:deprecated[Deprecated in 5.26], +
-`CloudSeedProvider` label:new[Introduced in 5.25] 
+| `CloudSeedProvider`
 | `s3://mybucket/backups/backup1.backup`
 
 | `gs:`
-| `CloudSeedProvider` label:new[Introduced in 5.25] 
+| `CloudSeedProvider`
 | `gs://mybucket/backups/backup1.backup`
 
 | `azb:`
-| `CloudSeedProvider` label:new[Introduced in 5.25] 
+| `CloudSeedProvider`
 | `azb://mystorageaccount.blob/backupscontainer/backup1.backup`
 |===
 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -601,6 +601,45 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBack
 
 This will seed the database with transactions up to, but not including transaction 123.
 
+[role=label--deprecated]
+[[s3-seed-provider]]
+==== S3SeedProvider
+
+// When Cypher 25 is released, we have to label this section 'Cypher 5' as this functionality is only available in Cypher 5.
+
+The `S3SeedProvider` supports:
+
+** `s3:`
+
+
+[NOTE]
+====
+Neo4j 5 comes bundled with necessary libraries for AWS S3 connectivity.
+Therefore, if you use `S3SeedProvider`,`aws cli` is not required but can be used with the `CloudSeedProvider`.
+====
+
+The `S3SeedProvider` requires additional configuration.
+This is specified with the `seedConfig` option.
+This option expects a comma-separated list of configurations.
+Each configuration value is specified as a name followed by `=` and the value, as such:
+
+[source, cypher, role="noplay"]
+----
+CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedConfig: 'region=eu-west-1' }
+----
+
+`S3SeedProvider` also requires passing in credentials.
+These are specified with the `seedCredentials` option.
+Seed credentials are securely passed from the Cypher command to each server hosting the database.
+For this to work, Neo4j on each server in the cluster must be configured with identical keystores.
+This is identical to the configuration required by remote aliases, see xref:database-administration/aliases/remote-database-alias-configuration.adoc#remote-alias-config-DBMS_admin-A[Configuration of DBMS with remote database alias].
+If this configuration is not performed, the `seedCredentials` option fails.
+
+[source, cypher, role="noplay"]
+----
+CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedConfig: 'region=eu-west-1', seedCredentials: [accessKey];[secretKey] }
+----
+Where `accessKey` and `secretKey` are provided by AWS.
 ==== Seed provider reference
 
 [cols="1,2,2",options="header"]

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -594,7 +594,7 @@ To seed up to a specific transaction ID, you need to pass the differential backu
 CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBackup.backup', seedRestoreUntil: 123 }
 ----
 
-This will seed the database with transactions up to, but not including, the transaction 123.
+This will seed the database with transactions up to, but not including transaction 123.
 
 ==== Seed provider reference
 

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -531,7 +531,7 @@ With the provided differential backup, the `CloudSeedProvider` searches the dire
 
 [.tabbed-example]
 =====
-[role=include-with-AWS-S3 label--new-5.25]
+[role=include-with-AWS-S3]
 ======
 
 include::partial$/aws-s3-overrides.adoc[]
@@ -546,7 +546,7 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3:/myBucket/myBack
 ----
 
 ======
-[role=include-with-Google-cloud-storage label--new-5.25]
+[role=include-with-Google-cloud-storage]
 ======
 
 include::partial$/gcs-credentials.adoc[]
@@ -558,7 +558,7 @@ include::partial$/gcs-credentials.adoc[]
 CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'gs:/myBucket/myBackup.backup' }
 ----
 ======
-[role=include-with-Azure-cloud-storage label--new-5.25]
+[role=include-with-Azure-cloud-storage]
 ======
 
 include::partial$/azb-credentials.adoc[]


### PR DESCRIPTION
- Remove 5.x specific documentation from 'Seed from URI' section
- Add section on `seedRestoreUntil` option