### PR TITLE
`dbms.cypher.infer_schema_parts` defaults to `MOST_SELECTIVE_LABEL`

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -1816,7 +1816,7 @@ If more than one label can be inferred for a given node, the planner keeps the m
 |Valid values
 a|One of [MOST_SELECTIVE_LABEL, OFF].
 |Default value
-m|+++OFF+++
+m|+++MOST_SELECTIVE_LABEL+++
 |===
 
 For some queries, the planner can infer predicates such as labels or types from the graph structure that can improve estimating the number of rows that each operator produces.


### PR DESCRIPTION
The planner now infers labels by default in cardinality estimation.
It can still be disabled.