### PR TITLE
Clarify that CREATE OR REPLACE DB deletes indexes and constraints as well (#2154)

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -205,6 +205,21 @@ CREATE OR REPLACE DATABASE customers
 
 This is equivalent to running `DROP DATABASE customers IF EXISTS` followed by `CREATE DATABASE customers`.
 
+Keep in mind that using `CREATE OR REPLACE DATABASE` also removes indexes and constraints.
+To preserve them, run the following Cypher commands before the `CREATE OR REPLACE DATABASE` and save their outputs:
+
+[source, cypher]
+----
+SHOW CONSTRAINTS YIELD createStatement AS statement
+----
+
+[source, cypher]
+----
+SHOW INDEXES YIELD createStatement, owningConstraint
+WHERE owningConstraint IS NULL
+RETURN createStatement AS statement
+----
+
 The behavior of `IF NOT EXISTS` and `OR REPLACE` apply to both standard and composite databases (e.g. a composite database may replace a standard database or another composite database).
 
 [NOTE]


### PR DESCRIPTION

You may need to preserve the database structure (indexes and constraints) when you move the database from test env to production. In this case, it's important to know that the `CREATE OR REPLACE DB` cmd removes not only data but also indexes and constraints. If you want to keep them, you have to do it before executing the command.