### PR TITLE
Remove deprecated 'group' settings - everything is 'tag' now

### DIFF
--- a/modules/ROOT/pages/clustering/clustering-advanced/multi-data-center-routing.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/multi-data-center-routing.adoc
@@ -297,13 +297,10 @@ These provide coarse-grained algorithms for selecting an upstream server:
 |===
 | Plugin name                                          | Resulting behavior
 | `connect-to-random-primary-server`                   | Connect to any *primary server* selecting at random from those currently available.
-| `typically-connect-to-random-secondary`           | Connect to any available *secondary server*, but around 10% of the time connect to any random primary server.
-| `connect-randomly-to-server-tags`                   | Connect at random to any available *secondary server* tagged with any of the server tags specified in the comma-separated list `server.cluster.catchup.connect_randomly_to_server_tags`.
+| `typically-connect-to-random-secondary`              | Connect to any available *secondary server*, but around 10% of the time connect to any random primary server.
+| `connect-randomly-to-server-tags`                    | Connect at random to any available *secondary server* tagged with any of the server tags specified in the comma-separated list `server.cluster.catchup.connect_randomly_to_server_tags`.
 | `leader-only`                                        | Connect only to the current Raft leader of the *primary servers*.
-| [deprecated]#`connect-randomly-to-server-group`# | [deprecated]#Connect at random to any available *secondary server* in the server groups specified in the comma-separated list `server.cluster.catchup.connect_randomly_to_server_group`.
-                                                         Deprecated, please use `connect-randomly-to-server-tags`.#
-| [deprecated]#`connect-randomly-within-server-group`# | [deprecated]#Connect at random to any available *secondary server* in any of the server groups to which this server belongs.
-                                                         Deprecated, please use `connect-randomly-to-server-tags`.#
+| `connect-randomly-within-server-tags`                | Connect at random to any available *secondary server* with any of the server tags which this server has.
 |===
 
 Pre-defined strategies are used by configuring the xref:configuration/configuration-settings.adoc#config_server.cluster.catchup.upstream_strategy[`server.cluster.catchup.upstream_strategy`] option.

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -246,22 +246,6 @@ m|+++2.00GiB+++
 |===
 
 
