### PR TITLE
Remove deprecated and removed Cluster metrics

### DIFF
--- a/modules/ROOT/pages/monitoring/metrics/reference.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/reference.adoc
@@ -452,99 +452,6 @@ label:deprecated[Deprecated in 5.15]
 |<prefix>.cluster.discovery.memberset.unreachable|Number of unreachable cluster members. (gauge)
 |===
 
-[[raft-core-metrics]]
-=== Raft core metrics
-
-label:deprecated[Deprecated in 5.0]
-
-.Raft core metrics
-[options="header",cols="<3m,<4"]
-|===
-|Name
-|Description
-
-|<prefix>.causal_clustering.core.append_index
-|The append index of the Raft log. Each index represents a write transaction (possibly internal) proposed for commitment. The values mostly increase, but sometimes they can decrease as a consequence of leader changes. The append index should always be bigger than or equal to the commit index. (gauge)
-
-|<prefix>.causal_clustering.core.commit_index
-|The commit index of the Raft log. Represents the commitment of previously appended entries. Its value increases monotonically if you do not unbind the cluster state. The commit index should always be less than or equal to the append index and bigger than or equal to the applied index. (gauge)
-
-|<prefix>.causal_clustering.core.applied_index
-|The applied index of the Raft log. Represents the application of the committed Raft log entries to the database and internal state. The applied index should always be less than or equal to the commit index. The difference between this and the commit index can be used to monitor how up-to-date the follower database is. (gauge)
-
-|<prefix>.causal_clustering.core.term
-|The Raft Term of this server. It increases monotonically if you do not unbind the cluster state. (gauge)
-
-|<prefix>.causal_clustering.core.tx_retries
-|Transaction retries. (counter)
-
-|<prefix>.causal_clustering.core.is_leader
-|Is this server the leader? Track this for each Core cluster member. It will report 0 if it is not the leader and 1 if it is the leader. The sum of all of these should always be 1. However, there will be transient periods in which the sum can be more than 1 because more than one member thinks it is the leader. Action may be needed if the metric shows 0 for more than 30 seconds. (gauge)
-
-|<prefix>.causal_clustering.core.in_flight_cache.total_bytes
-|In-flight cache total bytes. (gauge)
-
-|<prefix>.causal_clustering.core.in_flight_cache.max_bytes
-|In-flight cache max bytes. (gauge)
-
-|<prefix>.causal_clustering.core.in_flight_cache.element_count
-|In-flight cache element count. (gauge)
-
-|<prefix>.causal_clustering.core.in_flight_cache.max_elements
-|In-flight cache maximum elements. (gauge)
-
-|<prefix>.causal_clustering.core.in_flight_cache.hits
-|In-flight cache hits. (counter)
-
-|<prefix>.causal_clustering.core.in_flight_cache.misses
-|In-flight cache misses. (counter)
-
-|<prefix>.causal_clustering.core.raft_log_entry_prefetch_buffer.lag
-|Raft Log Entry Prefetch Lag. (gauge)
-
-|<prefix>.causal_clustering.core.raft_log_entry_prefetch_buffer.bytes
-|Raft Log Entry Prefetch total bytes. (gauge)
-
-|<prefix>.causal_clustering.core.raft_log_entry_prefetch_buffer.size
-|Raft Log Entry Prefetch buffer size. (gauge)
-
-|<prefix>.causal_clustering.core.raft_log_entry_prefetch_buffer.async_put
-|Raft Log Entry Prefetch buffer async puts. (gauge)
-
-|<prefix>.causal_clustering.core.raft_log_entry_prefetch_buffer.sync_put
-|Raft Log Entry Prefetch buffer sync puts. (gauge)
-
-|<prefix>.causal_clustering.core.message_processing_delay
-|Delay between Raft message receive and process. (gauge)
-
-|<prefix>.causal_clustering.core.message_processing_timer
-|Timer for Raft message processing. (counter, histogram)
-
-|<prefix>.causal_clustering.core.replication_new
-|The total number of Raft replication requests. It increases with write transactions (possibly internal) activity. (counter)
-
-|<prefix>.causal_clustering.core.replication_attempt
-|The total number of Raft replication requests attempts. It is bigger or equal than the replication requests. (counter)
-
-|<prefix>.causal_clustering.core.replication_fail
-|The total number of Raft replication attempts that have failed. (counter)
-
-|<prefix>.causal_clustering.core.replication_maybe
-|Raft Replication maybe count. (counter)
-
-|<prefix>.causal_clustering.core.replication_success
-|The total number of Raft replication requests that have succeeded. (counter)
-
-|<prefix>.causal_clustering.core.last_leader_message
-|The time elapsed since the last message from a leader in milliseconds. Should reset periodically. (gauge)
-|===
-
-[IMPORTANT]
-====
-Metrics specific to _Causal Clustering_ are deprecated, as the previous table shows.
-The deprecated Raft core metrics are replaced accordingly by the Raft metrics in the following table.
-====
-
 [[raft-metrics]]
 === Raft metrics
 
@@ -581,33 +488,6 @@ The deprecated Raft core metrics are replaced accordingly by the Raft metrics in
 |<prefix>.cluster.raft.last_leader_message|The time elapsed since the last message from a leader in milliseconds. Should reset periodically. (gauge)
 |===
 
-
-[[read-replica-metrics]]
-=== Read Replica metrics
-
-label:deprecated[Deprecated in 5.0]
-
-.Read Replica metrics
-[options="header",cols="<3m,<4"]
-|===
-|Name
-|Description
-
-|<prefix>.causal_clustering.read_replica.pull_updates
-|The total number of pull requests made by this instance. (counter)
-
-|<prefix>.causal_clustering.read_replica.pull_update_highest_tx_id_requested
-|The highest transaction id requested in a pull update by this instance. (counter)
-
-|<prefix>.causal_clustering.read_replica.pull_update_highest_tx_id_received
-|The highest transaction id that has been pulled in the last pull updates by this instance. (counter)
-|===
-
-[IMPORTANT]
-====
-Metrics specific to _Causal Clustering_ are deprecated, as the previous table shows.
-The deprecated Read Replica metrics are replaced accordingly by the Story copy metrics in the following table.
-====
 
 [[store-copy-metrics]]
 === Store copy metrics


### PR DESCRIPTION
The Raft core metrics and Read replica metrics were old names from 4.x, supported during 5.x. They have been removed in 2025.01