### PR TITLE
Add description to fields in RaftedStatusCheck procedure

### DIFF
--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -58,7 +58,7 @@ The procedure returns a row for all primary members of all the requested databas
 | recognisedLeaderTerm  | Integer      | The term of the perceived leader of each primary member.
 If the members report different leaders, the one with the highest term should be trusted.
 | requester             | Boolean      | Whether a server is the requester or not.
-| error                 | String       | Contains any error message if present. An example of an error is that one or more of the requested databases do not exist on the requester.
+| error                 | String       | Contains any error message if present.
 An example of an error is that one or more of the requested databases do not exist on the requester.
 |===
 

--- a/modules/ROOT/pages/clustering/monitoring/status-check.adoc
+++ b/modules/ROOT/pages/clustering/monitoring/status-check.adoc
@@ -36,7 +36,7 @@ CALL dbms.cluster.statusCheck(databases :: LIST<STRING>, timeoutMilliseconds = n
 | Name                | Type         | Description
 | databases           | List<String> | Databases for which the status check should run.
 Providing an empty list runs the status check for all *clustered* databases on that server, i.e. it does not run on singles or secondaries.
-| timeoutMilliseconds | Integer | How long to allow for replication, before returning it was unsuccessful.
+| timeoutMilliseconds | Integer | Specifies the maximum wait time for replication before marking it unsuccessful.
 Default value is 1000 milliseconds.
 |===
 
@@ -58,7 +58,7 @@ The procedure returns a row for all primary members of all the requested databas
 | recognisedLeaderTerm  | Integer      | The term of the perceived leader of each primary member.
 If the members report different leaders, the one with the highest term should be trusted.
 | requester             | Boolean      | Whether a server is the requester or not.
-| error                 | String       | Contains the error message if one is present.
+| error                 | String       | Contains any error message if present. An example of an error is that one or more of the requested databases do not exist on the requester.
 An example of an error is that one or more of the requested databases do not exist on the requester.
 |===
 

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -636,19 +636,19 @@ It will still run with the `Admin` privilege, but that should be considered depr
 | *Syntax* 3+m| dbms.cluster.statusCheck(databases, timeoutMilliseconds) :: (database, serverId, serverName, address, replicationSuccessful, memberStatus, recognisedLeader, recognisedLeaderTerm, requester, error)
 | *Description* 3+a| Performs a rafted status check.
 .3+| *Input arguments* | *Name* | *Type* | *Description*
-| `databases` | `LIST<STRING>` | databases :: LIST<STRING>
-| `timeoutMilliseconds` | `INTEGER` | timeoutMilliseconds = null :: INTEGER
+| `databases` | `LIST<STRING>` | Databases for which the status check should run. Providing an empty list runs the status check for all clustered databases on that server, i.e. it does not run on singles or secondaries.
+| `timeoutMilliseconds` | `INTEGER` | How long to allow for replication, before returning it was unsuccessful. Default value is 1000 milliseconds.
 .11+| *Return arguments* | *Name* | *Type* | *Description*
-| `database` | `STRING` | database :: STRING
-| `serverId` | `STRING` | serverId :: STRING
-| `serverName` | `STRING` | serverName :: STRING
-| `address` | `STRING` | address :: STRING
-| `replicationSuccessful` | `BOOLEAN` | replicationSuccessful :: BOOLEAN
-| `memberStatus` | `STRING` | memberStatus :: STRING
-| `recognisedLeader` | `STRING` | recognisedLeader :: STRING
-| `recognisedLeaderTerm` | `INTEGER` | recognisedLeaderTerm :: INTEGER
-| `requester` | `BOOLEAN` | requester :: BOOLEAN
-| `error` | `STRING` | error :: STRING
+| `database` | `STRING` | The database for which a status check entry was replicated.
+| `serverId` | `STRING` | The UUID of the server, which did or did not participate in a successful replication of the status check entry.
+| `serverName` | `STRING` | The friendly name of the server, or its UUID if no name is set.
+| `address` | `STRING` | The address of the Bolt port for the server.
+| `replicationSuccessful` | `BOOLEAN` | Indicates if the server (on which the procedure is run) can replicate a transaction.
+| `memberStatus` | `STRING` | The status of each primary member.
+| `recognisedLeader` | `STRING` | The server id of the perceived leader of each primary member.
+| `recognisedLeaderTerm` | `INTEGER` | The term of the perceived leader of each primary member. If the members report different leaders, the one with the highest term should be trusted.
+| `requester` | `BOOLEAN` | Whether a server is the requester or not.
+| `error` | `STRING` | Contains the error message if one is present. An example of an error is that one or more of the requested databases do not exist on the requester.
 | *Mode* 3+| DBMS
 |===
 

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -637,7 +637,7 @@ It will still run with the `Admin` privilege, but that should be considered depr
 | *Description* 3+a| Performs a rafted status check.
 .3+| *Input arguments* | *Name* | *Type* | *Description*
 | `databases` | `LIST<STRING>` | Databases for which the status check should run. Providing an empty list runs the status check for all clustered databases on that server, i.e. it does not run on singles or secondaries.
-| `timeoutMilliseconds` | `INTEGER` | How long to allow for replication, before returning it was unsuccessful. Default value is 1000 milliseconds.
+| `timeoutMilliseconds` | `INTEGER` | Specifies the maximum wait time for replication before marking it unsuccessful. Default value is 1000 milliseconds.
 .11+| *Return arguments* | *Name* | *Type* | *Description*
 | `database` | `STRING` | The database for which a status check entry was replicated.
 | `serverId` | `STRING` | The UUID of the server, which did or did not participate in a successful replication of the status check entry.
@@ -648,7 +648,7 @@ It will still run with the `Admin` privilege, but that should be considered depr
 | `recognisedLeader` | `STRING` | The server id of the perceived leader of each primary member.
 | `recognisedLeaderTerm` | `INTEGER` | The term of the perceived leader of each primary member. If the members report different leaders, the one with the highest term should be trusted.
 | `requester` | `BOOLEAN` | Whether a server is the requester or not.
-| `error` | `STRING` | Contains the error message if one is present. An example of an error is that one or more of the requested databases do not exist on the requester.
+| `error` | `STRING` | Contains any error message if present. An example of an error is that one or more of the requested databases do not exist on the requester.
 | *Mode* 3+| DBMS
 |===
 


### PR DESCRIPTION
Related to https://github.com/neo-technology/neo4j/pull/28664
The description is copy-pasted from this other docs page: https://github.com/neo4j/docs-operations/blob/dev/modules/ROOT/pages/clustering/monitoring/status-check.adoc?plain=1