### PR TITLE
Update Antora files for LTS

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,8 @@
 name: operations-manual
 title: Operations Manual
 version: '5'
+display_version: '5.26'
+lts: true
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,5 +1,5 @@
 [[operations-manual]]
-= The Neo4j Operations Manual v{neo4j-version}
+= The Neo4j Operations Manual
 :neo4j-buildnumber: {neo4j-version}
 :download-center-uri: https://neo4j.com/deployment-center/
 :upgrade-current-uri: https://neo4j.com/docs/upgrade-migration-guide/current/

--- a/publish.yml
+++ b/publish.yml
@@ -7,7 +7,7 @@ site:
 content:
   sources:
   - url: ./
-    branches: ['3.5', '4.0', '4.1', '4.2', '4.3', '4.4', 'HEAD']
+    branches: ['4.4', 'HEAD']
     edit_url: https://github.com/neo4j/docs-operations/tree/{refname}/{path}
     exclude:
     - '!**/_includes/*'
@@ -25,10 +25,6 @@ urls:
 
 antora:
   extensions:
-  - require: "@neo4j-antora/antora-modify-sitemaps"
-    sitemap_version: '5'
-    sitemap_loc_version: 'current'
-    move_sitemaps_to_components: true
   - require: "@neo4j-antora/antora-unlisted-pages"
 
 asciidoc:

--- a/publish.yml
+++ b/publish.yml
@@ -7,7 +7,7 @@ site:
 content:
   sources:
   - url: ./
-    branches: ['3.5', '4.0', '4.1', '4.2', '4.3', '4.4', '5.x']
+    branches: ['3.5', '4.0', '4.1', '4.2', '4.3', '4.4', 'HEAD']
     edit_url: https://github.com/neo4j/docs-operations/tree/{refname}/{path}
     exclude:
     - '!**/_includes/*'


### PR DESCRIPTION
This PR updates the component descriptor (_antora.yml_) to mark 5.26 as LTS.

To do this, we add `lts: true`. By also setting `display_version: 5.26` we can keep the current URL structure (_/5/_) but at the same time we can be explicit about the minor version that the _/5/_ docs apply to. 

This PR can be merged after 2025.01 is released.