### PR TITLE
Fix the Configure the thread pool for a Bolt connector example to show minimum size 5 as it is in the description (#2103)

### DIFF
--- a/modules/ROOT/pages/performance/bolt-thread-pool-configuration.adoc
+++ b/modules/ROOT/pages/performance/bolt-thread-pool-configuration.adoc
@@ -64,7 +64,7 @@ In this example we configure the Bolt thread pool to be of minimum size `5`, max
 
 [source, properties]
 ----
-server.bolt.thread_pool_min_size=10
+server.bolt.thread_pool_min_size=5
 server.bolt.thread_pool_max_size=100
 server.bolt.thread_pool_keep_alive=10m
 ----


### PR DESCRIPTION
Cherry-picked from #2103 