### PR TITLE
Add missing options of the copy and incremental import commands

### DIFF
--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -212,11 +212,14 @@ For more information on the block format, see xref:database-internals/store-form
 
 [NOTE]
 ====
-In addition to the `--from-pagecache=<size>` option, a new option `--max-off-heap-memory` is introduced in Neo4j 2025.01.
+In Neo4j 2025.01, the `--from-pagecache=<size>` option is replaced with a dual-named option: `--from-pagecache, --max-off-heap-memory=<size>`.
+This change helps you to control off-heap memory rather than just allocate cache.
 
-You can still use the `--from-pagecache` option to speed up the copy operation by specifying how much cache to allocate when reading the source.
-The `--from-pagecache` should be assigned whatever memory you can spare since Neo4j does random reads from the source.
-Note that the `--from-pagecache` option is considered to be deprecated.
+Both options control the same underlying parameter, which determines the maximum amount of off-heap memory available for reading the source database during the copy process.
+
+To configure this value, you can use either `--from-pagecache=<size>` or `--max-off-heap-memory=<size>`.
+
+Note that the `--from-pagecache` option is considered to be deprecated and may be removed in future versions.
 ====
 
 

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -212,11 +212,13 @@ For more information on the block format, see xref:database-internals/store-form
 
 [NOTE]
 ====
-In Neo4j 2025.01, the `--from-pagecache=<size>` option is replaced with a dual-named option: `--from-pagecache, --max-off-heap-memory=<size>`, which determines the maximum amount of off-heap memory available during the copy process, for both reading and writing.
+In Neo4j 2025.01, a new dual-named option `--from-pagecache, --max-off-heap-memory=<size>` replaces the `--from-pagecache=<size>` option, which was used to specify how much cache to allocate when reading the source.
+
+The new option determines the maximum amount of off-heap memory available during the copy process for reading and writing.
 This change helps you to control off-heap memory rather than just allocate cache.
 
 To configure the off-heap memory value, you can use either `--from-pagecache=<size>` or `--max-off-heap-memory=<size>`.
-Note that the `--from-pagecache` option is considered to be deprecated and may be removed in future versions.
+Note that the `--from-pagecache` option is considered deprecated and may be removed in future versions.
 ====
 
 

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -28,7 +28,7 @@ For more information, see <<copy-estimating-iops, Estimating the processing time
 [source,role=noheader]
 ----
 neo4j-admin database copy [-h] [--copy-schema] [--expand-commands] [--force] [--verbose] [--compact-node-store[=true|false]]
