### PR TITLE
updated 5.26 linux install instructions to move the repository links

### DIFF
--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -8,8 +8,7 @@ You can install Neo4j on Debian, and Debian-based distributions like Ubuntu, usi
 == Java prerequisites
 
 Neo4j {neo4j-version} requires the Java 17 runtime.
-Java 17 is not included in Ubuntu 16.04 LTS and will have to be set up manually before installing or upgrading to Neo4j {neo4j-version}, as described below.
-Debian 11 and Ubuntu 18.04 onwards already have the OpenJDK Java 17 package available through `apt`.
+
 From version 5.14 onwards, Neo4j also supports JDK 21.
 
 [[debian-prerequisites-notopenjdk]]
@@ -23,21 +22,6 @@ Download and installation instructions can be found on the manufacturer's websit
 * https://www.oracle.com/java/technologies/downloads/[Oracle JDK]
 * https://www.azul.com/downloads/?package=jdk[Zulu JDK]
 * https://aws.amazon.com/corretto[Amazon Corretto JDK]
-
-
-[[ubuntu-java17]]
-=== OpenJDK 17 on Ubuntu 16.04
-
-Add the official OpenJDK package repository to `apt`:
-
-[source, shell]
-----
-sudo add-apt-repository -y ppa:openjdk-r/ppa
-sudo apt-get update
-----
-
-You are now ready to install Neo4j, which will install Java 17 automatically if it is not already installed.
-See xref:installation/linux/debian.adoc#multiple-java-versions[Dealing with multiple installed Java versions] to make sure you can start Neo4j after installation.
 
 
 [[multiple-java-versions]]
@@ -88,22 +72,10 @@ The Debian package is available from https://debian.neo4j.com.
 [source, shell]
 ----
 wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/neotechnology.gpg
-echo 'deb [signed-by=/etc/apt/keyrings/neotechnology.gpg] https://debian.neo4j.com stable latest' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
-sudo apt-get update
-----
-+
-To avoid the risk of the `apt` package manager accidentally forcing a database upgrade, different major and minor releases of Neo4j are also available separately inside the repository.
-To install Neo4j this way, specify the major and minor version required, in place of `latest`.
-+
-The following method for production or business-critical installations is recommended:
-+
-[source, shell, subs="attributes"]
-----
-wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/neotechnology.gpg
 echo 'deb [signed-by=/etc/apt/keyrings/neotechnology.gpg] https://debian.neo4j.com stable {neo4j-version}' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
 sudo apt-get update
 ----
-
++
 . Once the repository has been added to `apt`, you can verify which Neo4j versions are available by running:
 +
 [source, shell]

--- a/modules/ROOT/pages/installation/linux/rpm.adoc
+++ b/modules/ROOT/pages/installation/linux/rpm.adoc
@@ -14,24 +14,6 @@ Neo4j 5.x runs on Java 17, and from Neo4j 5.14, it also supports Java 21.
 Most of our supported Linux distributions have OpenJDK Java 17 available by default.
 Consequently, no extra setup is required if you are using OpenJDK Java, the correct Java dependency will be installed by the package manager when installing Neo4j.
 
-
-[[linux-rpm-prerequisites-oracle]]
-=== Oracle Java 17
-There is some minor setup required for compatibility with Oracle Java 17 because Oracle and OpenJDK provide incompatible RPM packages for Java 17.
-
-You can use an adapter for Oracle Java 17, which must be installed before Neo4j.
-The adapter contains no code but stops the package manager from installing OpenJDK 17 as a dependency despite an existing Oracle Java 17 installation.
-
-. Download and install the Oracle Java 17 JDK from the https://www.oracle.com/technetwork/java/javase/downloads/index.html[Oracle website].
-. Install the adapter:
-+
-[source, shell]
-----
-sudo yum install https://dist.neo4j.org/neo4j-java17-adapter.noarch.rpm
-----
-+
-The SHA-256 of the adapter package can be verified against https://dist.neo4j.org/neo4j-java17-adapter.noarch.rpm.sha256.
-
 === Zulu JDK 17 or Corretto 17
 
 If you want to use a non-default JDK, it must be installed before starting the Neo4j installation.
@@ -179,11 +161,6 @@ curl -O https://dist.neo4j.org/rpm/neo4j-enterprise-{neo4j-version-exact}-1.noar
 . Manually move the downloaded RPM packages to the offline machine.
 Before installing Neo4j, you must manually install the required Java 17 packages.
 +
-[NOTE]
-====
-If using Oracle Java 17, the same dependency issues apply as with the xref:installation/linux/rpm.adoc#linux-rpm-prerequisites-oracle[Oracle Java prerequisites].
-You will need to additionally download and install the Java adaptor described in that section.
-====
 . Install Neo4j and Cypher Shell as `root` using the following command depending on which edition you are using:
 +
 [NOTE]


### PR DESCRIPTION
key differences:
* must download from `{neo4j-version}` not `latest` now.
* no need for annoying oracle jdk workaround in redhat/fedora. Oracle seem to have fixed that bug in multiple java versions :woman_shrugging: 

dev PR is https://github.com/neo4j/docs-operations/pull/2054