### PR TITLE
Clarify that a recreate won't keep read availability.

### DIFF
--- a/modules/ROOT/pages/clustering/disaster-recovery.adoc
+++ b/modules/ROOT/pages/clustering/disaster-recovery.adoc
@@ -6,7 +6,7 @@
 A database can become unavailable due to issues on different system levels.
 For example, a data center failover may lead to the loss of multiple servers, which may cause a set of databases to become unavailable.
 
-This section contains a step-by-step guide on how to recover *unavailable databases* that are incapable of serving writes, while possibly still being able to serve reads.
+This section contains a step-by-step guide on how to recover *unavailable databases* that are incapable of serving writes and/or reads.
 The guide recovers the unavailable databases and make them fully operational, with minimal impact on the other databases in the cluster.
 However, if a database is not performing as expected for other reasons, this section cannot help.
 


### PR DESCRIPTION
Remove ambiguity that disaster recovery can recover a write unavailable database without causing read unavailability.