### PR TITLE
Remove deprecated and migrated server.max_databases setting

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -5054,24 +5054,6 @@ m|
 |===
 
 
-[role=label--enterprise-edition label--deprecated-5.6]
-[[config_server.max_databases]]
-=== `server.max_databases`
-
-.server.max_databases
-[frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
-|===
-|Description
-a|The maximum number of databases.
-|Valid values
-a|A long that is minimum `2`.
-|Default value
-m|+++100+++
-|Replaced by
-a|<<config_dbms.max_databases,`dbms.max_databases`>>
-|===
-
-
 [role=label--enterprise-edition label--changed-2025.01]
 [[config_server.panic.shutdown_on_panic]]
 === `server.panic.shutdown_on_panic`

--- a/modules/ROOT/pages/docker/ref-settings.adoc
+++ b/modules/ROOT/pages/docker/ref-settings.adoc
@@ -781,9 +781,6 @@ For more information on the configuration descriptions, valid values, and defaul
 | `server.logs.user.config`
 | `+NEO4J_server_logs_user_config+`
 
-| `server.max_databases`
-| `+NEO4J_server._max__databases+`
-
 | `server.memory.heap.initial_size`
 | `+NEO4J_server_memory_heap_initial__size+`
 


### PR DESCRIPTION
This was replaced by dbms.max_databases in 5.6.