### PR TITLE
Fix links to Cypher Manual

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/built-in-roles.adoc
+++ b/modules/ROOT/pages/authentication-authorization/built-in-roles.adoc
@@ -827,7 +827,7 @@ These include the rights to perform the following classes of tasks:
 
 * Manage xref:authentication-authorization/database-administration.adoc[database privileges] to control the rights to perform actions on specific databases:
 ** Manage access to a database and the right to start and stop a database.
-** Manage link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-search-performance/[indexes] and link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints/[constraints].
+** Manage link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance/[indexes] and link:{neo4j-docs-base-uri}/cypher-manual/current/constraints/[constraints].
 ** Allow the creation of labels, relationship types, or property names.
 ** Manage transactions.
 * Manage xref:authentication-authorization/dbms-administration.adoc[DBMS privileges] to control the rights to perform actions on the entire system:

--- a/modules/ROOT/pages/authentication-authorization/dbms-administration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/dbms-administration.adoc
@@ -65,7 +65,7 @@ CREATE ROLE deniedConfigurationViewer IF NOT EXISTS;
 
 All DBMS privileges are relevant system-wide.
 Like user management, they do not belong to one specific database or graph.
-For more details on the differences between graphs, databases, and the DBMS, refer to link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/introduction/cypher_neo4j/[Cypher Manual -> Cypher and Neo4j].
+For more details on the differences between graphs, databases, and the DBMS, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/introduction/cypher_neo4j/[Cypher Manual -> Cypher and Neo4j].
 
 image::privileges_grant_and_deny_syntax_dbms_privileges.svg[title="Syntax of GRANT and DENY DBMS Privileges"]
 
@@ -2055,7 +2055,7 @@ In this case, `+*+` means 0 or more characters, and `?` matches exactly one char
 
 [NOTE]
 ====
-The name-globbing is subject to the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/naming/[Cypher Manual -> Naming rules and recommendations], with the exception that it may include dots, stars, and question marks without the need for escaping using backticks.
+The name-globbing is subject to the link:{neo4j-docs-base-uri}/cypher-manual/current/syntax/naming/[Cypher Manual -> Naming rules and recommendations], with the exception that it may include dots, stars, and question marks without the need for escaping using backticks.
 
 Each part of the name-globbing separated by dots may be individually quoted.
 For example, `++mine.`procedureWith%`++` is allowed, but not `++mine.procedure`With%`++`.

--- a/modules/ROOT/pages/authentication-authorization/limitations.adoc
+++ b/modules/ROOT/pages/authentication-authorization/limitations.adoc
@@ -19,14 +19,14 @@ The known limitations and implications of Neo4j's role-based access control secu
 [[access-control-limitations-indexes]]
 == Security and indexes
 
-As described in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-search-performance/[Cypher Manual -> Indexes for search performance], Neo4j {neo4j-version} supports the creation and use of indexes to improve the performance of Cypher queries.
+As described in link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance/[Cypher Manual -> Indexes for search performance], Neo4j {neo4j-version} supports the creation and use of indexes to improve the performance of Cypher queries.
 
 Note that the Neo4j security model impacts the results of queries, regardless if the indexes are used or not.
 When using non full-text Neo4j indexes, a Cypher query will always return the same results it would have if no index existed.
 This means that, if the security model causes fewer results to be returned due to restricted read access in xref:authentication-authorization/manage-privileges.adoc[Graph and sub-graph access control],
 the index will also return the same fewer results.
 
-However, this rule is not fully obeyed by link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-full-text-search[Cypher Manual -> Indexes for full-text search].
+However, this rule is not fully obeyed by link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-full-text-search[Cypher Manual -> Indexes for full-text search].
 These specific indexes are backed by _Lucene_ internally.
 It is therefore not possible to know for certain whether a security violation has affected each specific entry returned from the index.
 In face of this, Neo4j will return zero results from full-text indexes in case it is determined that any result might be violating the security privileges active for that query.
@@ -51,7 +51,7 @@ CREATE FULLTEXT INDEX userNames FOR (n:User|Person) ON EACH [n.name, n.surname];
 [NOTE]
 ====
 Full-text indexes support multiple labels.
-See link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-full-text-search/[Cypher Manual -> Indexes for full-text search] for more details on creating and using full-text indexes.
+See link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-full-text-search/[Cypher Manual -> Indexes for full-text search] for more details on creating and using full-text indexes.
 ====
 
 After creating these indexes, it would appear that the latter two indexes accomplish the same thing.

--- a/modules/ROOT/pages/authentication-authorization/load-privileges.adoc
+++ b/modules/ROOT/pages/authentication-authorization/load-privileges.adoc
@@ -14,14 +14,14 @@ CREATE ROLE roleLoadCidr
 This section explains how to use Cypher to manage load privileges.
 All load privileges apply to the whole system.
 Like DBMS privileges, they do not belong to one specific database or graph.
-For more details on the differences between graphs, databases, and the DBMS, refer to link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/introduction/cypher_neo4j/[Cypher Manual -> Cypher and Neo4j].
+For more details on the differences between graphs, databases, and the DBMS, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/introduction/cypher_neo4j/[Cypher Manual -> Cypher and Neo4j].
 
 image::privileges_grant_and_deny_syntax_load_privileges.svg[width="800", title="Syntax of GRANT and DENY load Privileges"]
 
 // TODO: add image later when there is more than one LOAD privilege
 //image::privileges_hierarchy_load.svg[title="Load privileges hierarchy"]
 
-The load privileges apply to the Cypher link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/load-csv/[`LOAD CSV` clause], deciding whether or not the data can be loaded from the given source.
+The load privileges apply to the Cypher link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/load-csv/[`LOAD CSV` clause], deciding whether or not the data can be loaded from the given source.
 
 == Load privileges syntax
 

--- a/modules/ROOT/pages/authentication-authorization/privileges-writes.adoc
+++ b/modules/ROOT/pages/authentication-authorization/privileges-writes.adoc
@@ -34,7 +34,7 @@ For more details about the syntax descriptions, see xref:database-administration
 == The `CREATE` privilege
 
 The `CREATE` privilege allows a user to create new node and relationship elements on a graph.
