### PR TITLE
Update lists of deprecated and removed procedures before 2025.01 and Cypher 25

### DIFF
--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -1884,34 +1884,34 @@ Besides, they can be removed in the future releases without replacement.
 | Enterprise Edition
 | Comment
 
-| xref:procedures.adoc#procedure_cdc_current[`cdc.current()`]
+| xref:procedures.adoc#procedure_cdc_current[`cdc.current()`] label:beta[]
 |
 | {check-mark}
-| label:beta[] label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
+| label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_current[`db.cdc.current()`]
 
-| xref:procedures.adoc#procedure_cdc_earliest[`cdc.earliest()`]
+| xref:procedures.adoc#procedure_cdc_earliest[`cdc.earliest()`] label:beta[]
 |
 | {check-mark}
-| label:beta[] label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
+| label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_earliest[`db.cdc.earliest()`]
 
-| xref:procedures.adoc#procedure_cdc_query[`cdc.query()`]
+| xref:procedures.adoc#procedure_cdc_query[`cdc.query()`] label:beta[] 
 |
 | {check-mark}
-| label:beta[] label:admin-only[] label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
+| label:admin-only[] label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_query[`db.cdc.query()`]
 
-| xref:procedures.adoc#procedure_db_create_setVectorProperty[`db.create.setVectorProperty()`]
+| xref:procedures.adoc#procedure_db_create_setVectorProperty[`db.create.setVectorProperty()`] label:beta[]
 | {check-mark}
 | {check-mark}
-| label:beta[] label:deprecated[Deprecated in Neo4j 5.13] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25] +
+| label:deprecated[Deprecated in Neo4j 5.13] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_create_setNodeVectorProperty[`db.create.setNodeVectorProperty()`]
 
-| xref:procedures.adoc#procedure_dbms_cluster_readreplicatoggle[`dbms.cluster.readReplicaToggle()`]
+| xref:procedures.adoc#procedure_dbms_cluster_readreplicatoggle[`dbms.cluster.readReplicaToggle()`] label:admin-only[]
 |
 | {check-mark}
-| label:admin-only[] label:deprecated[Deprecated since Neo4j 5.6] label:available[Available in Cypher 5 and Cypher 25] +
+| label:deprecated[Deprecated since Neo4j 5.6] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_dbms_cluster_secondaryreplicationdisable[`dbms.cluster.secondaryReplicationDisable()`].
 
 | xref:procedures.adoc#procedure_dbms_cluster_routing_getroutingtable[`dbms.cluster.routing.getRoutingTable()`]
