### PR TITLE
Deprecate `dbms.cluster.recreateDatabase` (#2210)

### DIFF
--- a/modules/ROOT/pages/changes-deprecations-removals.adoc
+++ b/modules/ROOT/pages/changes-deprecations-removals.adoc
@@ -386,6 +386,13 @@ For deprecations in Cypher language, see link:https://neo4j.com/docs/cypher-manu
 | Enterprise Edition
 | Comment
 
+| xref:procedures.adoc#procedure_dbms_cluster_recreateDatabase[`dbms.cluster.recreateDatabase()`] 
+|
+| {check-mark}
+| label:deprecated[Deprecated in 2025.04] +
+Replaced by xref:procedures.adoc#procedure_dbms_recreateDatabase[`dbms.recreateDatabase()`]
+
+
 | xref:procedures.adoc#procedure_dbms_quarantineDatabase[`dbms.quarantineDatabase()`] label:admin-only[]
 |
 | {check-mark}

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -249,7 +249,9 @@ neo4j@neo4j> DRYRUN REALLOCATE DATABASES;
 [[recreate-databases]]
 == Recreate a database
 
-The xref:procedures.adoc#procedure_dbms_cluster_recreateDatabase[`dbms.cluster.recreateDatabase()`] procedure allows you to:
+In Neo4j 2025.04, the xref:procedures.adoc#procedure_dbms_cluster_recreateDatabase[`dbms.cluster.recreateDatabase()`] procedure is deprecated in favour of xref:procedures.adoc#procedure_dbms_recreateDatabase[`dbms.recreateDatabase()`].
+
+The recreate procedure allows you to:
 
 * Change the database store to a specified backup, while keeping all the associated privileges for the database.
 
@@ -304,7 +306,7 @@ See xref::database-administration/standard-databases/seed-from-uri.adoc[Seed fro
 
 [source, shell]
 ----
-CALL dbms.cluster.recreateDatabase("neo4j", {seedURI: "s3://myBucket/myBackup.backup"});
+CALL dbms.recreateDatabase("neo4j", {seedURI: "s3://myBucket/myBackup.backup"});
 ----
 
 [[seed-servers]]
@@ -328,7 +330,7 @@ The number of defined servers cannot exceed the number of total allocations in t
 +
 [source, shell]
 ----
-CALL dbms.cluster.recreateDatabase("neo4j", {seedingServers: ["serverId1", "serverId2", "serverId3"]});
+CALL dbms.recreateDatabase("neo4j", {seedingServers: ["serverId1", "serverId2", "serverId3"]});
 ----
 
 [[undefined-servers]]
@@ -339,7 +341,7 @@ The store will be replaced by the most up-to-date seeder available in the cluste
 +
 [source, shell]
 ----
-CALL dbms.cluster.recreateDatabase("neo4j", {seedingServers: []});
+CALL dbms.recreateDatabase("neo4j", {seedingServers: []});
 ----
 
 [[undefined-servers-backup]]
@@ -351,7 +353,7 @@ This means the store is replaced by the most up-to-date seeder if available; oth
 +
 [source, shell]
 ----
-CALL dbms.cluster.recreateDatabase("neo4j", {seedingServers: [], seedURI: "s3://myBucket/myBackup.backup"});
+CALL dbms.recreateDatabase("neo4j", {seedingServers: [], seedURI: "s3://myBucket/myBackup.backup"});
 ----
 
 [[alter-topology-recreate]]
@@ -365,7 +367,7 @@ If there are more available servers in the cluster hosting the database than the
 
 [source, shell]
 ----
-CALL dbms.cluster.recreateDatabase("neo4j", {seedingServers: [], primaries: 3, secondaries: 0});
+CALL dbms.recreateDatabase("neo4j", {seedingServers: [], primaries: 3, secondaries: 0});
 ----
 
 [[cluster-seed]]

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -660,7 +660,7 @@ Incremental import into an existing database.
 The importer works well on standalone servers.
 
 In clustering environments with multiple copies of the database, the updated database must be used as a source to reseed the rest of the database copies.
-You can use the procedure xref:procedures.adoc#procedure_dbms_cluster_recreateDatabase[`dbms.cluster.recreateDatabase()`].
+You can use the procedure xref:procedures.adoc#procedure_dbms_recreateDatabase[`dbms.recreateDatabase()`].
 For details, see xref:clustering/databases.adoc#recreate-databases[Recreate databases].
 
 Starting the clustered database after an incremental import without reseeding or performing the incremental import on a single server while the database remains online on other clustered members may result in unpredictable consequences, including data inconsistency between cluster members.

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -540,7 +540,7 @@ CALL dbms.cluster.readReplicaToggle("neo4j", false)
 |===
 
 
-[role=label--enterprise-edition]
+[role=label--deprecated-2025.04 label--enterprise-edition]
 [[procedure_dbms_cluster_recreateDatabase]]
 === dbms.cluster.recreateDatabase()
 
@@ -697,6 +697,31 @@ Running the procedure with an admin privilege is deprecated.
 ====
 Running the procedure with an admin privilege is deprecated.
 ====
+
+
+[role=label--enterprise-edition label--new-2025.04]
+[[procedure_dbms_recreateDatabase]]
+=== dbms.recreateDatabase()
+
+
+.Details
+|===
+| *Syntax* 3+m| dbms.recreateDatabase(database :: STRING, options = {} :: MAP)
+| *Description* 3+a| Recreates a database while keeping all RBAC settings.
+The procedure initiates a process, which when complete, will have synchronized and started all database instances within the cluster.
+.3+| *Input arguments* | *Name* | *Type* | *Description*
+| `database` | `STRING` | The name of the database to recreate.
+| `options` | `MAP` | The seeding and topology options to use for recreating the database.
+| *Mode* 3+| WRITE
+|===
+
+[NOTE]
+====
+It is mandatory to specify either `seedURI` or `seedingServers` as seeding options in the `options` field.
+Further details on how to use the `dbms.recreateDatabase()` procedure are provided in the related section inside the xref:clustering/databases.adoc#recreate-databases[Managing databases in a cluster] page.
+If no topology option is defined, the database will be recreated with the previous topology.
+====
+
 
 [role=label--admin-only label--enterprise-edition]
 [[procedure_dbms_setDefaultAllocationNumbers]]


### PR DESCRIPTION
In 2025.04 we deprecate `dbms.cluster.recreateDatabase` in favour of `dbms.recreateDatabase`.

---------