-                             [--additional-config=<file>] [--from-pagecache=<size>] [--from-pagecache, --max-off-heap-memory=<size>]
+                             [--additional-config=<file>] [--from-pagecache, --max-off-heap-memory=<size>]
                              [--temp-path=<path>] [--to-format=<format>]
                              [--to-path-schema=<path>] [--copy-only-node-properties=<label.property>[,<label.property>...]]...
                              [--copy-only-nodes-with-labels=<label>[,<label>...]]... [--copy-only-relationship-properties=<relationship.
@@ -123,13 +123,6 @@ The indexes will be built the first time the database is started.
 |--force
 |Force the command to run even if the integrity of the database cannot be verified.
 |
-
-|--from-pagecache=<size>
-|The size of the page cache to use for reading.
-[TIP]
-You can use the `--from-pagecache` option to speed up the copy operation by specifying how much cache to allocate when reading the source.
-The `--from-pagecache` should be assigned whatever memory you can spare since Neo4j does random reads from the source.
-|8m
 
 |--from-path-data=<path>
 |Path to the databases directory, containing the database directory to source from.

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -157,10 +157,10 @@ Cannot be combined with `--copy-only-relationships-with-types`.
 |
 
 |--from-pagecache, --max-off-heap-memory=<size>
-|Maximum memory that neo4j-admin can use for various data structures and caching to improve performance.
+|label:new[Introduced in 2025.01] Maximum memory that neo4j-admin can use for various data structures and caching to improve performance.
 Values can be plain numbers, such as 10000000, or 20G for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example 70%.
-|
+|90%
 
 |--skip-labels=<label>[,<label>...]
 |A comma-separated list of labels to ignore.

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -212,13 +212,13 @@ For more information on the block format, see xref:database-internals/store-form
 
 [NOTE]
 ====
-In Neo4j 2025.01, a new dual-named option `--from-pagecache, --max-off-heap-memory=<size>` replaces the `--from-pagecache=<size>` option, which was used to specify how much cache to allocate when reading the source.
+Neo4j 2025.01 introduces a dual-named option `--from-pagecache, --max-off-heap-memory=<size>`, which enhances the functionality of the `--from-pagecache=<size>` option.
 
-The new option determines the maximum amount of off-heap memory available during the copy process for reading and writing.
-This change helps you to control off-heap memory rather than just allocate cache.
+The new option determines the maximum amount of off-heap memory available during the copy process for reading and writing, instead of specifying how much cache to allocate when reading the source.
 
-To configure the off-heap memory value, you can use either `--from-pagecache=<size>` or `--max-off-heap-memory=<size>`.
-Note that the `--from-pagecache` option is considered deprecated and may be removed in future versions.
+For details, see <<off-heap-memory-control,Improving the performance>>.
+
+Note that the `--from-pagecache` option may be removed in future versions.
 ====
 
 
@@ -375,3 +375,29 @@ Therefore, with an additional 144 GB of both read and write, the best-case scena
 
 Finally, it is also important to consider that in almost all Cloud environments, the published IOPS value may not be the same as the actual value, or be able to continuously maintain the maximum possible IOPS.
 The real processing time for this example _could_ be well above that estimation of 3 hours.
+
+[[off-heap-memory-control]]
+=== Improving the performance
+
+You can improve the performance of the copy process by specifying the memory limit.
+Neo4j 2025.01 introduces an option `--from-pagecache, --max-off-heap-memory=<size>` to replace the old `--from-pagecache=<size>` option.
+
+The new option controls how much off-heap memory the copy process may use in addition to the heap size the JVM is given.
+Values can be plain numbers, such as 10000000, or 20G for 20 gigabytes.
+It can also be specified as a percentage of the available memory, for example 70%.
+
+Starting from 2025.01, to configure the off-heap memory value, you can use either the old name `--from-pagecache=<size>` or the new one `--max-off-heap-memory=<size>`.
+
+
+.Using `--from-pagecache=<size>`
+[source, shell]
+----
+bin/neo4j-admin database copy neo4j copy --from-pagecache=95%
+----
+
+.Using `--max-off-heap-memory=<size>`
+[source, shell]
+----
+bin/neo4j-admin database copy neo4j copy --max-off-heap-memory=95%
+----
+

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -28,7 +28,7 @@ For more information, see <<copy-estimating-iops, Estimating the processing time
 [source,role=noheader]
 ----
 neo4j-admin database copy [-h] [--copy-schema] [--expand-commands] [--force] [--verbose] [--compact-node-store[=true|false]]
-                             [--additional-config=<file>] [--from-pagecache] [--max-off-heap-memory=<size>]
+                             [--additional-config=<file>] [--from-pagecache=<size>] [--from-pagecache, --max-off-heap-memory=<size>]
                              [--temp-path=<path>] [--to-format=<format>]
                              [--to-path-schema=<path>] [--copy-only-node-properties=<label.property>[,<label.property>...]]...
                              [--copy-only-nodes-with-labels=<label>[,<label>...]]... [--copy-only-relationship-properties=<relationship.
@@ -124,7 +124,7 @@ The indexes will be built the first time the database is started.
 |Force the command to run even if the integrity of the database cannot be verified.
 |
 
-|--from-pagecache
+|--from-pagecache=<size>
 |The size of the page cache to use for reading.
 [TIP]
 You can use the `--from-pagecache` option to speed up the copy operation by specifying how much cache to allocate when reading the source.
@@ -156,7 +156,7 @@ relationship types will not be included in the copy.
 Cannot be combined with `--copy-only-relationships-with-types`.
 |
 
-|--max-off-heap-memory=<size>
+|--from-pagecache, --max-off-heap-memory=<size>
 |Maximum memory that neo4j-admin can use for various data structures and caching to improve performance.
 Values can be plain numbers, such as 10000000, or 20G for 20 gigabytes.
 It can also be specified as a percentage of the available memory, for example 70%%.

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -210,6 +210,16 @@ The block format is the default format for all newly-created databases as long a
 For more information on the block format, see xref:database-internals/store-formats.adoc[Store formats].
 ====
 
+[NOTE]
+====
+In addition to the `--from-pagecache=<size>` option, a new option `--max-off-heap-memory` is introduced in Neo4j 2025.01.
+
+You can still use the `--from-pagecache` option to speed up the copy operation by specifying how much cache to allocate when reading the source.
+The `--from-pagecache` should be assigned whatever memory you can spare since Neo4j does random reads from the source.
+Note that the `--from-pagecache` option is considered to be deprecated.
+====
+
+
 [[copy-database-examples]]
 == Examples
 

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -212,13 +212,10 @@ For more information on the block format, see xref:database-internals/store-form
 
 [NOTE]
 ====
-In Neo4j 2025.01, the `--from-pagecache=<size>` option is replaced with a dual-named option: `--from-pagecache, --max-off-heap-memory=<size>`.
+In Neo4j 2025.01, the `--from-pagecache=<size>` option is replaced with a dual-named option: `--from-pagecache, --max-off-heap-memory=<size>`, which determines the maximum amount of off-heap memory available during the copy process, for both reading and writing.
 This change helps you to control off-heap memory rather than just allocate cache.
 
-Both options control the same underlying parameter, which determines the maximum amount of off-heap memory available for reading the source database during the copy process.
-
-To configure this value, you can use either `--from-pagecache=<size>` or `--max-off-heap-memory=<size>`.
-
+To configure the off-heap memory value, you can use either `--from-pagecache=<size>` or `--max-off-heap-memory=<size>`.
 Note that the `--from-pagecache` option is considered to be deprecated and may be removed in future versions.
 ====
 

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -28,7 +28,8 @@ For more information, see <<copy-estimating-iops, Estimating the processing time
 [source,role=noheader]
 ----
 neo4j-admin database copy [-h] [--copy-schema] [--expand-commands] [--force] [--verbose] [--compact-node-store[=true|false]]
-                             [--additional-config=<file>] [--from-pagecache=<size>] [--temp-path=<path>] [--to-format=<format>]
+                             [--additional-config=<file>] [--from-pagecache] [--max-off-heap-memory=<size>]
+                             [--temp-path=<path>] [--to-format=<format>]
                              [--to-path-schema=<path>] [--copy-only-node-properties=<label.property>[,<label.property>...]]...
                              [--copy-only-nodes-with-labels=<label>[,<label>...]]... [--copy-only-relationship-properties=<relationship.
                              property>[,<relationship.property>...]]... [--copy-only-relationships-with-types=<type>[,<type>...]]...
@@ -123,7 +124,7 @@ The indexes will be built the first time the database is started.
 |Force the command to run even if the integrity of the database cannot be verified.
 |
 
-|--from-pagecache=<size>
+|--from-pagecache
 |The size of the page cache to use for reading.
 [TIP]
 You can use the `--from-pagecache` option to speed up the copy operation by specifying how much cache to allocate when reading the source.
@@ -153,6 +154,12 @@ Cannot be combined with `--copy-only-nodes-with-labels`.
 |A comma-separated list of relationship types. Relationships with any of the specified
 relationship types will not be included in the copy.
 Cannot be combined with `--copy-only-relationships-with-types`.
+|
+
+|--max-off-heap-memory=<size>
+|Maximum memory that neo4j-admin can use for various data structures and caching to improve performance.
+Values can be plain numbers, such as 10000000, or 20G for 20 gigabytes.
+It can also be specified as a percentage of the available memory, for example 70%%.
 |
 
 |--skip-labels=<label>[,<label>...]

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -159,7 +159,7 @@ Cannot be combined with `--copy-only-relationships-with-types`.
 |--from-pagecache, --max-off-heap-memory=<size>
 |Maximum memory that neo4j-admin can use for various data structures and caching to improve performance.
 Values can be plain numbers, such as 10000000, or 20G for 20 gigabytes.
-It can also be specified as a percentage of the available memory, for example 70%%.
+It can also be specified as a percentage of the available memory, for example 70%.
 |
 
 |--skip-labels=<label>[,<label>...]

--- a/modules/ROOT/pages/changes-deprecations-removals.adoc
+++ b/modules/ROOT/pages/changes-deprecations-removals.adoc
@@ -539,7 +539,10 @@ Neo4j 2025.01::
 
 * The `neo4j-admin database copy` command.
 +
-The `--from-pagecache=<size>` option is replaced with an option: `--from-pagecache, --max-off-heap-memory=<size>`, which controls the amount of off-heap memory used for the copy operation.
+The functionality of the `--from-pagecache=<size>` option is changed. +
+Instead of specifying how much cache to allocate when reading the source, now you can control the maximum amount of off-heap memory used for the copy operation, both for reading and writing.
+By configuring the off-heap memory value, you can impact the cache allocation as well. +
+To reflect this change, a new name was added to the option: `--max-off-heap-memory=<size>`.
 +
 For details, refer to the xref:backup-restore/copy-database.adoc#off-heap-memory-control[Improving the performance].
 

--- a/modules/ROOT/pages/changes-deprecations-removals.adoc
+++ b/modules/ROOT/pages/changes-deprecations-removals.adoc
@@ -529,4 +529,17 @@ Replaced by xref:backup-restore/aggregate.adoc[`neo4j-admin backup aggregate`]
 For more information, see xref:clustering/databases.adoc#s3-seed-provider[Seed from URI].
 
 
+== Changes in Neo4j 2025.x
+
+The section covers changes to Neo4j server functionality across different areas.
+
+=== Neo4j-admin tool
+
+Neo4j 2025.01::
+
+* The `neo4j-admin database copy` command.
++
+The `--from-pagecache=<size>` option is replaced with an option: `--from-pagecache, --max-off-heap-memory=<size>`, which controls the amount of off-heap memory used for the copy operation.
++
+For details, refer to the xref:backup-restore/copy-database.adoc#off-heap-memory-control[Improving the performance].
 

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -880,7 +880,7 @@ performance, this value should not be greater than the number of available proce
 |false
 
 |--update-all-matching-relationships
-|label:new[Introduced in 2025.01] If one relationship data entry matches multiple existing relationships, this decides whether to update all matching, or to instead log as error --verbose Enable verbose output.
+|label:new[Introduced in 2025.01] If one relationship data entry matches multiple existing relationships, this decides whether to update all matching, or to instead log as error.
 |false
 
 |--verbose

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -880,7 +880,7 @@ performance, this value should not be greater than the number of available proce
 |false
 
 |--update-all-matching-relationships
-|If one relationship data entry matches multiple existing relationships, this decides whether to update all matching, or to instead log as error
+|If one relationship data entry matches multiple existing relationships, this decides whether to update all matching, or to instead log as error --verbose Enable verbose output.
 |false
 
 |--verbose

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -609,8 +609,8 @@ neo4j-admin database import incremental [-h] [--expand-commands] --force [--upda
                                         [--read-buffer-size=<size>] [--report-file=<path>] [--schema=<path>]
                                         [--stage=all|prepare|build|merge] [--threads=<num>] --nodes=[<label>[:
                                         <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
-                                        [--relationships=[<type>=]<files>...]... [--multiline-fields=true|false|<path>[,
-                                        <path>] [--multiline-fields-format=v1|v2]] <database>
+                                        [--relationships=[<type>=]<files>...]... [--multiline-fields=true|false|<path>[,<path>]
+                                        [--multiline-fields-format=v1|v2]] <database>
 ----
 
 === Description

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -595,7 +595,8 @@ The syntax for importing a set of CSV files incrementally is:
 
 [source, syntax, role="nocopy"]
 ----
-neo4j-admin database import incremental [-h] [--expand-commands] --force [--verbose] [--auto-skip-subsequent-headers
+neo4j-admin database import incremental [-h] [--expand-commands] --force [--update-all-matching-relationships] 
+                                        [--verbose] [--auto-skip-subsequent-headers
                                         [=true|false]] [--ignore-empty-strings[=true|false]] [--ignore-extra-columns
                                         [=true|false]] [--legacy-style-quoting[=true|false]] [--normalize-types
                                         [=true|false]] [--skip-bad-entries-logging[=true|false]]
@@ -876,6 +877,10 @@ performance, this value should not be greater than the number of available proce
 
 |--trim-strings[=true\|false]footnote:ingnoredByParquet2[]
 |Whether or not strings should be trimmed for whitespaces.
+|false
+
+|--update-all-matching-relationships
+|If one relationship data entry matches multiple existing relationships, this decides whether to update all matching, or to instead log as error
 |false
 
 |--verbose

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -596,20 +596,20 @@ The syntax for importing a set of CSV files incrementally is:
 [source, syntax, role="nocopy"]
 ----
 neo4j-admin database import incremental [-h] [--expand-commands] --force [--update-all-matching-relationships] 
-                                        [--verbose] [--auto-skip-subsequent-headers
-                                        [=true|false]] [--ignore-empty-strings[=true|false]] [--ignore-extra-columns
-                                        [=true|false]] [--legacy-style-quoting[=true|false]] [--normalize-types
-                                        [=true|false]] [--skip-bad-entries-logging[=true|false]]
-                                        [--skip-bad-relationships[=true|false]] [--skip-duplicate-nodes[=true|false]]
-                                        [--strict[=true|false]] [--trim-strings[=true|false]]
-                                        [--additional-config=<file>] [--array-delimiter=<char>] [--bad-tolerance=<num>]
-                                        [--delimiter=<char>] [--high-parallel-io=on|off|auto]
-                                        [--id-type=string|integer|actual] [--input-encoding=<character-set>]
-                                        [--input-type=csv|parquet] [--max-off-heap-memory=<size>] [--quote=<char>]
-                                        [--read-buffer-size=<size>] [--report-file=<path>] [--schema=<path>]
-                                        [--stage=all|prepare|build|merge] [--threads=<num>] --nodes=[<label>[:
-                                        <label>]...=]<files>... [--nodes=[<label>[:<label>]...=]<files>...]...
-                                        [--relationships=[<type>=]<files>...]... [--multiline-fields=true|false|<path>[,<path>]
+                                        [--verbose] [--auto-skip-subsequent-headers[=true|false]]
+                                        [--ignore-empty-strings[=true|false]] [--ignore-extra-columns[=true|false]]
+                                        [--legacy-style-quoting[=true|false]] [--normalize-types[=true|false]]
+                                        [--skip-bad-entries-logging[=true|false]] [--skip-bad-relationships
+                                        [=true|false]] [--skip-duplicate-nodes[=true|false]] [--strict[=true|false]]
+                                        [--trim-strings[=true|false]] [--additional-config=<file>]
+                                        [--array-delimiter=<char>] [--bad-tolerance=<num>] [--delimiter=<char>]
+                                        [--high-parallel-io=on|off|auto] [--id-type=string|integer|actual]
+                                        [--input-encoding=<character-set>] [--input-type=csv|parquet]
+                                        [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>]
+                                        [--report-file=<path>] [--schema=<path>] [--stage=all|prepare|build|merge]
+                                        [--threads=<num>] --nodes=[<label>[:<label>]...=]<files>...  [--nodes=[<label>[:
+                                        <label>]...=]<files>...]... [--relationships=[<type>=]<files>...]...
+                                        [--multiline-fields=true|false|<path>[,<path>]
                                         [--multiline-fields-format=v1|v2]] <database>
 ----
 

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -607,7 +607,7 @@ neo4j-admin database import incremental [-h] [--expand-commands] --force [--upda
                                         [--input-encoding=<character-set>] [--input-type=csv|parquet]
                                         [--max-off-heap-memory=<size>] [--quote=<char>] [--read-buffer-size=<size>]
                                         [--report-file=<path>] [--schema=<path>] [--stage=all|prepare|build|merge]
-                                        [--threads=<num>] --nodes=[<label>[:<label>]...=]<files>...  [--nodes=[<label>[:
+                                        [--threads=<num>] --nodes=[<label>[:<label>]...=]<files>... [--nodes=[<label>[:
                                         <label>]...=]<files>...]... [--relationships=[<type>=]<files>...]...
                                         [--multiline-fields=true|false|<path>[,<path>]
                                         [--multiline-fields-format=v1|v2]] <database>
@@ -880,7 +880,7 @@ performance, this value should not be greater than the number of available proce
 |false
 
 |--update-all-matching-relationships
-|If one relationship data entry matches multiple existing relationships, this decides whether to update all matching, or to instead log as error --verbose Enable verbose output.
+|label:new[Introduced in 2025.01] If one relationship data entry matches multiple existing relationships, this decides whether to update all matching, or to instead log as error --verbose Enable verbose output.
 |false
 
 |--verbose


### PR DESCRIPTION
Document changes for the 2025.01 release:
* new option of the copy command
* new option of the incremental import command

The `neo4j-admin database restore` command will be updated in the 2025.02 release.