@@ -1926,30 +1926,30 @@ Replaced by: xref:procedures.adoc#procedure_dbms_routing_getroutingtable[`dbms.r
 | label:deprecated[Deprecated since Neo4j 5.23] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25] +
 Replaced by xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE SERVER`].
 
-| xref:procedures.adoc#procedure_dbms_setDatabaseAllocator[`dbms.setDatabaseAllocator()`]
+| xref:procedures.adoc#procedure_dbms_setDatabaseAllocator[`dbms.setDatabaseAllocator()`] label:admin-only[]
 |
 | {check-mark}
-| label:admin-only[] label:deprecated[Deprecated in 5.23]
+| label:deprecated[Deprecated since Neo4j 5.23] label:available[Available in Cypher 5 and Cypher 25]
 
-| xref:procedures.adoc#procedure_dbms_upgrade[`dbms.upgrade()`]
+| xref:procedures.adoc#procedure_dbms_upgrade[`dbms.upgrade()`] label:admin-only[]
 | {check-mark}
 | {check-mark}
-| label:admin-only[] label:deprecated[Deprecated since Neo4j 5.9] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
+| label:deprecated[Deprecated since Neo4j 5.9] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
-| xref:procedures.adoc#procedure_dbms_upgradestatus[`dbms.upgradeStatus()`]
+| xref:procedures.adoc#procedure_dbms_upgradestatus[`dbms.upgradeStatus()`] label:admin-only[]
 | {check-mark}
 | {check-mark}
-| label:admin-only[] label:deprecated[Deprecated since Neo4j 5.9] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
+| label:deprecated[Deprecated since Neo4j 5.9] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
-| xref:procedures.adoc#procedure_db_index_vector_createnodeindex[`db.index.vector.createNodeIndex()`]
+| xref:procedures.adoc#procedure_db_index_vector_createnodeindex[`db.index.vector.createNodeIndex()`] label:admin-only[]
 | {check-mark}
 | {check-mark}
-| label:admin-only[] label:deprecated[Deprecated since Neo4j 5.26] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
+| label:deprecated[Deprecated since Neo4j 5.26] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
-| xref:procedures.adoc#procedure_dbms_quarantineDatabase[`dbms.quarantineDatabase()`]
+| xref:procedures.adoc#procedure_dbms_quarantineDatabase[`dbms.quarantineDatabase()`] label:admin-only[]
 |
 | {check-mark}
-| label:admin-only[] label:deprecated[Deprecated in 2025.01] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
+| label:deprecated[Deprecated in 2025.01] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
 |===
 

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -1884,43 +1884,43 @@ Besides, they can be removed in the future releases without replacement.
 | xref:procedures.adoc#procedure_cdc_current[`cdc.current()`]
 | label:no[]
 | label:yes[]
-| label:beta[] label:deprecated[Deprecated in Cypher 5] label:deprecated[Deprecated in Cypher 25] +
+| label:beta[] label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_current[`db.cdc.current()`]
 
 | xref:procedures.adoc#procedure_cdc_earliest[`cdc.earliest()`]
 | label:no[]
 | label:yes[]
-| label:beta[] label:deprecated[Deprecated in Cypher 5] label:deprecated[Deprecated in Cypher 25] +
+| label:beta[] label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_earliest[`db.cdc.earliest()`]
 
 | xref:procedures.adoc#procedure_cdc_query[`cdc.query()`]
 | label:no[]
 | label:yes[]
-| label:beta[] label:admin-only[] label:deprecated[Deprecated in Cypher 5] label:deprecated[Deprecated in Cypher 25] +
+| label:beta[] label:admin-only[] label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_query[`db.cdc.query()`]
 
 | xref:procedures.adoc#procedure_db_create_setVectorProperty[`db.create.setVectorProperty()`]
 | label:yes[]
 | label:yes[]
-| label:beta[] label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25] +
+| label:beta[] label:deprecated[Deprecated in Neo4j 5.13] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_create_setNodeVectorProperty[`db.create.setNodeVectorProperty()`]
 
 | xref:procedures.adoc#procedure_dbms_cluster_readreplicatoggle[`dbms.cluster.readReplicaToggle()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[] label:deprecated[Deprecated in Cypher 5] label:deprecated[Deprecated in Cypher 25] +
+| label:admin-only[] label:deprecated[Deprecated since Neo4j 5.6] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_dbms_cluster_secondaryreplicationdisable[`dbms.cluster.secondaryReplicationDisable()`].
 
 | xref:procedures.adoc#procedure_dbms_cluster_routing_getroutingtable[`dbms.cluster.routing.getRoutingTable()`]
 | label:yes[]
 | label:yes[]
-| label:deprecated[Deprecated in Cypher 5] label:deprecated[Deprecated in Cypher 25] +
+| label:deprecated[Deprecated since Neo4j 5.21] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_dbms_routing_getroutingtable[`dbms.routing.getRoutingTable()`].
 
 | xref:procedures.adoc#procedure_dbms_cluster_uncordonServer[`dbms.cluster.uncordonServer()`]
 | label:no[]
 | label:yes[]
-| label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25] +
+| label:deprecated[Deprecated since Neo4j 5.23] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25] +
 Replaced by xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE SERVER`].
 
 | xref:procedures.adoc#procedure_dbms_setDatabaseAllocator[`dbms.setDatabaseAllocator()`]
@@ -1931,22 +1931,22 @@ Replaced by xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE 
 | xref:procedures.adoc#procedure_dbms_upgrade[`dbms.upgrade()`]
 | label:yes[]
 | label:yes[]
-| label:admin-only[] label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25]
+| label:admin-only[] label:deprecated[Deprecated since Neo4j 5.9] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
 | xref:procedures.adoc#procedure_dbms_upgradestatus[`dbms.upgradeStatus()`]
 | label:yes[]
 | label:yes[]
-| label:admin-only[] label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25]
+| label:admin-only[] label:deprecated[Deprecated since Neo4j 5.9] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
 | xref:procedures.adoc#procedure_db_index_vector_createnodeindex[`db.index.vector.createNodeIndex()`]
 | label:yes[]
 | label:yes[]
-| label:admin-only[] label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25]
+| label:admin-only[] label:deprecated[Deprecated since Neo4j 5.26] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
 | xref:procedures.adoc#procedure_dbms_quarantineDatabase[`dbms.quarantineDatabase()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[] label:deprecated[Deprecated in 2025.01] label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25]
