### PR TITLE
Add example on how to CREATE db from the seed URI

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -218,7 +218,8 @@ The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used toge
 
 ==== Create databases using seeding options
 
-Neo4j has built-in support for seed from a mounted file system (file), FTP server, HTTP/HTTPS server, Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
+Neo4j has built-in support for a seed from a mounted file system (file), FTP server, HTTP/HTTPS server, Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
+To select a seed provider, you need to configure xref:configuration/configuration-settings.afoc#config_dbms.databases.seed_from_uri_providers[dbms.databases.seed_from_uri_providers].
 
 For more information on seeding from URI, refer to xref::clustering/databases.adoc#cluster-seed-uri[Manage databases in a cluster -> Seed from URI].
 

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -222,7 +222,7 @@ Neo4j has built-in support for seed from a mounted file system (file), FTP serve
 
 For more information on seeding from URI, refer to xref::clustering/databases.adoc#cluster-seed-uri[Manage databases in a cluster -> Seed from URI].
 
-.Seed providers supported in Neo4j by default
+.Seed providers supported in Neo4j
 [cols="2,1,2",options="header"]
 |===
 | Seed provider

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -219,12 +219,12 @@ The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used toge
 ==== Create databases using seeding options
 
 Neo4j has built-in support for a seed from a mounted file system (file), FTP server, HTTP/HTTPS server, Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
-To select a seed provider, you need to configure xref:configuration/configuration-settings.adoc#config_dbms.databases.seed_from_uri_providers[dbms.databases.seed_from_uri_providers].
-
-For more details and examples of seeding from URI, refer to xref::clustering/databases.adoc#cluster-seed-uri[Manage databases in a cluster -> Seed from URI].
+The seed provider is determined by the xref:configuration/configuration-settings.adoc#config_dbms.databases.seed_from_uri_providers[dbms.databases.seed_from_uri_providers] setting.
+By default, Neo4j enables support for Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
+To use other providers, you must configure `dbms.databases.seed_from_uri_providers` accordingly.
 
 .Seed providers supported in Neo4j
-[cols="2,1,2",options="header"]
+[cols="2,1,3",options="header"]
 |===
 | Seed provider
 | URL scheme
@@ -234,7 +234,7 @@ For more details and examples of seeding from URI, refer to xref::clustering/dat
 | `file:`
 | `file:/tmp/backup1.backup`
 
-| `URLConnectionSeedProvider`
+| `URLConnectionSeedProvider`footnote:[From 2025.01, `URLConnectionSeedProvider` does not support `file`.]
 | `ftp:` +
 `http:` +
 `https:`
