### PR TITLE
Update REVOKE information to say that in cypher 25 you get errors for impossible revoke commands

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/database-administration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/database-administration.adoc
@@ -179,7 +179,7 @@ Use `REVOKE` if you want to remove a privilege.
 ====
 
 Common errors, such as misspellings or attempts to revoke privileges that have not been granted or denied, will lead to notifications.
-Notifications for impossible `REVOKE` commands where any of the user, role or database does not exist have been replaced with errors in Cypher 25.
+In Cypher 25, notifications for impossible `REVOKE` commands, where a user, a role, or a database does not exist, have been replaced with errors.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes for Errors & Notifications -> Server notifications] for details on notifications.
 
 The hierarchy between the different database privileges is shown in the image below.

--- a/modules/ROOT/pages/authentication-authorization/database-administration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/database-administration.adoc
@@ -179,7 +179,7 @@ Use `REVOKE` if you want to remove a privilege.
 ====
 
 Common errors, such as misspellings or attempts to revoke privileges that have not been granted or denied, will lead to notifications.
-Some of these notifications may be replaced with errors in a future major version of Neo4j.
+Some of these notifications have been replaced with errors in Cypher 25.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes for Errors & Notifications -> Server notifications] for details on notifications.
 
 The hierarchy between the different database privileges is shown in the image below.

--- a/modules/ROOT/pages/authentication-authorization/database-administration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/database-administration.adoc
@@ -179,7 +179,7 @@ Use `REVOKE` if you want to remove a privilege.
 ====
 
 Common errors, such as misspellings or attempts to revoke privileges that have not been granted or denied, will lead to notifications.
-Some of these notifications have been replaced with errors in Cypher 25.
+Notifications for impossible `REVOKE` commands where any of the user, role or database does not exist have been replaced with errors in Cypher 25.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes for Errors & Notifications -> Server notifications] for details on notifications.
 
 The hierarchy between the different database privileges is shown in the image below.

--- a/modules/ROOT/pages/authentication-authorization/manage-privileges.adoc
+++ b/modules/ROOT/pages/authentication-authorization/manage-privileges.adoc
@@ -197,7 +197,7 @@ Use `REVOKE` if you want to remove a privilege.
 ====
 
 Common errors, such as misspellings or attempts to revoke privileges that have not been granted or denied, will result in notifications.
-Some of these notifications have been replaced with errors in Cypher 25.
+Notifications for impossible `REVOKE` commands where any of the user, role or database does not exist have been replaced with errors in Cypher 25.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 
 The general `GRANT` and `DENY` syntaxes are illustrated in the following image:

--- a/modules/ROOT/pages/authentication-authorization/manage-privileges.adoc
+++ b/modules/ROOT/pages/authentication-authorization/manage-privileges.adoc
@@ -197,7 +197,7 @@ Use `REVOKE` if you want to remove a privilege.
 ====
 
 Common errors, such as misspellings or attempts to revoke privileges that have not been granted or denied, will result in notifications.
-Some of these notifications may be replaced with errors in a future major version of Neo4j.
+Some of these notifications have been replaced with errors in Cypher 25.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 
 The general `GRANT` and `DENY` syntaxes are illustrated in the following image:

--- a/modules/ROOT/pages/authentication-authorization/manage-privileges.adoc
+++ b/modules/ROOT/pages/authentication-authorization/manage-privileges.adoc
@@ -197,7 +197,7 @@ Use `REVOKE` if you want to remove a privilege.
 ====
 
 Common errors, such as misspellings or attempts to revoke privileges that have not been granted or denied, will result in notifications.
-Notifications for impossible `REVOKE` commands where any of the user, role or database does not exist have been replaced with errors in Cypher 25.
+In Cypher 25, notifications for impossible `REVOKE` commands, where a user, a role, or a database does not exist, have been replaced with errors.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 
 The general `GRANT` and `DENY` syntaxes are illustrated in the following image:

--- a/modules/ROOT/pages/authentication-authorization/manage-roles.adoc
+++ b/modules/ROOT/pages/authentication-authorization/manage-roles.adoc
@@ -814,7 +814,7 @@ REVOKE ROLES role1, role2 FROM user1, user2, user3
 ----
 
 Common errors, such as misspellings or attempts to revoke roles from users who have not been granted those roles, will lead to notifications.
-Notifications for impossible `REVOKE` commands where any of the user, role or database does not exist have been replaced with errors in Cypher 25.
+In Cypher 25, notifications for impossible `REVOKE` commands, where a user, a role, or a database does not exist, have been replaced with errors.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 
 [[access-control-drop-roles]]

--- a/modules/ROOT/pages/authentication-authorization/manage-roles.adoc
+++ b/modules/ROOT/pages/authentication-authorization/manage-roles.adoc
@@ -814,7 +814,7 @@ REVOKE ROLES role1, role2 FROM user1, user2, user3
 ----
 
 Common errors, such as misspellings or attempts to revoke roles from users who have not been granted those roles, will lead to notifications.
-Some of these notifications may be replaced with errors in a future major version of Neo4j.
+Some of these notifications have been replaced with errors in Cypher 25.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 
 [[access-control-drop-roles]]

--- a/modules/ROOT/pages/authentication-authorization/manage-roles.adoc
+++ b/modules/ROOT/pages/authentication-authorization/manage-roles.adoc
@@ -814,7 +814,7 @@ REVOKE ROLES role1, role2 FROM user1, user2, user3
 ----
 
 Common errors, such as misspellings or attempts to revoke roles from users who have not been granted those roles, will lead to notifications.
-Some of these notifications have been replaced with errors in Cypher 25.
+Notifications for impossible `REVOKE` commands where any of the user, role or database does not exist have been replaced with errors in Cypher 25.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 
 [[access-control-drop-roles]]


### PR DESCRIPTION
Not sure this is the right way to do it, mention Cypher 25 in the operations manual, or is there a way to specify which cypher version to see documentation for? 