+| label:admin-only[] label:deprecated[Deprecated in 2025.01] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
 |===
 

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -2009,9 +2009,6 @@ Several procedures were removed with the 2025.01 release of Neo4j.
 |
 | {check-mark}
 | Removed without replacement
-
-
 |===
-
 ====
 

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -679,21 +679,6 @@ Since Neo4j 5.23, it can be run with the `SERVER MANAGEMENT` privilege.
 It will still run with the `Admin` privilege, but that should be considered deprecated.
 ====
 
-[role=label--enterprise-edition label--admin-only label--deprecated-5.23]
-[[procedure_dbms_setDatabaseAllocator]]
-=== dbms.setDatabaseAllocator()
-
-
-.Details
-|===
-| *Syntax* 3+m| dbms.setDatabaseAllocator(allocator)
-| *Description* 3+a| With this method you can set the allocator that is responsible for selecting servers for hosting databases.
-.2+| *Input arguments* | *Name* | *Type* | *Description*
-| `allocator` | `STRING` | The name of the allocator.
-| *Mode* 3+| WRITE
-|===
-
-
 [role=label--enterprise-edition label--admin-only]
 [[procedure_dbms_setDefaultAllocationNumbers]]
 === dbms.setDefaultAllocationNumbers()
@@ -1963,11 +1948,6 @@ Replaced by: xref:procedures.adoc#procedure_dbms_routing_getroutingtable[`dbms.r
 | label:deprecated[Deprecated since Neo4j 5.23] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25] +
 Replaced by xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE SERVER`].
 
-| xref:procedures.adoc#procedure_dbms_setDatabaseAllocator[`dbms.setDatabaseAllocator()`] label:admin-only[]
-|
-| {check-mark}
-| label:deprecated[Deprecated since Neo4j 5.23] label:available[Available in Cypher 5 and Cypher 25]
-
 | xref:procedures.adoc#procedure_dbms_upgrade[`dbms.upgrade()`] label:admin-only[]
 | {check-mark}
 | {check-mark}
@@ -2024,6 +2004,12 @@ Several procedures were removed with the 2025.01 release of Neo4j.
 |
 | {check-mark}
 | Removed without replacement
+
+| link:{neo4j-docs-base-uri}/operations-manual/5/procedures/#procedure_dbms_setDatabaseAllocator[`dbms.setDatabaseAllocator()`] label:admin-only[]
+|
+| {check-mark}
+| Removed without replacement
+
 
 |===
 

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -27,7 +27,7 @@ This page provides a complete reference to Neo4j's built-in procedures.
 // * <<#_transaction_management,Transaction management>>
 
 
-It also lists current xref:procedures.adoc#deprecated-procedures[deprecated procedures] and the xref:procedures.adoc#removed-procedures[procedures removed in Neo4j 5], along with their replacements.
+It also lists current xref:procedures.adoc#deprecated-procedures[deprecated procedures] and the xref:procedures.adoc#removed-procedures[procedures removed in Neo4j 2025.01].
 
 The available procedures on a server depends on several factors:
 
@@ -1867,9 +1867,9 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 [[deprecated-procedures]]
 == List of deprecated procedures
 
-Neo4j 5 contains several deprecated procedures.
-These procedures have been replaced either by Cypher commands or different procedures.
-The procedures deprecated in Neo4j 5 will be removed in the next major release of Neo4j.
+Deprecated procedures may be replaced either by Cypher commands or different procedures.
+Besides, they can be removed in the future releases without replacement.
+
 
 .See all deprecated procedures
 [%collapsible]
@@ -1884,45 +1884,43 @@ The procedures deprecated in Neo4j 5 will be removed in the next major release o
 | xref:procedures.adoc#procedure_cdc_current[`cdc.current()`]
 | label:no[]
 | label:yes[]
-| label:new[Introduced in 5.13] label:beta[] label:deprecated[Deprecated in 5.17]
+| label:beta[] label:deprecated[Deprecated in Cypher 5] label:deprecated[Deprecated in Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_current[`db.cdc.current()`]
 
 | xref:procedures.adoc#procedure_cdc_earliest[`cdc.earliest()`]
 | label:no[]
 | label:yes[]
-| label:new[Introduced in 5.13] label:beta[] label:deprecated[Deprecated in 5.17]
+| label:beta[] label:deprecated[Deprecated in Cypher 5] label:deprecated[Deprecated in Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_earliest[`db.cdc.earliest()`]
 
 | xref:procedures.adoc#procedure_cdc_query[`cdc.query()`]
 | label:no[]
 | label:yes[]
-| label:new[Introduced in 5.13] label:beta[] label:admin-only[] label:deprecated[Deprecated in 5.17]
+| label:beta[] label:admin-only[] label:deprecated[Deprecated in Cypher 5] label:deprecated[Deprecated in Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_query[`db.cdc.query()`]
 
 | xref:procedures.adoc#procedure_db_create_setVectorProperty[`db.create.setVectorProperty()`]
 | label:yes[]
 | label:yes[]
-| label:new[Introduced in 5.11] label:beta[] label:deprecated[Deprecated in 5.13] Replaced by: xref:procedures.adoc#procedure_db_create_setNodeVectorProperty[`db.create.setNodeVectorProperty()`]
+| label:beta[] label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25] +
+Replaced by: xref:procedures.adoc#procedure_db_create_setNodeVectorProperty[`db.create.setNodeVectorProperty()`]
 
-// New in 4.2
-// com.neo4j.causaulclustering.discovery.procedures.ReadReplicaToggleProcedure
 | xref:procedures.adoc#procedure_dbms_cluster_readreplicatoggle[`dbms.cluster.readReplicaToggle()`]
 | label:no[]
 | label:yes[]
-| label:admin-only[] label:deprecated[Deprecated in 5.6]. +
+| label:admin-only[] label:deprecated[Deprecated in Cypher 5] label:deprecated[Deprecated in Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_dbms_cluster_secondaryreplicationdisable[`dbms.cluster.secondaryReplicationDisable()`].
 
 | xref:procedures.adoc#procedure_dbms_cluster_routing_getroutingtable[`dbms.cluster.routing.getRoutingTable()`]
 | label:yes[]
 | label:yes[]
-| label:deprecated[Deprecated in 5.21]. +
+| label:deprecated[Deprecated in Cypher 5] label:deprecated[Deprecated in Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_dbms_routing_getroutingtable[`dbms.routing.getRoutingTable()`].
 
 | xref:procedures.adoc#procedure_dbms_cluster_uncordonServer[`dbms.cluster.uncordonServer()`]
 | label:no[]
 | label:yes[]
-| label:deprecated[Deprecated in 5.23]. +
-Before Neo4j 5.23, the procedure can be run only with the `Admin` privileges. +
+| label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25] +
 Replaced by xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE SERVER`].
 
 | xref:procedures.adoc#procedure_dbms_setDatabaseAllocator[`dbms.setDatabaseAllocator()`]
