### PR TITLE
Turn 5th level headings into the descr list

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -334,35 +334,35 @@ If not used stores were more up to date than the used ones, this results in data
 ====
 
 [[specified-servers]]
-===== Specified servers
+Specified servers::
 
 You can specify a set of available servers.
 The stores on all allocations will be synchronized to the most up-to-date store from the defined servers.
 The number of defined servers cannot exceed the number of total allocations in the desired topology.
-
++
 [source, shell]
 ----
 CALL dbms.cluster.recreateDatabase("neo4j", {seedingServers: ["serverId1", "serverId2", "serverId3"]});
 ----
 
 [[undefined-servers]]
-===== Undefined servers
+Undefined servers::
 
 If you provide an empty list of seeding servers and do not specify a `seedURI`, Neo4j automatically selects all available allocations of the database as seeders.
 The store will be replaced by the most up-to-date seeder available in the cluster.
-
++
 [source, shell]
 ----
 CALL dbms.cluster.recreateDatabase("neo4j", {seedingServers: []});
 ----
 
 [[undefined-servers-backup]]
-===== Undefined servers with fallback backup
+Undefined servers with fallback backup::
 
 If both an empty list of seeding servers and a `seedURI` are provided, Neo4j finds all available allocations of the database and use those as seeders.
 However, if no available servers can be found, the database is recreated based on the backup or the dump defined by the URI.
 This means the store is replaced by the most up-to-date seeder if available; otherwise, the backup is used.
-
++
 [source, shell]
 ----
 CALL dbms.cluster.recreateDatabase("neo4j", {seedingServers: [], seedURI: "s3:/myBucket/myBackup.backup"});


### PR DESCRIPTION
Improve the formatting on the page _Manage db in cluster_. Based on the PR #2124 