### PR TITLE
Removed beta label from set vector property functions. (#2137)

### DIFF
--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -1155,7 +1155,6 @@ For more information, see:
 * link:{neo4j-docs-base-uri}/cypher-manual/current/functions/genai-functions/[Cypher Manual -> GenAI functions]
 * link:{neo4j-docs-base-uri}/genai/tutorials/embeddings-vector-indexes/[GenAI documentation -> Embeddings & Vector Indexes Tutorial]
 
-[role=label--beta]
 [[procedure_db_create_setnodevectorproperty]]
 === db.create.setNodeVectorProperty
 
@@ -1178,7 +1177,6 @@ Procedure signatures from `SHOW PROCEDURES` renders the vector arguments with a 
 The types are still enforced as `LIST<INTEGER | FLOAT>`.
 ====
 
-[role=label--beta]
 [[procedure_db_create_setrelationshipvectorproperty]]
 === db.create.setRelationshipVectorProperty()
 


### PR DESCRIPTION
These functions are supported, as they have been adopted by customers in production.