### PR TITLE
Discovery v2 - hightlight port change

### DIFF
--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -26,6 +26,10 @@ The new version v2 introduces the following configuration settings to control th
 Possible values are `V1_ONLY`, `V2_ONLY`, `V1_OVER_V2`, and `V2_OVER_V1`.
 * xref:configuration/configuration-settings.adoc#config_dbms.kubernetes.discovery.v2.service_port_name[`dbms.kubernetes.discovery.v2.service_port_name`] to specify the name of the service port name used in the Kubernetes API when using version v2.
 
+xref:configuration/ports.adoc[`Ports`] have also changed in discovery v2.
+Cluster discovery v1 port is no longer in used (port 5000).
+Instead discovery v2 now uses the Cluster internal traffic port (port 6000).
+
 The following sections describe the different methods for server discovery, configuration settings, and examples of how to move from discovery service v1 to v2.
 
 [[clustering-discovery-methods]]

--- a/modules/ROOT/pages/clustering/setup/discovery.adoc
+++ b/modules/ROOT/pages/clustering/setup/discovery.adoc
@@ -26,9 +26,9 @@ The new version v2 introduces the following configuration settings to control th
 Possible values are `V1_ONLY`, `V2_ONLY`, `V1_OVER_V2`, and `V2_OVER_V1`.
 * xref:configuration/configuration-settings.adoc#config_dbms.kubernetes.discovery.v2.service_port_name[`dbms.kubernetes.discovery.v2.service_port_name`] to specify the name of the service port name used in the Kubernetes API when using version v2.
 
-xref:configuration/ports.adoc[`Ports`] have also changed in discovery v2.
-Cluster discovery v1 port is no longer in used (port 5000).
-Instead discovery v2 now uses the Cluster internal traffic port (port 6000).
+xref:configuration/ports.adoc[`Ports`] have also changed in discovery service v2.
+Port `5000`, the discovery v1 port, is no longer used.
+Instead, discovery service v2 uses port `6000` - the cluster internal traffic port.
 
 The following sections describe the different methods for server discovery, configuration settings, and examples of how to move from discovery service v1 to v2.
 


### PR DESCRIPTION
This is to highlight the port change for discovery v2. I don't think this is needed in v2025 because users should be using Lighthouse by then.