### PR TITLE
Document executionPlanCacheKeyHash and executableQueryCacheHit

### DIFF
--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -1197,6 +1197,7 @@ If the type of the log entry is `query`, these additional fields are available:
 
 | id
 | The query ID.
+The ID is incremental, starting from 1 and resetting upon every Neo4j restart.
 Included when xref:configuration/configuration-settings.adoc#config_db.logs.query.enabled[`db.logs.query.enabled`] is `VERBOSE`.
 
 | elapsedTimeMs
@@ -1261,6 +1262,16 @@ See <<gql-error-information, GQL error information>> for details on the contents
 | The query plan.
 Included when xref:configuration/configuration-settings.adoc#config_db.logs.query.plan_description_enabled[`db.logs.query.plan_description_enabled`] is `true`.
 
+| executionPlanCacheKeyHash
+| The 32-bit hash of the cache key used to cache the execution plan.
+It is a fixed-length 8-character string of a hex-encoded integer value.
+Enabled by default only in the JSON format.
+If multiple query executions use the same cached execution plan, their hashes should match.
+For `event=start`, the value is 000000.
+
+| executableQueryCacheHit
+| Whether the query was executed using a cached execution plan.
+
 |===
 
 If the type of the log entry is `transaction`, the following additional fields are available:
@@ -1286,6 +1297,7 @@ Either same as `authenticatedUser` or an impersonated user.
 
 | transactionId
 | ID of the transaction.
+
 |===
 
 [[gql-error-information]]

--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -1270,7 +1270,7 @@ If multiple query executions use the same cached execution plan, their hashes sh
 For `event=start`, the value is `00000000`.
 
 | executableQueryCacheHit
-| Whether the query was executed using a cached execution plan.
+| Whether the query string matched a cached execution plan.
 
 |===
 

--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -1267,7 +1267,7 @@ Included when xref:configuration/configuration-settings.adoc#config_db.logs.quer
 It is a fixed-length 8-character string of a hex-encoded integer value.
 Enabled by default only in the JSON format.
 If multiple query executions use the same cached execution plan, their hashes should match.
-For `event=start`, the value is 000000.
+For `event=start`, the value is `00000000`.
 
 | executableQueryCacheHit
 | Whether the query was executed using a cached execution plan.


### PR DESCRIPTION
Hi @henriknyman, it seems that those two log entries were missing in the docs. Could you please take a look to see if I have documented them correctly? Also, in which version have they been introduced? Thanks a lot!