-For more details, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/create/[the Cypher Manual -> `CREATE`] clause.
+For more details, see link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/create/[the Cypher Manual -> `CREATE`] clause.
 
 [source, syntax, role="noheader"]
 ----
@@ -93,7 +93,7 @@ See xref:authentication-authorization/limitations.adoc#access-control-limitation
 == The `DELETE` privilege
 
 The `DELETE` privilege allows a user to delete node and relationship elements on a graph.
-For more details, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/delete/[the Cypher Manual -> `DELETE`] clause.
+For more details, see link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/delete/[the Cypher Manual -> `DELETE`] clause.
 
 [source, syntax, role="noheader"]
 ----
@@ -151,7 +151,7 @@ See xref:authentication-authorization/limitations.adoc#access-control-limitation
 [[access-control-privileges-writes-set-label]]
 == The `SET LABEL` privilege
 
-The `SET LABEL` privilege allows you to set labels on a node using the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/set/#set-set-a-label-on-a-node[Cypher `SET` clause]:
+The `SET LABEL` privilege allows you to set labels on a node using the link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/set/#set-set-a-label-on-a-node[Cypher `SET` clause]:
 
 [source, syntax, role="noheader"]
 ----
@@ -203,7 +203,7 @@ See xref:authentication-authorization/limitations.adoc#access-control-limitation
 [[access-control-privileges-writes-remove-label]]
 == The `REMOVE LABEL` privilege
 
-The `REMOVE LABEL` privilege allows you to remove labels from a node by using the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/remove/#remove-remove-a-label-from-a-node[Cypher `REMOVE` clause]:
+The `REMOVE LABEL` privilege allows you to remove labels from a node by using the link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/remove/#remove-remove-a-label-from-a-node[Cypher `REMOVE` clause]:
 
 [source, syntax, role="noheader"]
 ----
@@ -250,7 +250,7 @@ See xref:authentication-authorization/limitations.adoc#access-control-limitation
 [[access-control-privileges-writes-set-property]]
 == The `SET PROPERTY` privilege
 
-The `SET PROPERTY` privilege allows a user to set a property on a node or relationship element in a graph by using the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/set/#set-set-a-property[Cypher `SET` clause]:
+The `SET PROPERTY` privilege allows a user to set a property on a node or relationship element in a graph by using the link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/set/#set-set-a-property[Cypher `SET` clause]:
 
 [source, syntax, role="noheader"]
 ----
@@ -308,7 +308,7 @@ See xref:authentication-authorization/limitations.adoc#access-control-limitation
 == The `MERGE` privilege
 
 The `MERGE` privilege is a compound privilege that combines `TRAVERSE` and `READ` (i.e. `MATCH`) with `CREATE` and `SET PROPERTY`.
-This is intended to enable the use of the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/merge/[Cypher `MERGE` command], but it is also applicable to all reads and writes that require these privileges.
+This is intended to enable the use of the link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/merge/[Cypher `MERGE` command], but it is also applicable to all reads and writes that require these privileges.
 
 [source, syntax, role="noheader"]
 ----

--- a/modules/ROOT/pages/authentication-authorization/property-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/property-based-access-control.adoc
@@ -112,7 +112,7 @@ This is essential when revoking property-based privileges containing evaluated f
 ====
 [NOTE]
 ====
-Not all temporal values are comparable, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/operators/#cypher-ordering[Cypher Manual -> Syntax -> Operators -> Ordering and comparison of values].
+Not all temporal values are comparable, see link:{neo4j-docs-base-uri}/cypher-manual/current/syntax/operators/#cypher-ordering[Cypher Manual -> Syntax -> Operators -> Ordering and comparison of values].
 ====
 
 .Show the privilege created by the command in the previous example as a revoke command:

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -19,7 +19,7 @@ To create a database `foo` with 3 servers hosting the database in primary mode a
 ----
 CREATE DATABASE foo TOPOLOGY 3 PRIMARIES 2 SECONDARIES
 ----
-Alternatively, you can use link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/parameters[parameters] to provide the number of primaries and secondaries:
+Alternatively, you can use link:{neo4j-docs-base-uri}/cypher-manual/current/syntax/parameters[parameters] to provide the number of primaries and secondaries:
 
 .Parameters
 [source,javascript, indent=0]
@@ -67,7 +67,7 @@ To change the topology of the database `foo` from the previous example, the comm
 ----
 ALTER DATABASE foo SET TOPOLOGY 2 PRIMARIES 1 SECONDARY
 ----
-Alternatively, you can use link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/parameters[parameters] to provide the number of primaries and secondaries:
+Alternatively, you can use link:{neo4j-docs-base-uri}/cypher-manual/current/syntax/parameters[parameters] to provide the number of primaries and secondaries:
 
 .Parameters
 [source,javascript, indent=0]

--- a/modules/ROOT/pages/clustering/setup/routing.adoc
+++ b/modules/ROOT/pages/clustering/setup/routing.adoc
@@ -70,7 +70,7 @@ With server-side routing enabled, such queries are rerouted internally to a clus
 This situation can occur for write-transaction queries when they address a database for which the receiving cluster member is not the leader.
 
 The cluster role for cluster members is per database.