@@ -1930,17 +1928,25 @@ Replaced by xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE 
 | label:yes[]
 | label:admin-only[] label:deprecated[Deprecated in 5.23]
 
-// New in 4.1
 | xref:procedures.adoc#procedure_dbms_upgrade[`dbms.upgrade()`]
 | label:yes[]
 | label:yes[]
-| label:admin-only[] label:deprecated[Deprecated in 5.9]
+| label:admin-only[] label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25]
 
-// New in 4.1
 | xref:procedures.adoc#procedure_dbms_upgradestatus[`dbms.upgradeStatus()`]
 | label:yes[]
 | label:yes[]
-| label:admin-only[] label:deprecated[Deprecated in 5.9]
+| label:admin-only[] label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25]
+
+| xref:procedures.adoc#procedure_db_index_vector_createnodeindex[`db.index.vector.createNodeIndex()`]
+| label:yes[]
+| label:yes[]
+| label:admin-only[] label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25]
+
+| xref:procedures.adoc#procedure_dbms_quarantineDatabase[`dbms.quarantineDatabase()`]
+| label:no[]
+| label:yes[]
+| label:admin-only[] label:deprecated[Deprecated in 2025.01] label:deprecated[Deprecated in Cypher 5] label:removed[Removed in Cypher 25]
 
 |===
 
@@ -1949,10 +1955,10 @@ Replaced by xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE 
 [[removed-procedures]]
 == List of removed procedures
 
