### PR TITLE
Update column info for show databases to mention where composite databases return null

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -82,7 +82,7 @@ The default for a standalone database is `neo4j://localhost:7687`. label:default
 | role
 | The current role of the database (`primary`, `secondary`, `unknown`). label:default-output[]
 
-The value will be `NULL` for composite databases, as it is not applicable for them.
+The value for composite databases is `NULL` because it does not apply to them.
 | STRING
 
 | writer
@@ -133,28 +133,28 @@ Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`.
 | Number of primaries for this database reported as running currently.
 It is the same as the number of rows where `role=primary` and `name=this database`.
 
-The value will be `NULL` for composite databases, as it is not applicable for them.
+The value for composite databases is `NULL` because it does not apply to them.
 | INTEGER
 
 | `currentSecondariesCount`
 | Number of secondaries for this database reported as running currently.
 It is the same as the number of rows where `role=secondary` and `name=this database`.
 
-The value will be `NULL` for composite databases, as it is not applicable for them.
+The value for composite databases is `NULL` because it does not apply to them.
 | INTEGER
 
 | `requestedPrimariesCount`
 | The requested number of primaries for this database.
 May be lower than current if the DBMS is currently reducing the number of copies of the database, or higher if it is currently increasing the number of copies.
 
-The value will be `NULL` for composite databases, as it is not applicable for them.
+The value for composite databases is `NULL` because it does not apply to them.
 | INTEGER
 
 | `requestedSecondariesCount`
 | The requested number of secondaries for this database.
 May be lower than current if the DBMS is currently reducing the number of copies of the database, or higher if it is currently increasing the number of copies.
 
-The value will be `NULL` for composite databases, as it is not applicable for them.
+The value for composite databases is `NULL` because it does not apply to them.
 | INTEGER
 
 | creationTime
@@ -182,7 +182,7 @@ The value is a string formatted as:
 A database must be `online` or `deallocating` for this value to be available.
 For other database states the value will be `NULL`.
 
-The value will be `NULL` for composite databases, as it is not applicable for them.
+The value for composite databases is `NULL` because it does not apply to them.
 | STRING
 
 | lastCommittedTxn
@@ -208,7 +208,7 @@ For other database states the value will be `NULL`.
 |options
 |The map of options applied to the database.
 
-The value will be `NULL` for composite databases, as it is not applicable for them.
+The value for composite databases is `NULL` because it does not apply to them.
 | MAP
 
 |===

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -182,7 +182,7 @@ The value is a string formatted as:
 A database must be `online` or `deallocating` for this value to be available.
 For other database states the value will be `NULL`.
 
-The value for composite databases is `NULL` because it does not apply to them.
+The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[]
 | STRING
 
 | lastCommittedTxn

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -170,7 +170,7 @@ The value for composite databases is `NULL` because it does not apply to them.
 | ZONED DATETIME
 
 | store
-a|
+|
 Information about the storage engine and the store format.
 
 The value is a string formatted as:

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -82,7 +82,7 @@ The default for a standalone database is `neo4j://localhost:7687`. label:default
 | role
 | The current role of the database (`primary`, `secondary`, `unknown`). label:default-output[]
 
-The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[This change applies to versions 2025.04 and later and 5.25.5 and later.]
+The value for composite databases is `NULL` because it does not apply to them.
 | STRING
 
 | writer

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -154,7 +154,7 @@ The value for composite databases is `NULL` because it does not apply to them.
 | The requested number of secondaries for this database.
 May be lower than current if the DBMS is currently reducing the number of copies of the database, or higher if it is currently increasing the number of copies.
 
-The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[]
+The value for composite databases is `NULL` because it does not apply to them.
 | INTEGER
 
 | creationTime

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -133,7 +133,7 @@ Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`.
 | Number of primaries for this database reported as running currently.
 It is the same as the number of rows where `role=primary` and `name=this database`.
 
-The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[]
+The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[This change applies to versions 2025.04 and later and 5.26.5 and later.]
 | INTEGER
 
 | `currentSecondariesCount`

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -41,7 +41,7 @@ Depending on what you want to see, you can list:
 These commands return the following columns:
 
 .Listing databases output
-[options="header", width="100%", cols="4m,6a,2m"]
+[options="header", width="100%", cols="4m,6,2m"]
 |===
 | Column | Description | Type
 
@@ -82,7 +82,7 @@ The default for a standalone database is `neo4j://localhost:7687`. label:default
 | role
 | The current role of the database (`primary`, `secondary`, `unknown`). label:default-output[]
 