@@ -264,6 +264,8 @@ CREATE DATABASE foo OPTIONS {existingData: 'use', seedURI:'s3://myBucket/myBacku
 ----
 
 Starting from Neo4j 2025.01, seed from URI can also be used in combination with `CREATE OR REPLACE DATABASE`.
+
+For more details and examples of seeding from URI, refer to the xref::clustering/databases.adoc#cluster-seed-uri[Manage databases in a cluster -> Seed from URI] page.
 
 [[manage-databases-start]]
 == Start databases

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -216,7 +216,15 @@ The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used toge
 ====
 
 
-==== Create databases using seeding options
+==== Create a database using seeding options
+
+In Neo4j, you can create a database using the URI of the seed.
+The following example shows how to seed the database `customers` from Amazon S3.
+
+[source, cypher]
+----
+CREATE DATABASE customers OPTIONS {existingData: 'use', seedURI:'s3://myBucket/myBackup.backup'}
+----
 
 Neo4j has built-in support for a seed from a mounted file system (file), FTP server, HTTP/HTTPS server, Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
 The seed provider is determined by the xref:configuration/configuration-settings.adoc#config_dbms.databases.seed_from_uri_providers[dbms.databases.seed_from_uri_providers] setting, which defaults to `CloudSeedProvider`.
@@ -254,17 +262,9 @@ To use other providers, you must configure `dbms.databases.seed_from_uri_provide
 `azb://mystorageaccount.blob/backupscontainer/backup1.backup`
 |===
 
-
-The following example shows how to create a database using the URI of the seed:
-
-[source, cypher]
-----
-CREATE DATABASE foo OPTIONS {existingData: 'use', seedURI:'s3://myBucket/myBackup.backup'}
-----
-
 Starting from Neo4j 2025.01, seed from URI can also be used in combination with `CREATE OR REPLACE DATABASE`.
 
-For more details and examples of seeding from URI, refer to the xref::clustering/databases.adoc#cluster-seed-uri[Manage databases in a cluster -> Seed from URI] page.
+For more information about the seeding from URI functionality, refer to the xref::clustering/databases.adoc#cluster-seed-uri[Manage databases in a cluster -> Seed from URI] page.
 
 [[manage-databases-start]]
 == Start databases

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -219,7 +219,7 @@ The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used toge
 ==== Create databases using seeding options
 
 Neo4j has built-in support for a seed from a mounted file system (file), FTP server, HTTP/HTTPS server, Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
-To select a seed provider, you need to configure xref:configuration/configuration-settings.afoc#config_dbms.databases.seed_from_uri_providers[dbms.databases.seed_from_uri_providers].
+To select a seed provider, you need to configure xref:configuration/configuration-settings.adoc#config_dbms.databases.seed_from_uri_providers[dbms.databases.seed_from_uri_providers].
 
 For more information on seeding from URI, refer to xref::clustering/databases.adoc#cluster-seed-uri[Manage databases in a cluster -> Seed from URI].
 

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -92,17 +92,19 @@ Replaced by `existingDataSeedServer`.
 |
 Defines an identical seed from an external source which will be used to seed all servers.
 
+For examples, see xref::clustering/databases.adoc#cluster-seed-uri[Seed from URI].
+
 | `seedConfig`
 | Comma-separated list of configuration values.
 |
-For more information see xref::clustering/databases.adoc#cluster-seed-uri[Seed from URI].
+
 
 | `seedCredentials` label:deprecated[Deprecated in 5.26]
 | credentials
 |
 Defines credentials that need to be passed into certain seed providers.
 It is recommended to use the `CloudSeedProvider` seed provider, which does not require this configuration when seeding from cloud storage.
-For more information see xref::clustering/databases.adoc#cloud-seed-provider[CloudSeedProvider].
+For more information, see xref::clustering/databases.adoc#cloud-seed-provider[CloudSeedProvider].
 
 | `txLogEnrichment`
 | `FULL` \| `DIFF` \| `OFF`
@@ -213,6 +215,54 @@ The behavior of `IF NOT EXISTS` and `OR REPLACE` apply to both standard and comp
 The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used together.
 ====
 
+
+==== Create databases using seeding options
+
+Neo4j has built-in support for seed from a mounted file system (file), FTP server, HTTP/HTTPS server, Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
+
+For more information on seeding from URI, refer to xref::clustering/databases.adoc#cluster-seed-uri[Manage databases in a cluster -> Seed from URI].
+
+.Seed providers supported in Neo4j by default
+[cols="2,1,2",options="header"]
+|===
+| Seed provider
+| URL scheme
+| URI example
+
+| `FileSeedProvider`
+| `file:`
+| `file:/tmp/backup1.backup`
+
+| `URLConnectionSeedProvider`
+| `ftp:` +
+`http:` +
+`https:`
+| `ftp:://myftp.com/backups/backup1.backup` +
+`/http://myhttp.com/backups/backup1.backup` +
+`/https://myhttp.com/backups/backup1.backup`
+
+| `S3SeedProvider` label:deprecated[Deprecated in 5.26]
+| `s3:`
+| `s3://mybucket/backups/backup1.backup`
+
+| `CloudSeedProvider`
+| `s3:` +
+`gs:` +
+`azb:`
+| `s3://mybucket/backups/backup1.backup` +
+`gs://mybucket/backups/backup1.backup` +
+`azb://mystorageaccount.blob/backupscontainer/backup1.backup`
+|===
+
+
+The following example shows how to create a database using the URI of the seed:
+
+[source, cypher]
+----
+CREATE DATABASE foo OPTIONS {existingData: 'use', seedURI:'s3://myBucket/myBackup.backup'}
+----
+
+Starting from Neo4j 2025.01, seed from URI can also be used in combination with `CREATE OR REPLACE DATABASE`.
 
 [[manage-databases-start]]
 == Start databases

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -238,7 +238,7 @@ To use other providers, you must configure `dbms.databases.seed_from_uri_provide
 | `ftp:` +
 `http:` +
 `https:`
-| `ftp:://myftp.com/backups/backup1.backup` +
+| `ftp://myftp.com/backups/backup1.backup` +
 `/http://myhttp.com/backups/backup1.backup` +
 `/https://myhttp.com/backups/backup1.backup`
 

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -221,7 +221,7 @@ The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used toge
 Neo4j has built-in support for a seed from a mounted file system (file), FTP server, HTTP/HTTPS server, Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
 To select a seed provider, you need to configure xref:configuration/configuration-settings.adoc#config_dbms.databases.seed_from_uri_providers[dbms.databases.seed_from_uri_providers].
 
-For more information on seeding from URI, refer to xref::clustering/databases.adoc#cluster-seed-uri[Manage databases in a cluster -> Seed from URI].
+For more details and examples of seeding from URI, refer to xref::clustering/databases.adoc#cluster-seed-uri[Manage databases in a cluster -> Seed from URI].
 
 .Seed providers supported in Neo4j
 [cols="2,1,2",options="header"]

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -219,8 +219,7 @@ The `IF NOT EXISTS` and `OR REPLACE` parts of these commands cannot be used toge
 ==== Create databases using seeding options
 
 Neo4j has built-in support for a seed from a mounted file system (file), FTP server, HTTP/HTTPS server, Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
-The seed provider is determined by the xref:configuration/configuration-settings.adoc#config_dbms.databases.seed_from_uri_providers[dbms.databases.seed_from_uri_providers] setting.
-By default, Neo4j enables support for Amazon S3, Google Cloud Storage, and Azure Cloud Storage.
+The seed provider is determined by the xref:configuration/configuration-settings.adoc#config_dbms.databases.seed_from_uri_providers[dbms.databases.seed_from_uri_providers] setting, which defaults to `CloudSeedProvider`.
 To use other providers, you must configure `dbms.databases.seed_from_uri_providers` accordingly.
 
 .Seed providers supported in Neo4j

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -240,7 +240,7 @@ To use other providers, you must configure `dbms.databases.seed_from_uri_provide
 `https:`
 | `ftp://myftp.com/backups/backup1.backup` +
 `/http://myhttp.com/backups/backup1.backup` +
-`/https://myhttp.com/backups/backup1.backup`
+`/https://myhttps.com/backups/backup1.backup`
 
 | `S3SeedProvider` label:deprecated[Deprecated in 5.26]
 | `s3:`


### PR DESCRIPTION
In some sense, we repeat information provided on the page [_Managing databases in a cluster_ ](https://neo4j.com/docs/operations-manual/current/clustering/databases/). However, I don't see much harm in this repeating as information about seed options is relevant and can be very useful on the page where we speak on how to CREATE db in Neo4j.