-Several procedures were removed with the release of Neo4j.
-They were functionally replaced by Cypher commands or different procedures.
+Several procedures were removed with the 2025.01 release of Neo4j.
 
-.See all procedures removed in Neo4j 5.0 and their replacements
+
+.See all procedures removed in Neo4j 2025.01
 [%collapsible]
 ====
 
@@ -1961,221 +1967,22 @@ They were functionally replaced by Cypher commands or different procedures.
 | Name
 | Community Edition
 | Enterprise Edition
-| Replaced by
+| Notes
 
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_db_constraints[`db.constraints()`]
-| label:yes[]
-| label:yes[]
-| `SHOW CONSTRAINTS`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_db_createindex[`db.createIndex()`]
-| label:yes[]
-| label:yes[]
-| `CREATE INDEX`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_db_createnodekey[`db.createNodeKey()`]
+| link:{neo4j-docs-base-uri}/operations-manual/5/procedures/#procedure_dbms_cluster_movetonextdiscoveryversion[`dbms.cluster.moveToNextDiscoveryVersion()`]
 | label:no[]
 | label:yes[]
-| `CREATE CONSTRAINT ... IS NODE KEY`
+| Removed without replacement
 
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_db_createuniquepropertyconstraint[`db.createUniquePropertyConstraint()`]
-| label:yes[]
-| label:yes[]
-| `CREATE CONSTRAINT ... IS UNIQUE`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_db_indexes[`db.indexes()`]
-| label:yes[]
-| label:yes[]
-| `SHOW INDEXES`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_db_indexdetails[`db.indexDetails()`]
-| label:yes[]
-| label:yes[]
-| `SHOW INDEXES YIELD*`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_db_index_fulltext_createnodeindex[`db.index.fulltext.createNodeIndex()`]
-| label:yes[]
-| label:yes[]
-| `CREATE FULLTEXT INDEX ...`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_db_index_fulltext_createrelationshipindex[`db.index.fulltext.createRelationshipIndex()`]
-| label:yes[]
-| label:yes[]
-| `CREATE FULLTEXT INDEX ...`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_db_index_fulltext_drop[`db.index.fulltext.drop()`]
-| label:yes[]
-| label:yes[]
-| `DROP INDEX ...`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_db_schemastatements[`db.schemaStatements()`]
-| label:yes[]
-| label:yes[]
-| `SHOW INDEXES YIELD *` and `SHOW CONSTRAINTS YIELD *`
-
-// New in 4.0
-// com.neo4j.causaulclustering.discovery.procedures.ClusterOverviewProcedure
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_cluster_overview[`dbms.cluster.overview()`]
+| link:{neo4j-docs-base-uri}/operations-manual/5/procedures/#procedure_dbms_cluster_showparalleldiscoverystate[`dbms.cluster.showParallelDiscoveryState()`]
 | label:no[]
 | label:yes[]
-| `SHOW SERVERS`
+| Removed without replacement
 
-
-// New in 4.2
-// com.neo4j.dbms.procedures.QuarantineProcedure
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_cluster_quarantinedatabase[`dbms.cluster.quarantineDatabase()`]
+| link:{neo4j-docs-base-uri}/operations-manual/5/procedures/#procedure_dbms_cluster_switchdiscoveryserviceversion[`dbms.cluster.switchDiscoveryServiceVersion()`]
 | label:no[]
 | label:yes[]
