### PR TITLE
Custom tx timeout can be set to any value (#2282)

### DIFF
--- a/modules/ROOT/pages/database-internals/transaction-management.adoc
+++ b/modules/ROOT/pages/database-internals/transaction-management.adoc
@@ -54,8 +54,7 @@ db.transaction.timeout=10s
 ====
 
 Configuring transaction timeout does not affect transactions executed with custom timeouts (e.g., via the Java API or Neo4j Drivers), as the custom timeout overrides the value set for `db.transaction.timeout`.
-Note that the timeout value can only be overridden to a value smaller than that configured by `db.transaction.timeout`.
-You can set the transaction timeout to any value, even larger than configured by `db.transaction.timeout`.
+Custom timeouts can be set to any value, even larger than configured by `db.transaction.timeout`.
 
 
 == Manage transactions


### PR DESCRIPTION
This is true since Neo4j 5.13.

---------