### PR TITLE
Remove `useExisting` option; polish examples & page

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
@@ -200,7 +200,7 @@ Where `accessKey` and `secretKey` are provided by AWS.
 
 | `file:`
 | `FileSeedProvider`
-| `\file://tmp/backup1.backup`
+| `\file:///tmp/backup1.backup`
 
 | `ftp:`
 | `URLConnectionSeedProvider`


### PR DESCRIPTION
This all started with me using this feature and noticing that the documented examples triggered a warning.

![Screenshot from 2025-04-19 08-57-24](https://github.com/user-attachments/assets/a18a0724-9a65-4f65-957c-7791eb82e9f8)

Digging further into the feature and thus the docs, I took the chance to polish examples (syntax highlighting, avoid scrolling) and a few wordings.