### PR TITLE
Add description for the fields of recreateDatabase procedure

### DIFF
--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -531,11 +531,17 @@ CALL dbms.cluster.readReplicaToggle("neo4j", false)
 | *Description* 3+a| Recreates a database while keeping all RBAC settings.
 The procedure initiates a process, which when complete, will have synchronized and started all database instances within the cluster.
 .3+| *Input arguments* | *Name* | *Type* | *Description*
-| `database` | `STRING` | database :: STRING
-| `options` | `MAP` | options = {} :: MAP
+| `database` | `STRING` | The name of the database to recreate.
+| `options` | `MAP` | The seeding and topology options to use for recreating the database.
 | *Mode* 3+| WRITE
 |===
 
+[NOTE]
+====
+It is mandatory to specify either `seedURI` or `seedingServers` as seeding options in the `options` field.
+Further details on how to use the `dbms.cluster.recreateDatabase()` procedure are provided in the related section inside the xref:clustering/databases.adoc#recreate-databases[Managing databases in a cluster] page.
+If no topology option is defined, the database will be recreated with the previous topology.
+====
 
 [role=label--enterprise-edition label--deprecated-5.21]
 [[procedure_dbms_cluster_routing_getroutingtable]]


### PR DESCRIPTION
The title says it all: we didn't have description for the fields of the `recreateDatabase` procedure 🙈 
The related monorepo PR is https://github.com/neo-technology/neo4j/pull/28960