### PR TITLE
Comment out the note about Cypher 25 database names with dots

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
@@ -20,9 +20,13 @@ Support for database names starting with a numeric character is available from N
 The `-` (dash) and `.` (dot) characters are not legal in Cypher variables.
 Names containing a `-` or that begin with a numeric character must be enclosed within backticks.
 For example, `CREATE DATABASE ++`main-db`++` is a valid database name.
-In Cypher 25, names that contain a dot (`.`) must be quoted in backticks.
-However, using dots in database names is not recommended, as it makes it difficult to determine if a dot is part of the database name or a delimiter for a database alias in a composite database.
-A future version of Neo4j may entirely disallow database names with dots.
+//Remove the following line and uncomment the rest when Cypher 25 is released.
+Database names are the only identifier for which dots do not need to be quoted.
+For example `main.db` is a valid database name.
+However, this behavior is deprecated due to the difficulty of determining if a dot is part of the database name or a delimiter for a database alias in a composite database.
+//In Cypher 25, names that contain a dot (`.`) must be quoted in backticks.
+//However, using dots in database names is not recommended, as it makes it difficult to determine if a dot is part of the database name or a delimiter for a database alias in a composite database.
+//A future version of Neo4j may entirely disallow database names with dots.
 ====
 
 It is possible to create an alias to refer to an existing database to avoid these restrictions.


### PR DESCRIPTION
https://github.com/neo4j/docs-operations/pull/1948/files had been merged before we knew that Cypher 25 would not be released together with 2025.01. So, this PR comments out the note. 