-The value for composite databases is `NULL` because it does not apply to them.
+The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[This change applies to versions 2025.04 and later and 5.25.5 and later.]
 | STRING
 
 | writer
@@ -133,28 +133,28 @@ Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`.
 | Number of primaries for this database reported as running currently.
 It is the same as the number of rows where `role=primary` and `name=this database`.
 
-The value for composite databases is `NULL` because it does not apply to them.
+The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[]
 | INTEGER
 
 | `currentSecondariesCount`
 | Number of secondaries for this database reported as running currently.
 It is the same as the number of rows where `role=secondary` and `name=this database`.
 
-The value for composite databases is `NULL` because it does not apply to them.
+The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[]
 | INTEGER
 
 | `requestedPrimariesCount`
 | The requested number of primaries for this database.
 May be lower than current if the DBMS is currently reducing the number of copies of the database, or higher if it is currently increasing the number of copies.
 
-The value for composite databases is `NULL` because it does not apply to them.
+The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[]
 | INTEGER
 
 | `requestedSecondariesCount`
 | The requested number of secondaries for this database.
 May be lower than current if the DBMS is currently reducing the number of copies of the database, or higher if it is currently increasing the number of copies.
 
-The value for composite databases is `NULL` because it does not apply to them.
+The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[]
 | INTEGER
 
 | creationTime

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -35,7 +35,7 @@ Depending on what you want to see, you can list:
 
 * All databases.
 * A particular database.
-* The default database.
+* The DBMS default database.
 * The home database.
 
 These commands return the following columns:
@@ -81,6 +81,8 @@ The default for a standalone database is `neo4j://localhost:7687`. label:default
 
 | role
 | The current role of the database (`primary`, `secondary`, `unknown`). label:default-output[]
+
+The value will be `NULL` for composite databases, as it is not applicable for them.
 | STRING
 
 | writer
@@ -117,34 +119,42 @@ See <<database-states>> for more information.
 
 | default
 |
-Show if this is the default database for the DBMS. label:default-output[]
+`true` if this is the default database for the DBMS. label:default-output[]
 Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`.
 | BOOLEAN
 
 | home
 |
-Shown if this is the home database for the current user. label:default-output[]
+`true` if this is the home database for the current user. label:default-output[]
 Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`.
 | BOOLEAN
 
 | `currentPrimariesCount`
 | Number of primaries for this database reported as running currently.
 It is the same as the number of rows where `role=primary` and `name=this database`.
+
+The value will be `NULL` for composite databases, as it is not applicable for them.
 | INTEGER
 
 | `currentSecondariesCount`
 | Number of secondaries for this database reported as running currently.
 It is the same as the number of rows where `role=secondary` and `name=this database`.
+
+The value will be `NULL` for composite databases, as it is not applicable for them.
 | INTEGER
 
 | `requestedPrimariesCount`
 | The requested number of primaries for this database.
 May be lower than current if the DBMS is currently reducing the number of copies of the database, or higher if it is currently increasing the number of copies.
+
+The value will be `NULL` for composite databases, as it is not applicable for them.
 | INTEGER
 
 | `requestedSecondariesCount`
 | The requested number of secondaries for this database.
 May be lower than current if the DBMS is currently reducing the number of copies of the database, or higher if it is currently increasing the number of copies.
+
+The value will be `NULL` for composite databases, as it is not applicable for them.
 | INTEGER
 
 | creationTime
@@ -171,6 +181,8 @@ The value is a string formatted as:
 ----
 A database must be `online` or `deallocating` for this value to be available.
 For other database states the value will be `NULL`.
+
+The value will be `NULL` for composite databases, as it is not applicable for them.
 | STRING
 
 | lastCommittedTxn
@@ -195,6 +207,8 @@ For other database states the value will be `NULL`.
 
 |options
 |The map of options applied to the database.
+
+The value will be `NULL` for composite databases, as it is not applicable for them.
 | MAP
 
 |===

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -147,7 +147,7 @@ The value for composite databases is `NULL` because it does not apply to them.fo
 | The requested number of primaries for this database.
 May be lower than current if the DBMS is currently reducing the number of copies of the database, or higher if it is currently increasing the number of copies.
 
-The value for composite databases is `NULL` because it does not apply to them.footnote:compositeDb[]
+The value for composite databases is `NULL` because it does not apply to them.
 | INTEGER
 
 | `requestedSecondariesCount`


### PR DESCRIPTION
We updated the store column to not say `--0.0` in 2025.04 (and backported to next release of 5.LTS as well), and the currentPrimariesCount/currentSecondariesCount to be null to match what the requested versions already did.

Also added the sentence about being null for composite on the columns where that was already the case.