### PR TITLE
Revert "Disallow unquoted database names with dot"

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
@@ -20,9 +20,9 @@ Support for database names starting with a numeric character is available from N
 The `-` (dash) and `.` (dot) characters are not legal in Cypher variables.
 Names containing a `-` or that begin with a numeric character must be enclosed within backticks.
 For example, `CREATE DATABASE ++`main-db`++` is a valid database name.
-In Cypher 25, names that contain a dot (`.`) must be quoted in backticks.
-However, using dots in database names is not recommended, as it makes it difficult to determine if a dot is part of the database name or a delimiter for a database alias in a composite database.
-A future version of Neo4j may entirely disallow database names with dots.
+Database names are the only identifier for which dots do not need to be quoted.
+For example `main.db` is a valid database name.
+However, this behavior is deprecated due to the difficulty of determining if a dot is part of the database name or a delimiter for a database alias in a composite database.
 ====
 
 It is possible to create an alias to refer to an existing database to avoid these restrictions.


### PR DESCRIPTION
Reverts neo4j/docs-operations#1948
Cypher 25 will not be released with 2025.01. I'll create a separate PR with this feature.