### PR TITLE
Document `server.backup.advertised_address` and deprecate `dbms.routing.load_balancing.plugin`

### DIFF
--- a/modules/ROOT/pages/changes-deprecations-removals.adoc
+++ b/modules/ROOT/pages/changes-deprecations-removals.adoc
@@ -473,6 +473,11 @@ Replaced by: xref:procedures.adoc#procedure_dbms_cluster_secondaryreplicationdis
 | Enterprise Edition
 | Comment
 
+| xref:configuration/configuration-settings.adoc#config_dbms.routing.load_balancing.plugin[`dbms.routing.load_balancing.plugin`]
+| 
+| {check-mark}
+| label:deprecated[Deprecated in 2025.05]
+
 | xref:configuration/configuration-settings.adoc#config_server.db.query_cache_size[`server.db.query_cache_size`]
 | {check-mark}
 | {check-mark}

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -4798,6 +4798,23 @@ m|+++127.0.0.1:6362+++
 |===
 
 
+[role=label--enterprise-edition label--new-2025.05]
+[[config_server.backup.advertised_address]]
+=== `server.backup.advertised_address`
+
+.server.backup.advertised_address
+[frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
+|===
+|Description
+a|The advertised address for the backup server. Default is the default advertised address combined with port defined in the backup listen address.
+|Valid values
+a|A socket address in the format of `hostname:port`, `hostname`, or `:port`.
+|Default value
+m|+++0+++
+|===
+
+
+
 [role=label--enterprise-edition]
 [[config_server.backup.store_copy_max_retry_time_per_request]]
 === `server.backup.store_copy_max_retry_time_per_request`

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -1697,9 +1697,9 @@ m|+++true+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|The load balancing plugin to use.
+a|Vary the order of the entries in routing tables each time one is produced. This means that different clients should select a range of servers as their first contact, reducing the chance of all clients contacting the same server if alternatives are available. This makes the load across the servers more even.
 |Valid values
-a|A string that specified load balancer plugin exist..
+a|A string.
 |Default value
 m|+++server_policies+++
 |===
@@ -4808,7 +4808,7 @@ m|+++127.0.0.1:6362+++
 |Description
 a|The advertised address for the backup server. Default is the default advertised address combined with port defined in the backup listen address.
 |Valid values
-a|A socket address in the format of `hostname:port`, `hostname`, or `:port`.
+a|A socket address in the format of `hostname:port`, `hostname`, or `:port` that is an accessible address. If missing, it is acquired from `server.default_advertised_address`.
 |Default value
 m|+++0+++
 |===

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -1689,7 +1689,7 @@ m|+++true+++
 |===
 
 
-[role=label--enterprise-edition]
+[role=label--enterprise-edition label--deprecated-2025.05]
 [[config_dbms.routing.load_balancing.plugin]]
 === `dbms.routing.load_balancing.plugin`
 
@@ -4810,7 +4810,7 @@ a|The advertised address for the backup server. Default is the default advertise
 |Valid values
 a|A socket address in the format of `hostname:port`, `hostname`, or `:port` that is an accessible address. If missing, it is acquired from `server.default_advertised_address`.
 |Default value
-m|+++0+++
+m|+++:0+++
 |===
 
 


### PR DESCRIPTION
based on https://github.com/neo-technology/neo4j/pull/30553