### PR TITLE
Add a note about the automatic group_to_role_mapping being disabled

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
+++ b/modules/ROOT/pages/authentication-authorization/sso-integration.adoc
@@ -185,6 +185,12 @@ Custom-defined roles, such as `rolename`, must be explicitly created using the `
 See xref:authentication-authorization/manage-roles.adoc[Manage roles].
 ====
 
+[NOTE]
+====
+When specifying explicit group to role mapping the automatic mapping for groups and roles sharing a name is disabled.
+This means that all groups and roles need to be specified to be mapped, even if they share a name.
+====
+
 [[auth-sso-configure-provider]]
 == Configure Neo4j to use an OpenID Connect identity provider
 


### PR DESCRIPTION
when any groups and roles are explicitly given