### PR TITLE
Clarify that CREATE OR REPLACE DB deletes indexes and constraints as well

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -206,8 +206,8 @@ CREATE OR REPLACE DATABASE customers
 
 This is equivalent to running `DROP DATABASE customers IF EXISTS` followed by `CREATE DATABASE customers`.
 
-Keep in mind that by running `CREATE OR REPLACE DATABASE` you delete also indexes and constraints.
-If you wish to preserve them, run the following Cypher command before the `CREATE OR REPLACE DATABASE` and save the output:
+Keep in mind that using `CREATE OR REPLACE DATABASE` also removes indexes and constraints.
+To preserve them, run the following Cypher command before the `CREATE OR REPLACE DATABASE` and save the output:
 
 [source, cypher]
 ----

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -207,14 +207,18 @@ CREATE OR REPLACE DATABASE customers
 This is equivalent to running `DROP DATABASE customers IF EXISTS` followed by `CREATE DATABASE customers`.
 
 Keep in mind that using `CREATE OR REPLACE DATABASE` also removes indexes and constraints.
-To preserve them, run the following Cypher command before the `CREATE OR REPLACE DATABASE` and save the output:
+To preserve them, run the following Cypher commands before the `CREATE OR REPLACE DATABASE` and save their outputs:
 
 [source, cypher]
 ----
-SHOW INDEXES YIELD createStatement
-UNION
-SHOW CONSTRAINTS YIELD createStatement
-RETURN createStatement as statement
+SHOW CONSTRAINTS YIELD createStatement AS statement
+----
+
+[source, cypher]
+----
+SHOW INDEXES YIELD createStatement, owningConstraint
+WHERE owningConstraint IS NULL
+RETURN createStatement AS statement
 ----
 
 The behavior of `IF NOT EXISTS` and `OR REPLACE` apply to both standard and composite databases (e.g. a composite database may replace a standard database or another composite database).

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -197,7 +197,7 @@ First, appending `IF NOT EXISTS` to the command ensures that no error is returne
 CREATE DATABASE customers IF NOT EXISTS
 ----
 
-Second, adding `OR REPLACE` to the command deletes any existing database and creates a new one.
+Second, adding `OR REPLACE` to the command deletes any existing database and creates a new one. 
 
 [source, cypher]
 ----
@@ -205,6 +205,17 @@ CREATE OR REPLACE DATABASE customers
 ----
 
 This is equivalent to running `DROP DATABASE customers IF EXISTS` followed by `CREATE DATABASE customers`.
+
+Keep in mind that by running `CREATE OR REPLACE DATABASE` you delete also indexes and constraints.
+If you wish to preserve them, run the following Cypher command before the `CREATE OR REPLACE DATABASE` and save the output:
+
+[source, cypher]
+----
+SHOW INDEXES YIELD createStatement
+UNION
+SHOW CONSTRAINTS YIELD createStatement
+RETURN createStatement as statement
+----
 
 The behavior of `IF NOT EXISTS` and `OR REPLACE` apply to both standard and composite databases (e.g. a composite database may replace a standard database or another composite database).
 

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -197,7 +197,7 @@ First, appending `IF NOT EXISTS` to the command ensures that no error is returne
 CREATE DATABASE customers IF NOT EXISTS
 ----
 
-Second, adding `OR REPLACE` to the command deletes any existing database and creates a new one. 
+Second, adding `OR REPLACE` to the command deletes any existing database and creates a new one.
 
 [source, cypher]
 ----


### PR DESCRIPTION
You may need to preserve the database structure (indexes and constraints) when you move the database from test env to production. In this case, it's important to know that the `CREATE OR REPLACE DB` cmd removes not only data but also indexes and constraints. If you want to keep them, you have to do it before executing the command.