-[role="label--enterprise-edition label--deprecated-5.4"]
-[[config_db.cluster.raft.leader_transfer.priority_group]]
-=== `db.cluster.raft.leader_transfer.priority_group`
-
-.db.cluster.raft.leader_transfer.priority_group
-[frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
-|===
-|Description
-a|The name of a server_group whose members should be prioritized as leaders. This does not guarantee that the leader will always be a member of this group, but the cluster will attempt to transfer the leadership to such a member when possible. If a database is specified using `db.cluster.raft.leader_transfer.priority_group.<database>`, the specified priority group will apply to that database only. If no database is specified, that group will be the default and apply to all databases with no explicitly set priority group. Using this setting will disable leadership balancing.
-|Valid values
-a|A string identifying a server tag.
-|Default value
-m|++++++
-|===
-
-
 [role=label--enterprise-edition]
 [[config_db.cluster.raft.leader_transfer.priority_tag]]
 === `db.cluster.raft.leader_transfer.priority_tag`
@@ -630,7 +614,7 @@ m|+++20s-23s+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|Which strategy to use when transferring database leaderships around a cluster. Note that if a `leadership_priority_group` is specified for a given database, the value of this setting will be ignored for that database.
+a|Which strategy to use when transferring database leaderships around a cluster. Note that if a `leader_transfer.priority_tag` is specified for a given database, the value of this setting will be ignored for that database.
 The following values are available:
 
 * `equal_balancing` automatically ensures that each primary server holds the leader role for an equal number of databases.
@@ -882,22 +866,6 @@ m|+++:6000+++
 |===
 
 
-[role=label--enterprise-edition label--dynamic label--deprecated-5.4]
-[[config_server.cluster.catchup.connect_randomly_to_server_group]]
-=== `server.cluster.catchup.connect_randomly_to_server_group`
-
-.server.cluster.catchup.connect_randomly_to_server_group
-[frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
-|===
-|Description
-a|Comma-separated list of groups to be used by the connect-randomly-to-server-group selection strategy. The connect-randomly-to-server-group strategy is used when the list of strategies (`<<config_server.cluster.catchup.upstream_strategy,server.cluster.catchup.upstream_strategy>>`) includes the value `connect-randomly-to-server-group`.
-|Valid values
-a|A comma-separated list where each element is a string identifying a server tag.
-|Default value
-m|++++++
-|===
-
-
 [role=label--enterprise-edition label--dynamic]
 [[config_server.cluster.catchup.connect_randomly_to_server_tags]]
 === `server.cluster.catchup.connect_randomly_to_server_tags`
@@ -1039,24 +1007,6 @@ a|Host and port to bind the cluster member discovery management communication.
 a|A socket address in the format of `hostname:port`, `hostname`, or `:port`. If missing, it is acquired from server.default_listen_address.
 |Default value
 m|+++:5000+++
-|===
-
-
-[role=label--enterprise-edition label--deprecated-5.4]
-[[config_server.groups]]
-=== `server.groups`
-
-.server.groups
-[frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
-|===
-|Description
-a|A list of tag names for the server used when configuring load balancing and replication policies.
-|Valid values
-a|A comma-separated list where each element is a string identifying a server tag.
-|Default value
-m|++++++
-|Replaced by
-m|initial.server.tags
 |===
 
 == Connection settings

--- a/modules/ROOT/pages/configuration/dynamic-settings.adoc
+++ b/modules/ROOT/pages/configuration/dynamic-settings.adoc
@@ -77,7 +77,6 @@ RETURN name
 | "dbms.security.ldap.authorization.nested_groups_search_filter" |
 | "dbms.security.ldap.authorization.user_search_base"            |
 | "dbms.security.ldap.authorization.user_search_filter"          |
-| "server.cluster.catchup.connect_randomly_to_server_group"      |
 | "server.cluster.catchup.connect_randomly_to_server_tags"       |
 | "server.databases.default_to_read_only"                        |
 | "server.databases.read_only"                                   |

--- a/modules/ROOT/pages/docker/ref-settings.adoc
+++ b/modules/ROOT/pages/docker/ref-settings.adoc
@@ -70,9 +70,6 @@ For more information on the configuration descriptions, valid values, and defaul
 | `db.cluster.raft.in_queue.max_bytes`
 | `+NEO4J_db_cluster_raft_in__queue_max__bytes+`
 
-| `db.cluster.raft.leader_transfer.priority_group`
-| `+NEO4J_db_cluster_raft_leader__transfer_priority__group+`
-
 | `db.cluster.raft.log.prune_strategy`
 | `+NEO4J_db_cluster_raft_log_prune__strategy+`
 
@@ -640,9 +637,6 @@ For more information on the configuration descriptions, valid values, and defaul
 | `server.cluster.advertised_address`
 | `+NEO4J_server_cluster_advertised__address+`
 
-| `server.cluster.catchup.connect_randomly_to_server_group`
-| `+NEO4J_server_cluster_catchup_connect__randomly__to__server__group+`
-
 | `server.cluster.catchup.upstream_strategy`
 | `+NEO4J_server_cluster_catchup_upstream__strategy+`
 
@@ -732,9 +726,6 @@ For more information on the configuration descriptions, valid values, and defaul
 
 | `server.dynamic.setting.allowlist`
 | `+NEO4J_server_dynamic_setting_allowlist+`
-
-| `server.groups`
-| `+NEO4J_server_groups+`
 
 | `server.http.advertised_address`
 | `+NEO4J_server_http_advertised__address+`


### PR DESCRIPTION
The settings will still be migrated to the new ones if used, for now. But we should remove them from the docs.