-| `dbms.quarantineDatabase()`
-
-
-// New in 4.0
-// Removed in 5.0
-// com.neo4j.causaulclustering.discovery.procedures.RoleProcedure
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_cluster_role[`dbms.cluster.role()`]
-| label:no[]
-| label:yes[]
-| `SHOW DATABASES`
-
-// New in 4.1
-// Removed in 5.0
-// com.neo4j.dbms.procedures.ClusterSetDefaultDatabaseProcedure
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_cluster_setdefaultdatabase[`dbms.cluster.setDefaultDatabase()`]
-| label:no[]
-| label:yes[]
-| `dbms.setDefaultDatabase`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_database_state[`dbms.database.state()`]
-| label:yes[]
-| label:yes[]
-| `SHOW DATABASES`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_functions[`dbms.functions()`]
-| label:yes[]
-| label:yes[]
-| `SHOW FUNCTIONS`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_killqueries[`dbms.killQueries()`]
-| label:yes[]
-| label:yes[]
-| `TERMINATE TRANSACTIONS`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_killquery[`dbms.killQuery()`]
-| label:yes[]
-| label:yes[]
-| `TERMINATE TRANSACTIONS`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_killtransaction[`dbms.killTransaction()`]
-| label:yes[]
-| label:yes[]
-| `TERMINATE TRANSACTIONS`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_killtransactions[`dbms.killTransactions()`]
-| label:yes[]
-| label:yes[]
-| `TERMINATE TRANSACTIONS`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_listqueries[`dbms.listQueries()`]
-| label:yes[]
-| label:yes[]
-| `SHOW TRANSACTIONS`
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_listtransactions[`dbms.listTransactions()`]
-| label:yes[]
-| label:yes[]
-| `SHOW TRANSACTIONS`
-
-
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_procedures[`dbms.procedures()`]
-| label:no[]
-| label:yes[]
-| `SHOW PROCEDURES`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_activateuser[`dbms.security.activateUser()`]
-| label:no[]
-| label:yes[]
-| `ALTER USER`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_addroletouser[`dbms.security.addRoleToUser()`]
-| label:no[]
-| label:yes[]
-| `GRANT ROLE TO USER`
-
-// Removed in 5.0
-// newSet( READER, EDITOR, PUBLISHER, ARCHITECT, ADMIN )
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_changepassword[`dbms.security.changePassword()`]
-| label:yes[]
-| label:yes[]
-| `ALTER CURRENT USER SET PASSWORD`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_changeuserpassword[`dbms.security.changeUserPassword()`]
-| label:no[]
-| label:yes[]
-| `ALTER USER`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_createrole[`dbms.security.createRole()`]
-| label:no[]
-| label:yes[]
-| `CREATE ROLE`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_createuser[`dbms.security.createUser()`]
-| label:yes[]
-| label:yes[]
-| `CREATE USER`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_deleterole[`dbms.security.deleteRole()`]
-| label:no[]
-| label:yes[]
-| `DROP ROLE`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_deleteuser[`dbms.security.deleteUser()`]
-| label:yes[]
-| label:yes[]
-| `DROP USER`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_listroles[`dbms.security.listRoles()`]
-| label:yes[]
-| label:yes[]
-| `SHOW ROLES`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_listrolesforuser[`dbms.security.listRolesForUser()`]
-| label:no[]
-| label:yes[]
-| `SHOW USERS`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_listusers[`dbms.security.listUsers()`]
-| label:yes[]
-| label:yes[]
-| `SHOW USERS`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_listusersforrole[`dbms.security.listUsersForRole()`]
-| label:no[]
-| label:yes[]
-| `SHOW ROLES WITH USERS`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_removerolefromuser[`dbms.security.removeRoleFromUser()`]
-| label:no[]
-| label:yes[]
-| `REVOKE ROLE FROM USER`
-
-// Removed in 5.0
-| link:{neo4j-docs-base-uri}/operations-manual/4.4/reference/#procedure_dbms_security_suspenduser[`dbms.security.suspendUser()`]
-| label:no[]
-| label:yes[]
-| `ALTER USER`
+| Removed without replacement
 
 |===
 

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -8,6 +8,9 @@
 :stem:
 :mathjax-tex-packages: ams
 
+//Check Mark
+:check-mark: icon:check[]
+
 This page provides a complete reference to Neo4j's built-in procedures.
 // The procedures are grouped into the following categories:
 
@@ -1882,70 +1885,70 @@ Besides, they can be removed in the future releases without replacement.
 | Comment
 
 | xref:procedures.adoc#procedure_cdc_current[`cdc.current()`]
-| label:no[]
-| label:yes[]
+|
+| {check-mark}
 | label:beta[] label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_current[`db.cdc.current()`]
 
 | xref:procedures.adoc#procedure_cdc_earliest[`cdc.earliest()`]
-| label:no[]
-| label:yes[]
+|
+| {check-mark}
 | label:beta[] label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_earliest[`db.cdc.earliest()`]
 
 | xref:procedures.adoc#procedure_cdc_query[`cdc.query()`]
-| label:no[]
-| label:yes[]
+|
+| {check-mark}
 | label:beta[] label:admin-only[] label:deprecated[Deprecated since Neo4j 5.17] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_cdc_query[`db.cdc.query()`]
 
 | xref:procedures.adoc#procedure_db_create_setVectorProperty[`db.create.setVectorProperty()`]
