### PR TITLE
Tie up the Database internals section with the v4.4 (#1973)

### DIFF
--- a/modules/ROOT/pages/database-internals/checkpointing.adoc
+++ b/modules/ROOT/pages/database-internals/checkpointing.adoc
@@ -16,6 +16,11 @@ Pruning is reliant on checkpointing.
 Checkpointing determines which logs can be pruned and determines the occurrence of pruning, as the absence of a checkpoint implies that the set of transaction log files available for pruning cannot have changed.
 Consequently, pruning is triggered whenever checkpointing occurs.
 
+[NOTE]
+====
+For information on checkpointing and log pruning in Neo4j 4.4, refer to link:https://neo4j.com/docs/operations-manual/4.4/configuration/configuration-settings/#_checkpoint_settings[Configuration settings -> Checkpoint settings], link:https://neo4j.com/docs/operations-manual/4.4/performance/disks-ram-and-other-tips/#performance-checkpoint-iops-limit[Performance -> Checkpoint IOPS limit], and link:https://neo4j.com/docs/operations-manual/4.4/configuration/transaction-logs/#transaction-logging-log-pruning[Transaction log -> Log pruning] respectively.
+====
+
 [[checkpointing-policy]]
 == Configure the checkpointing policy
 

--- a/modules/ROOT/pages/database-internals/index.adoc
+++ b/modules/ROOT/pages/database-internals/index.adoc
@@ -25,3 +25,9 @@ The following sections describe the transactional behavior in detail and how to 
 * xref:database-internals/transaction-logs.adoc[]
 * xref:database-internals/checkpointing.adoc[]
 * xref:database-internals/store-formats.adoc[]
+
+[NOTE]
+====
+For information on Neo4j 4.4, see link:https://neo4j.com/docs/java-reference/4.4/transaction-management/[Java Reference 4.4 -> Transaction management].
+====
+

--- a/modules/ROOT/pages/database-internals/store-formats.adoc
+++ b/modules/ROOT/pages/database-internals/store-formats.adoc
@@ -1,5 +1,6 @@
-= Store formats
 :description: This page describes store formats in Neo4j.
+[[store-formats]]
+= Store formats
 
 Neo4j's storage engine supports several store formats that describe how data is written to disk.
 Starting from 5.23, `block` format is the recommended format for Enterprise Edition due to its superior performance and scalability.
@@ -10,6 +11,11 @@ Starting from 5.23, `block` format is the recommended format for Enterprise Edit
 `standard` and `high_limit` formats are deprecated starting from Neo4j 5.23.
 It is not recommended to use these formats for new databases.
 For more information on the deprecation and timeline for the eventual removal of these formats, see <<format-deprecations, Format deprecations>>.
+
+[NOTE]
+====
+For information on store formats in Neo4j 4.4, see link:https://neo4j.com/docs/operations-manual/4.4/tools/neo4j-admin/neo4j-admin-store-info/[Tools -> Neo4j Admin -> Display store information].
+====
 
 [[store-format-overview]]
 == Available store formats

--- a/modules/ROOT/pages/tutorial/tutorial-composite-database.adoc
+++ b/modules/ROOT/pages/tutorial/tutorial-composite-database.adoc
@@ -2,7 +2,7 @@
 [[tutorial-composite-database]]
 = Set up and use a Composite database
 :description: This tutorial walks through the basics of setting up and using a Composite database.
-:page-aliases: fabric-tutorial.adoc
+:page-aliases: tutorial/fabric-tutorial.adoc
 
 Composite databases allow queries that access multiple graphs at once.
 This is a function that enables:


### PR DESCRIPTION
The _Database internals_ section was created in 5.x. This means we don't have anything similar in the v4.4 docs.
Some of the pages can be linked to the Java Reference 4.4 and its section _Transaction management_.