-Thus, if a write-transaction query is sent to a cluster member that is not the leader for the specified database (specified either via the link:{neo4j-docs-base-uri}/bolt/current/bolt[Bolt Protocol] or with Cypher link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/use[`USE` clause]), server-side routing is performed if properly configured.
+Thus, if a write-transaction query is sent to a cluster member that is not the leader for the specified database (specified either via the link:{neo4j-docs-base-uri}/bolt/current/bolt[Bolt Protocol] or with Cypher link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/use[`USE` clause]), server-side routing is performed if properly configured.
 
 Server-side routing is enabled by the DBMS, by setting xref:configuration/configuration-settings.adoc#config_dbms.routing.enabled[`dbms.routing.enabled=true`] for each cluster member.
 The listen address (xref:configuration/configuration-settings.adoc#config_server.routing.listen_address[`server.routing.listen_address`]) and advertised address (xref:configuration/configuration-settings.adoc#config_server.routing.advertised_address[`server.routing.advertised_address`]) also need to be configured for server-side routing communication.

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -1820,8 +1820,8 @@ m|+++OFF+++
 |===
 
 For some queries, the planner can infer predicates such as labels or types from the graph structure that can improve estimating the number of rows that each operator produces.
-for more information, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/execution-plans/#runtimes-reading-execution-plans[Cypher Manual -> Execution plans and query tuning -> Understanding execution plans]. +
-For details on how to configure this setting on a per-query basis,effectively overriding this setting on that particular query, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/query-tuning/#cypher-infer-schema-parts[Cypher Manual -> Query tuning -> Cypher infer schema parts].
+for more information, see link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/execution-plans/#runtimes-reading-execution-plans[Cypher Manual -> Execution plans and query tuning -> Understanding execution plans]. +
+For details on how to configure this setting on a per-query basis,effectively overriding this setting on that particular query, see link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/query-tuning/#cypher-infer-schema-parts[Cypher Manual -> Query tuning -> Cypher infer schema parts].
 
 // In general, inferring more information should improve the estimation and thereby the planner's decisions.
 // Should this not be the case, this setting provides the means to disable inference.

--- a/modules/ROOT/pages/configuration/file-locations.adoc
+++ b/modules/ROOT/pages/configuration/file-locations.adoc
@@ -254,11 +254,11 @@ For Enterprise Edition, these are:
 
 * link:{neo4j-docs-base-uri}/bloom-user-guide/current/[Neo4j Bloom]
 * link:{neo4j-docs-base-uri}/graph-data-science/current/[Graph Data Science Library]
-* link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/genai-integrations/[GenAI plugin]
+* link:{neo4j-docs-base-uri}/cypher-manual/current/genai-integrations/[GenAI plugin]
 * link:{neo4j-docs-base-uri}/ops-manager/current/[Neo4j Ops Manager Server]
 * _README.txt_ file -- with information on enabling them.
 
-Community Edition contains only the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/genai-integrations/[GenAI plugin].
+Community Edition contains only the link:{neo4j-docs-base-uri}/cypher-manual/current/genai-integrations/[GenAI plugin].
 
 File permissions:: Read only.
 

--- a/modules/ROOT/pages/configuration/plugins.adoc
+++ b/modules/ROOT/pages/configuration/plugins.adoc
@@ -41,7 +41,7 @@ The following plugins are supported:
 | GenAI
 | `genai`
 |
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/genai-integrations/[Cypher Manual -> GenAI integrations].
+| link:{neo4j-docs-base-uri}/cypher-manual/current/genai-integrations/[Cypher Manual -> GenAI integrations].
 
 | GraphQL
 | `graphql`

--- a/modules/ROOT/pages/database-administration/aliases/manage-aliases-composite-databases.adoc
+++ b/modules/ROOT/pages/database-administration/aliases/manage-aliases-composite-databases.adoc
@@ -139,7 +139,7 @@ ALTER ALIAS garden.flowers SET DATABASE PROPERTIES { perennial: true }
 ALTER ALIAS garden.trees SET DATABASE TARGET updatedTrees AT 'neo4j+s://location:7687' PROPERTIES { treeVersion: 2 }
 ----
 
-The updated properties can then be used in queries with the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions/graph/#functions-graph-propertiesByName[`graph.propertiesByName()` function].
+The updated properties can then be used in queries with the link:{neo4j-docs-base-uri}/cypher-manual/current/functions/graph/#functions-graph-propertiesByName[`graph.propertiesByName()` function].
 
 The changes for all database aliases will show up in the `SHOW ALIASES FOR DATABASE` command.
 

--- a/modules/ROOT/pages/database-administration/aliases/manage-aliases-standard-databases.adoc
+++ b/modules/ROOT/pages/database-administration/aliases/manage-aliases-standard-databases.adoc
@@ -320,7 +320,7 @@ The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used toge
 === Set properties for local database aliases
 
 Local database aliases can also be given properties.
-These properties can then be used in queries with the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions/graph/#functions-graph-propertiesByName[`graph.propertiesByName()` function].
+These properties can then be used in queries with the link:{neo4j-docs-base-uri}/cypher-manual/current/functions/graph/#functions-graph-propertiesByName[`graph.propertiesByName()` function].
 
 .Query
 [source, cypher]
@@ -442,7 +442,7 @@ SHOW ALIAS `remote-with-driver-settings` FOR DATABASE YIELD *
 ==== Set properties for remote database aliases
 
 Just as the local database aliases, the remote database aliases can be given properties.
-These properties can then be used in queries with the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions/graph/#functions-graph-propertiesByName[`graph.propertiesByName()` function].
+These properties can then be used in queries with the link:{neo4j-docs-base-uri}/cypher-manual/current/functions/graph/#functions-graph-propertiesByName[`graph.propertiesByName()` function].
 
 .Query
 [source, cypher]
@@ -575,7 +575,7 @@ ALTER ALIAS `motion pictures` SET DATABASE PROPERTIES { nameContainsSpace: true,
 ALTER ALIAS `movie scripts` SET DATABASE PROPERTIES { nameContainsSpace: true }
 ----
 
-The updated properties can then be used in queries with the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions/graph/#functions-graph-propertiesByName[`graph.propertiesByName()` function].
+The updated properties can then be used in queries with the link:{neo4j-docs-base-uri}/cypher-manual/current/functions/graph/#functions-graph-propertiesByName[`graph.propertiesByName()` function].
 
 === Use `IF EXISTS` when altering database aliases
 

--- a/modules/ROOT/pages/database-administration/aliases/naming-aliases.adoc
+++ b/modules/ROOT/pages/database-administration/aliases/naming-aliases.adoc
@@ -3,7 +3,7 @@
 = Naming rules for database aliases
 
 Database alias names are subject to the standard Cypher restrictions on valid identifiers.
-See link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/naming[Cypher Manual -> Naming rules and recommendations].
+See link:{neo4j-docs-base-uri}/cypher-manual/current/syntax/naming[Cypher Manual -> Naming rules and recommendations].
 
 The following naming rules apply:
 

--- a/modules/ROOT/pages/database-administration/aliases/remote-database-alias-configuration.adoc
+++ b/modules/ROOT/pages/database-administration/aliases/remote-database-alias-configuration.adoc
@@ -199,7 +199,7 @@ A user can connect to a remote database alias the same way they would do to a da
 This includes:
 
 * Connecting directly to the remote database alias.
-* The Cypher link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/use[`USE` clause] enables a user to query a remote database alias that they are not directly connected to:
+* The Cypher link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/use[`USE` clause] enables a user to query a remote database alias that they are not directly connected to:
 
 [source, Cypher]
 ----

--- a/modules/ROOT/pages/database-administration/composite-databases/querying-composite-databases.adoc
+++ b/modules/ROOT/pages/database-administration/composite-databases/querying-composite-databases.adoc
@@ -7,7 +7,7 @@
 //Make an image that sets up the example?
 //The query examples assume that we have a setup similar to that in <<example-create-a-single-instance-fabric-setup>>.
 
-The examples featured in this section make use of the two Cypher clauses: link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/use[`USE`] and link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/call-subquery[`CALL {}`].
+The examples featured in this section make use of the two Cypher clauses: link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/use[`USE`] and link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/call-subquery[`CALL {}`].
 
 [[composite-databases-queries-graph-set-up]]
 == Graph set-up
@@ -113,7 +113,7 @@ In this case, once selecting `cineasts.latest`, and once selecting `cineasts.upc
 [[composite-databases-queries-listing-graphs]]
 === Listing graphs
 
-The built-in function link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions/query-functions#functions-graph-names[`graph.names()`] returns a list containing the names of all constituent graphs on the current Composite database.
+The built-in function link:{neo4j-docs-base-uri}/cypher-manual/current/functions/query-functions#functions-graph-names[`graph.names()`] returns a list containing the names of all constituent graphs on the current Composite database.
 
 .The `graph.names()` function
 ====
@@ -316,7 +316,7 @@ RETURN m
 
 When a query is submitted to a Composite database, different parts of the query may run using different runtimes.
 Clauses or expressions in scopes where no graph has been specified run using the _slotted_ runtime.
-Parts of the query directed to different constituent graphs are run using the default runtime for that graph, or respect the submitted link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/query-tuning/query-options/#cypher-runtime[Cypher query options] if specified.
+Parts of the query directed to different constituent graphs are run using the default runtime for that graph, or respect the submitted link:{neo4j-docs-base-uri}/cypher-manual/current/query-tuning/query-options/#cypher-runtime[Cypher query options] if specified.
 
 [[composite-databases-queries-built-in-functions]]
 == Built-in graph functions
@@ -338,4 +338,4 @@ The following table describes these functions:
 | Returns a map containing the properties associated with the given graph.
 |===
 
-For more information, see _Graph functions_ in the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions/graph/[Cypher Manual].
+For more information, see _Graph functions_ in the link:{neo4j-docs-base-uri}/cypher-manual/current/functions/graph/[Cypher Manual].

--- a/modules/ROOT/pages/database-administration/routing-decisions.adoc
+++ b/modules/ROOT/pages/database-administration/routing-decisions.adoc
@@ -12,8 +12,8 @@ Before the query is executed, these are the decisions taken during query routing
 
 Step 1: Determine the name of the target database::
    Pick the first of these that has a value:
-. link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/use[Cypher `USE` clause]
-** Note that link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/administration/databases[administration commands]  implicitly have `USE system`.
+. link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/use[Cypher `USE` clause]
+** Note that link:{neo4j-docs-base-uri}/cypher-manual/current/administration/databases[administration commands]  implicitly have `USE system`.
 . link:{neo4j-docs-base-uri}/drivers-apis/[Driver session database]
 . xref:database-administration/index.adoc#manage-databases-default[Home or default database]
 Step 2: Reuse open transaction::

--- a/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
@@ -3,7 +3,7 @@
 = Naming rules for databases
 
 Database names are subject to the standard Cypher restrictions on valid identifiers.
-See link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/syntax/naming[Cypher Manual -> Naming rules and recommendations].
+See link:{neo4j-docs-base-uri}/cypher-manual/current/syntax/naming[Cypher Manual -> Naming rules and recommendations].
 
 Naming rules for databases are as follows:
 

--- a/modules/ROOT/pages/database-internals/concurrent-data-access.adoc
+++ b/modules/ROOT/pages/database-internals/concurrent-data-access.adoc
@@ -125,12 +125,12 @@ The easiest way to work around this is to only read each property once, and keep
 === Missing and double reads
 
 When scanning an xref:performance/index-configuration.adoc[index], entities may be observed multiple times or skipped entirely, even if they are present in the index.
-This is true even for indexes that back link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints/managing-constraints/#create-property-uniqueness-constraints[property uniqueness constraints].
+This is true even for indexes that back link:{neo4j-docs-base-uri}/cypher-manual/current/constraints/managing-constraints/#create-property-uniqueness-constraints[property uniqueness constraints].
 
 During the scan, if another concurrent query changes an entity's property to a position ahead of the scan, the entity might appear again in the index.
 Similarly, the entity may not appear at all if the property is changed to a previously scanned position.
 
-This anomaly can only occur with operators that scan an index, or parts of an index, for example link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/operators/operators-detail/#query-plan-node-index-scan[`NodeIndexScan`] or link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/operators/operators-detail/#query-plan-directed-relationship-index-seek-by-range[`DirectedRelationshipIndexSeekByRange`].
+This anomaly can only occur with operators that scan an index, or parts of an index, for example link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/operators/operators-detail/#query-plan-node-index-scan[`NodeIndexScan`] or link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/operators/operators-detail/#query-plan-directed-relationship-index-seek-by-range[`DirectedRelationshipIndexSeekByRange`].
 
 .Missing and double read
 ====

--- a/modules/ROOT/pages/database-internals/transaction-management.adoc
+++ b/modules/ROOT/pages/database-internals/transaction-management.adoc
@@ -63,4 +63,4 @@ You can set the transaction timeout to any value, even larger than configured by
 Transactions can be managed using the Cypher commands `SHOW TRANSACTIONS` and `TERMINATE TRANSACTIONS`.
 The `TERMINATE TRANSACTIONS` command can be combined with multiple `SHOW TRANSACTIONS` and `TERMINATE TRANSACTIONS` commands in the same query.
 
-For more information, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/transaction-clauses/[Cypher manual -> Transaction commands].
+For more information, see link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/transaction-clauses/[Cypher manual -> Transaction commands].

--- a/modules/ROOT/pages/introduction.adoc
+++ b/modules/ROOT/pages/introduction.adoc
@@ -70,7 +70,7 @@ a| link:https://www.gnu.org/licenses/quick-guide-gplv3.html[Open source under GP
 |
 |
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/queries/basic/[Property graph model]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/queries/basic/[Property graph model]
 | {check-mark}
 | {check-mark}
 
@@ -98,19 +98,19 @@ a| link:https://neo4j.com/docs/cdc/current/[Change Data Capture (CDC)]
 | {check-mark}
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/introduction/cypher-overview/[Cypher graph query language]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/introduction/cypher-overview/[Cypher graph query language]
 | {check-mark}
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts/#runtimes-slotted-runtime[Slotted Cypher runtime]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts/#runtimes-slotted-runtime[Slotted Cypher runtime]
 | {check-mark}
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts/#runtimes-pipelined-runtime[Pipelined Cypher runtime]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts/#runtimes-pipelined-runtime[Pipelined Cypher runtime]
 |
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts/#runtimes-parallel-runtime[Parallel Cypher runtime]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts/#runtimes-parallel-runtime[Parallel Cypher runtime]
 |
 | {check-mark}
 
@@ -122,7 +122,7 @@ a| link:https://neo4j.com/docs/cdc/current/[Change Data Capture (CDC)]
 | {check-mark}
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/query-tuning/[Cost-based query optimizer]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/query-tuning/[Cost-based query optimizer]
 | {check-mark}
 | {check-mark}
 
@@ -166,35 +166,35 @@ a| APOC 450+ link:https://neo4j.com/docs/apoc/5/[Core Procedures and Functions]
 |
 |
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes/search-performance-indexes/overview/[Fast writes via native label indexes]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/overview/[Fast writes via native label indexes]
 | {check-mark}
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes/search-performance-indexes/using-indexes/#composite-indexes[Composite indexes]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/using-indexes/#composite-indexes[Composite indexes]
 | {check-mark}
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes/semantic-indexes/full-text-indexes/[Full-text node & relationship indexes]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/full-text-indexes/[Full-text node & relationship indexes]
 | {check-mark}
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes/semantic-indexes/vector-indexes/[Vector indexes]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/vector-indexes/[Vector indexes]
 | {check-mark}
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints/managing-constraints/#create-property-uniqueness-constraints[Property uniqueness constraints]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/constraints/managing-constraints/#create-property-uniqueness-constraints[Property uniqueness constraints]
 | {check-mark}
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints/managing-constraints/#create-property-existence-constraints[Property existence constraints]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/constraints/managing-constraints/#create-property-existence-constraints[Property existence constraints]
 |
 | {check-mark}
 
-| link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints/managing-constraints/#create-property-type-constraints[Property type constraints]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/constraints/managing-constraints/#create-property-type-constraints[Property type constraints]
 |
 | {check-mark}
 
-|link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints/managing-constraints/#create-key-constraints[Node and relationship key constraints]
+|link:{neo4j-docs-base-uri}/cypher-manual/current/constraints/managing-constraints/#create-key-constraints[Node and relationship key constraints]
 |
 | {check-mark}
 

--- a/modules/ROOT/pages/monitoring/query-management.adoc
+++ b/modules/ROOT/pages/monitoring/query-management.adoc
@@ -8,14 +8,14 @@
 
 The procedure for listing queries, `dbms.listQueries()`, is replaced by the command for listing transactions, `SHOW TRANSACTIONS`.
 This command returns information about the currently executing query in the transaction.
-For more information on the command, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/transaction-clauses#query-listing-transactions[Cypher manual -> `SHOW TRANSACTIONS` command].
+For more information on the command, see the link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/transaction-clauses#query-listing-transactions[Cypher manual -> `SHOW TRANSACTIONS` command].
 
 [[query-management-terminate-queries]]
 == Terminate queries
 
 Queries are terminated by terminating the transaction on which they are running.
 This is done using the `TERMINATE TRANSACTIONS transactionIds` command.
-The `transactionIds` can be found using the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/transaction-clauses#query-listing-transactions[`SHOW TRANSACTIONS` command].
+The `transactionIds` can be found using the link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/transaction-clauses#query-listing-transactions[`SHOW TRANSACTIONS` command].
 
 The xref:authentication-authorization/database-administration.adoc#access-control-database-administration-transaction[`TERMINATE TRANSACTION` privilege] determines what transactions can be terminated.
 However, the xref:authentication-authorization/index.adoc#auth-terminology[current user] can always terminate all of their own transactions.
@@ -34,4 +34,4 @@ However, the xref:authentication-authorization/index.adoc#auth-terminology[curre
 | `transactionIds` | List parameter | The IDs of all the transactions to be terminated.
 |===
 
-For more information on the command, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/transaction-clauses#query-terminate-transactions[Cypher manual -> `TERMINATE TRANSACTIONS` command].
+For more information on the command, see the link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/transaction-clauses#query-terminate-transactions[Cypher manual -> `TERMINATE TRANSACTIONS` command].

--- a/modules/ROOT/pages/performance/index-configuration.adoc
+++ b/modules/ROOT/pages/performance/index-configuration.adoc
@@ -21,7 +21,7 @@ When you write a Cypher query, you do not need to specify which indexes to use.
 Cypher's query planner decides which of the available indexes to use.
 
 The rest of this page provides information on the available indexes and their configuration aspects.
-For further details on creating, querying, and dropping indexes, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-search-performance[Cypher Manual -> Indexes for search performance] and link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-full-text-search[Cypher Manual -> Indexes to support full-text search].
+For further details on creating, querying, and dropping indexes, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance[Cypher Manual -> Indexes for search performance] and link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-full-text-search[Cypher Manual -> Indexes to support full-text search].
 
 The type of an index can be identified according to the table below:
 
@@ -74,10 +74,10 @@ Point indexes are a type of highly-specialized, single-property index and they o
 Point indexes are designed to speed up spatial queries, specifically the `distance` and `bounding box` queries.
 Exact lookups are the only non-spatial query that this index type supports.
 
-For more information on the queries a point index can be used for, refer to link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/query-tuning/indexes[Cypher Manual -> Query Tuning -> The use of indexes].
+For more information on the queries a point index can be used for, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/query-tuning/indexes[Cypher Manual -> Query Tuning -> The use of indexes].
 
 Point indexes optionally accept configuration properties for tuning the behavior of spatial search.
-For more information on configuring point index, refer to link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-search-performance[Cypher Manual -> Indexes for search performance].
+For more information on configuring point index, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance[Cypher Manual -> Indexes for search performance].
 
 
 [[index-configuration-text]]
@@ -92,9 +92,9 @@ Even though text indexes do support other text queries, `ENDS WITH` or `CONTAINS
 
 The default provider is `text-2.0`.
 
-For more information on the queries a text index can be used for, refer to link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/query-tuning/indexes[Cypher Manual -> Query Tuning -> The use of indexes].
+For more information on the queries a text index can be used for, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/query-tuning/indexes[Cypher Manual -> Query Tuning -> The use of indexes].
 
-For more information on the different index types, refer to link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-search-performance[Cypher Manual -> Indexes for search performance].
+For more information on the different index types, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance[Cypher Manual -> Indexes for search performance].
 
 [[index-configuration-text-limitations]]
 === Limitations
@@ -129,7 +129,7 @@ They are however created and dropped using Cypher.
 The use of full-text indexes does require familiarity with how those indexes operate.
 
 Full-text indexes are powered by the http://lucene.apache.org/[Apache Lucene] indexing and search library.
-A full description of how to create and use full-text indexes is provided in the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-full-text-search/[Cypher Manual -> Indexes to support full-text search].
+A full description of how to create and use full-text indexes is provided in the link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-full-text-search/[Cypher Manual -> Indexes to support full-text search].
 
 
 [[index-configuration-fulltext-configuration]]
@@ -176,7 +176,7 @@ By default, the analyzer analyzes both the indexed values and query string.
 In some cases, however, using different analyzers for the indexed values and query string is more appropriate.
 You can do that by specifying an analyzer for the query string when using the full-text search procedures.
 
-For detailed information on how to create and use full-text indexes, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-full-text-search/[Cypher Manual -> Indexes to support full-text search].
+For detailed information on how to create and use full-text indexes, see the link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-full-text-search/[Cypher Manual -> Indexes to support full-text search].
 
 [[index-configuration-fulltext-per-property-analyzer]]
 === Per-property analyzer

--- a/modules/ROOT/pages/performance/memory-configuration.adoc
+++ b/modules/ROOT/pages/performance/memory-configuration.adoc
@@ -143,7 +143,7 @@ Limit transaction memory usage recommendation::
 The measured heap usage of all transactions is only an estimate and the actual heap utilization may be slightly larger or slightly smaller than the estimated value.
 In some cases, limitations of the estimation algorithm to detect shared objects at a deeper level of the memory graph could lead to overestimations.
 This is because a conservative estimate is given based on aggregated estimations of memory usage, where the identities of all contributing objects are not known, and cannot be assumed to be shared.
-For example, when you use link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/unwind[`UNWIND`] on a very large list, or expand a variable length or shortest path pattern, where many relationships are shared between the computed result paths.
+For example, when you use link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/unwind[`UNWIND`] on a very large list, or expand a variable length or shortest path pattern, where many relationships are shared between the computed result paths.
 +
 In these cases, if you experience problems with a query that gets terminated, you can execute the same query with the xref:performance/memory-configuration.adoc#memory-configuration-limit-transaction-memory[transaction memory limit] disabled.
 If the actual heap usage is not too large, it might succeed without triggering an out-of-memory error.

--- a/modules/ROOT/pages/performance/statistics-execution-plans.adoc
+++ b/modules/ROOT/pages/performance/statistics-execution-plans.adoc
@@ -9,7 +9,7 @@ This page describes how to configure the Neo4j statistics collection and the que
 [NOTE]
 ====
 Neo4j also uses statistical information about the database to optimize the execution plan.
-For more information, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/query-tuning[Cypher Manual -> Query tuning] and link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/execution-plans[Cypher Manual -> Execution plans].
+For more information, see link:{neo4j-docs-base-uri}/cypher-manual/current/query-tuning[Cypher Manual -> Query tuning] and link:{neo4j-docs-base-uri}/cypher-manual/current/execution-plans[Cypher Manual -> Execution plans].
 ====
 
 [[neo4j-statistics]]
@@ -132,6 +132,6 @@ You can use Cypher replanning to specify whether you want to force a replan, eve
 
 For more information, see:
 
-* link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/query-tuning#cypher-replanning[Cypher manual -> Cypher replanning]
-* link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/execution-plans[Cypher manual -> Execution plans]
+* link:{neo4j-docs-base-uri}/cypher-manual/current/query-tuning#cypher-replanning[Cypher manual -> Cypher replanning]
+* link:{neo4j-docs-base-uri}/cypher-manual/current/execution-plans[Cypher manual -> Execution plans]
 * xref:procedures.adoc[Procedures]

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -32,10 +32,10 @@ It also lists current xref:procedures.adoc#deprecated-procedures[deprecated proc
 The available procedures on a server depends on several factors:
 
 * Neo4j Enterprise Edition provides a larger set of procedures than Neo4j Community Edition.
-* Neo4j's link:{neo4j-docs-base-uri}/apoc/{page-version}/[APOC Core library] and link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/genai-integrations/[GenAI plugin] are installed by default on link:{neo4j-docs-base-uri}/aura/[Aura] instances, but have to be installed separately on on-prem servers.
+* Neo4j's link:{neo4j-docs-base-uri}/apoc/{page-version}/[APOC Core library] and link:{neo4j-docs-base-uri}/cypher-manual/current/genai-integrations/[GenAI plugin] are installed by default on link:{neo4j-docs-base-uri}/aura/[Aura] instances, but have to be installed separately on on-prem servers.
 * Cluster members have procedures that are not available in standalone mode.
 
-To check which procedures are available in your Neo4j DBMS, use the Cypher command link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/listing-procedures[`SHOW PROCEDURES`]:
+To check which procedures are available in your Neo4j DBMS, use the Cypher command link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/listing-procedures[`SHOW PROCEDURES`]:
 
 .List available procedures with default output columns
 [source, cypher]
@@ -123,7 +123,7 @@ For more information, see xref:monitoring/background-jobs.adoc[].
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [role=label--enterprise-edition label--admin-only]
@@ -145,7 +145,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [role=label--enterprise-edition label--admin-only]
@@ -176,7 +176,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [role=label--enterprise-edition]
@@ -737,7 +737,7 @@ For more information, see xref:configuration/index.adoc[].
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 
@@ -852,7 +852,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 == Connection management
@@ -936,7 +936,7 @@ For more information, see xref:database-administration/index.adoc[] and xref:dat
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [[procedure_db_info]]
@@ -976,7 +976,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [role=label--enterprise-edition label--admin-only]
@@ -1119,7 +1119,7 @@ If there are two servers in `QUARANTINED` mode, then you should not use concurre
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 
@@ -1143,17 +1143,17 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 == GenAI and vectors
 
 For more information, see:
 
-* link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes/semantic-indexes/vector-indexes/[Cypher Manual -> Vector indexes]
-* link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/genai-integrations[Cypher Manual -> GenAI integrations]
-* link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions/vector-functions/[Cypher Manual -> Vector functions]
-* link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions/genai-functions/[Cypher Manual -> GenAI functions]
+* link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/vector-indexes/[Cypher Manual -> Vector indexes]
+* link:{neo4j-docs-base-uri}/cypher-manual/current/genai-integrations[Cypher Manual -> GenAI integrations]
+* link:{neo4j-docs-base-uri}/cypher-manual/current/functions/vector-functions/[Cypher Manual -> Vector functions]
+* link:{neo4j-docs-base-uri}/cypher-manual/current/functions/genai-functions/[Cypher Manual -> GenAI functions]
 * link:{neo4j-docs-base-uri}/genai/tutorials/embeddings-vector-indexes/[GenAI documentation -> Embeddings & Vector Indexes Tutorial]
 
 [role=label--beta]
@@ -1248,7 +1248,7 @@ Use the `db.index.vector.queryNodes` procedure to query the named index.
 | `vectorDimension` | `INTEGER` | vectorDimension :: INTEGER
 | `vectorSimilarityFunction` | `STRING` | vectorSimilarityFunction :: STRING
 | *Mode* 3+| SCHEMA
-| *Replaced by* 3+| the Cypher command `CREATE VECTOR INDEX`. For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes/semantic-indexes/vector-indexes/#create-vector-index[Cypher Manual -> Create a vector index].
+| *Replaced by* 3+| the Cypher command `CREATE VECTOR INDEX`. For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/vector-indexes/#create-vector-index[Cypher Manual -> Create a vector index].
 |===
 
 [[procedure_db_index_vector_createrelationshipindex]]
@@ -1323,7 +1323,7 @@ For each element in the given resource LIST this returns:
 | *Mode* 3+| DEFAULT
 |===
 
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/genai-integrations/#multiple-embeddings[Cypher Manual -> Generating a batch of embeddings].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/genai-integrations/#multiple-embeddings[Cypher Manual -> Generating a batch of embeddings].
 
 .Known issue
 [NOTE]
@@ -1355,8 +1355,8 @@ The types are still enforced as `LIST<INTEGER | FLOAT>`.
 For more information, see:
 
 * xref:performance/index-configuration.adoc[]
-* link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes/search-performance-indexes/overview/[Cypher Manual -> Search performance indexes]
-* link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes/semantic-indexes/full-text-indexes[Cypher Manual -> Full-text indexes]
+* link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/overview/[Cypher Manual -> Search performance indexes]
+* link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/full-text-indexes[Cypher Manual -> Full-text indexes]
 
 [[procedure_db_awaitindex]]
 === db.awaitIndex()
@@ -1376,7 +1376,7 @@ For more information, see:
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [[procedure_db_awaitIndexes]]
@@ -1396,7 +1396,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 
@@ -1499,7 +1499,7 @@ An example of the `options` map: `{skip: 30, limit: 10, analyzer: 'whitespace'}`
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 
@@ -1518,7 +1518,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 == Metrics
@@ -1564,7 +1564,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [[procedure_db_schema_reltypeproperties]]
@@ -1588,7 +1588,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [[procedure_db_schema_visualization]]
@@ -1609,7 +1609,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [[procedure_db_createlabel]]
@@ -1682,7 +1682,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [[procedure_db_relationshiptypes]]
@@ -1702,7 +1702,7 @@ For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-ver
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 == Statistics and query planning
@@ -1741,7 +1741,7 @@ For more information, see xref:performance/statistics-execution-plans.adoc[]
 ====
 This procedure is not considered safe to run from multiple threads.
 It is therefore not supported by the parallel runtime.
-For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
+For more information, see the link:{neo4j-docs-base-uri}/cypher-manual/current/planning-and-tuning/runtimes/concepts#runtimes-parallel-runtime[Cypher Manual -> Parallel runtime].
 ====
 
 [role=label--admin-only]

--- a/modules/ROOT/pages/security/checklist.adoc
+++ b/modules/ROOT/pages/security/checklist.adoc
@@ -39,7 +39,7 @@ For more information, see xref:authentication-authorization/ldap-integration.ado
 Only the operating system user that Neo4j runs as should have permissions to those files.
 Refer to xref:configuration/file-locations.adoc#file-locations-permissions[File permissions] for instructions on permission levels.
 . With `LOAD CSV` enabled, ensure that it does not allow unauthorized users to import data.
-How to configure `LOAD CSV` is described in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/load-csv[Cypher Manual -> `LOAD CSV`].
+How to configure `LOAD CSV` is described in link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/load-csv[Cypher Manual -> `LOAD CSV`].
 . Use Neo4j authentication.
 The setting `xref:configuration/configuration-settings.adoc#config_dbms.security.auth_enabled[dbms.security.auth_enabled]` controls native authentication.
 The default value is `true`.

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -19,7 +19,7 @@ If your data has a lot of faults, it is recommended to clean it using a dedicate
 Other methods of importing data into Neo4j might be better suited to non-admin users:
 
 * Cypher(R) - CSV data can be bulk loaded via the Cypher command `LOAD CSV`.
-See link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/load-csv/[Cypher Manual -> `LOAD CSV`].
+See link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/load-csv/[Cypher Manual -> `LOAD CSV`].
 * Graphical Tools - link:{neo4j-docs-base-uri}/aura/auradb/importing/importing-data/#_load_csv[Neo4j AuraDB -> Importing data].
 
 [NOTE]
@@ -45,7 +45,7 @@ This section describes the `neo4j-admin database import` option.
 
 [TIP]
 ====
-For information on `LOAD CSV`, see the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/clauses/load-csv[Cypher Manual -> `LOAD CSV`].
+For information on `LOAD CSV`, see the link:{neo4j-docs-base-uri}/cypher-manual/current/clauses/load-csv[Cypher Manual -> `LOAD CSV`].
 For in-depth examples of using the command `neo4j-admin database import`, refer to the xref:tutorial/neo4j-admin-import.adoc[Tutorials -> Neo4j Admin import].
 ====
 
@@ -66,7 +66,7 @@ These are some things you need to keep in mind when creating your input files:
 .Indexes and constraints
 ====
 Indexes and constraints are not created during the import.
-Instead, you have to add these afterward (see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/indexes-for-full-text-search[Cypher Manual -> Indexes]).
+Instead, you have to add these afterward (see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-full-text-search[Cypher Manual -> Indexes]).
 
 You can use the `--schema` option to create indexes and contraints during the import process.
 The option is available in the Enterprise Edition and works only for the block format.
@@ -1000,8 +1000,8 @@ For example, importing nodes with a `Person` label that are uniquely identified 
 This is also true when working with multiple groups.
 For example, you can use `uuid:ID(Person){label:Person}`, where the relationship CSV data can refer to different groups for its `:START_ID` and `:END_ID`, just like the full import method.
 
-* For more information on constraints, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints[Cypher Manual -> Constraints].
-* For examples of creating property uniqueness constraints, see link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/constraints/managing-constraints/#create-property-uniqueness-constraints[Cypher Manual -> Create property uniqueness constraints].
+* For more information on constraints, see link:{neo4j-docs-base-uri}/cypher-manual/current/constraints[Cypher Manual -> Constraints].
+* For examples of creating property uniqueness constraints, see link:{neo4j-docs-base-uri}/cypher-manual/current/constraints/managing-constraints/#create-property-uniqueness-constraints[Cypher Manual -> Create property uniqueness constraints].
 ====
 
 [[import-tool-header-format-nodes]]
@@ -1130,7 +1130,7 @@ The max length of property keys for block format is 16,383 characters.
 
 Use one of `int`, `long`, `float`, `double`, `boolean`, `byte`, `short`, `char`, `string`, `point`, `date`, `localtime`, `time`, `localdatetime`, `datetime`, and `duration` to designate the data type for properties.
 By default, types (except arrays) are converted to Cypher types.
-See link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/values-and-types/property-structural-constructed/#_property_types[Cypher Manual -> Property, structural, and constructed values].
+See link:{neo4j-docs-base-uri}/cypher-manual/current/values-and-types/property-structural-constructed/#_property_types[Cypher Manual -> Property, structural, and constructed values].
 
 This behavior can be disabled using the option `--normalize-types=false`.
 Normalizing types can require more space on disk, but avoids Cypher converting the type during queries.
@@ -1162,7 +1162,7 @@ user03,Moe Know,2018-02-17,false,7
 
 Special considerations for the `point` data type::
 A point is specified using the Cypher syntax for maps.
-The map allows the same keys as the input to the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/functions/spatial/[Cypher Manual -> Point function].
+The map allows the same keys as the input to the link:{neo4j-docs-base-uri}/cypher-manual/current/functions/spatial/[Cypher Manual -> Point function].
 The point data type in the header can be amended with a map of default values used for all values of that column, e.g. `point{crs: 'WGS-84'}`.
 Specifying the header this way allows you to have an incomplete map in the value position in the data file.
 Optionally, a value in a data file may override default values from the header.
@@ -1210,7 +1210,7 @@ city03  San Mateo   {latitude:37.554167, longitude:-122.313056, height: 100, crs
 ====
 
 Special considerations for temporal data types::
-The format for all temporal data types must be defined as described in link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/values-and-types/temporal/#cypher-temporal-instants[Cypher Manual -> Temporal instants syntax] and link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/values-and-types/temporal/#cypher-temporal-durations[Cypher Manual -> Durations syntax].
+The format for all temporal data types must be defined as described in link:{neo4j-docs-base-uri}/cypher-manual/current/values-and-types/temporal/#cypher-temporal-instants[Cypher Manual -> Temporal instants syntax] and link:{neo4j-docs-base-uri}/cypher-manual/current/values-and-types/temporal/#cypher-temporal-durations[Cypher Manual -> Durations syntax].
 Two of the temporal types, _Time_ and _DateTime_, take a time zone parameter that might be common between all or many of the values in the data file.
 It is therefore possible to specify a default time zone for _Time_ and _DateTime_ values in the header, for example: `time{timezone:+02:00}` and: `datetime{timezone:Europe/Stockholm}`.
 If no default time zone is specified, the default timezone is determined by the xref:/configuration/configuration-settings.adoc#config_db.temporal.timezone[`db.temporal.timezone`] configuration setting.


### PR DESCRIPTION
The page-version attribute between the 2 manuals will no longer match once 2025.01 is released