### PR TITLE
Clarify the difference between copying and overwriting TLS certificates

### DIFF
--- a/modules/ROOT/pages/security/ssl-framework.adoc
+++ b/modules/ROOT/pages/security/ssl-framework.adoc
@@ -1122,22 +1122,24 @@ The following steps outline the process for certificates rotation.
 
 . Enable the dynamic reloading of certificates on all cluster members.
 It is best to do this when the cluster is deployed as changing this configuration requires a restart:
-
++
 [source, properties]
 ----
 dbms.security.tls_reload_enabled=true (default is false)
 ----
 
 . Replace old certificates either by overwriting them on the filesystem or by copying them to a new location.
-Then update the required SSL configuration for each effected scope.
 +
-New and old certificates may co-exist on the filesystem, but only one can be referenced in the configuration.
-New certificates need to be copied to all cluster members as required.
+Keep in mind that if you choose to copy the certificates to a new directory or use different filenames, you must dynamically update the SSL policy settings.
+If you are overwriting the certificates in place and not changing anything else, there is no need to dynamically update the SSL policy settings.
++
+New and old certificates may co-exist on the filesystem, but only one can be referenced in the configuration. +
+It is required to copy new certificates to all cluster members.
 
-. Make necessary changes to any of the SSL configuration and/or replace certificates for effected scopes. 
+. Make necessary changes to any of the SSL configuration and/or replace certificates for affected scopes.
 
 . Connect to each cluster member in turn with Cypher Shell using a <<ssl-bolt-connect,`bolt` URI scheme>> and run the reload procedure:
-
++
 [source]
 ----
 dbms.security.reloadTLS()


### PR DESCRIPTION
Clarify steps, fix formatting and mistakes.