-| label:yes[]
-| label:yes[]
+| {check-mark}
+| {check-mark}
 | label:beta[] label:deprecated[Deprecated in Neo4j 5.13] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_db_create_setNodeVectorProperty[`db.create.setNodeVectorProperty()`]
 
 | xref:procedures.adoc#procedure_dbms_cluster_readreplicatoggle[`dbms.cluster.readReplicaToggle()`]
-| label:no[]
-| label:yes[]
+|
+| {check-mark}
 | label:admin-only[] label:deprecated[Deprecated since Neo4j 5.6] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_dbms_cluster_secondaryreplicationdisable[`dbms.cluster.secondaryReplicationDisable()`].
 
 | xref:procedures.adoc#procedure_dbms_cluster_routing_getroutingtable[`dbms.cluster.routing.getRoutingTable()`]
-| label:yes[]
-| label:yes[]
+| {check-mark}
+| {check-mark}
 | label:deprecated[Deprecated since Neo4j 5.21] label:available[Available in Cypher 5 and Cypher 25] +
 Replaced by: xref:procedures.adoc#procedure_dbms_routing_getroutingtable[`dbms.routing.getRoutingTable()`].
 
 | xref:procedures.adoc#procedure_dbms_cluster_uncordonServer[`dbms.cluster.uncordonServer()`]
-| label:no[]
-| label:yes[]
+|
+| {check-mark}
 | label:deprecated[Deprecated since Neo4j 5.23] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25] +
 Replaced by xref:clustering/server-syntax.adoc#server-management-syntax[`ENABLE SERVER`].
 
 | xref:procedures.adoc#procedure_dbms_setDatabaseAllocator[`dbms.setDatabaseAllocator()`]
-| label:no[]
-| label:yes[]
+|
+| {check-mark}
 | label:admin-only[] label:deprecated[Deprecated in 5.23]
 
 | xref:procedures.adoc#procedure_dbms_upgrade[`dbms.upgrade()`]
-| label:yes[]
-| label:yes[]
+| {check-mark}
+| {check-mark}
 | label:admin-only[] label:deprecated[Deprecated since Neo4j 5.9] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
 | xref:procedures.adoc#procedure_dbms_upgradestatus[`dbms.upgradeStatus()`]
-| label:yes[]
-| label:yes[]
+| {check-mark}
+| {check-mark}
 | label:admin-only[] label:deprecated[Deprecated since Neo4j 5.9] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
 | xref:procedures.adoc#procedure_db_index_vector_createnodeindex[`db.index.vector.createNodeIndex()`]
-| label:yes[]
-| label:yes[]
+| {check-mark}
+| {check-mark}
 | label:admin-only[] label:deprecated[Deprecated since Neo4j 5.26] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
 | xref:procedures.adoc#procedure_dbms_quarantineDatabase[`dbms.quarantineDatabase()`]
-| label:no[]
-| label:yes[]
+|
+| {check-mark}
 | label:admin-only[] label:deprecated[Deprecated in 2025.01] label:available[Available in Cypher 5] label:removed[Removed in Cypher 25]
 
 |===
@@ -1970,18 +1973,18 @@ Several procedures were removed with the 2025.01 release of Neo4j.
 | Notes
 
 | link:{neo4j-docs-base-uri}/operations-manual/5/procedures/#procedure_dbms_cluster_movetonextdiscoveryversion[`dbms.cluster.moveToNextDiscoveryVersion()`]
-| label:no[]
-| label:yes[]
+|
+| {check-mark}
 | Removed without replacement
 
 | link:{neo4j-docs-base-uri}/operations-manual/5/procedures/#procedure_dbms_cluster_showparalleldiscoverystate[`dbms.cluster.showParallelDiscoveryState()`]
-| label:no[]
-| label:yes[]
+|
+| {check-mark}
 | Removed without replacement
 
 | link:{neo4j-docs-base-uri}/operations-manual/5/procedures/#procedure_dbms_cluster_switchdiscoveryserviceversion[`dbms.cluster.switchDiscoveryServiceVersion()`]
-| label:no[]
-| label:yes[]
+|
+| {check-mark}
 | Removed without replacement
 
 |===


### PR DESCRIPTION
An attempt to understand which information to display in the 2025.01 docs to make it clear for users how to use procedures with new Cypher versions.