### PR TITLE
 Remove `useExisting` option; polish examples & page

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
@@ -55,6 +55,9 @@ The `FileSeedProvider`  supports:
 
 ** `file:`
 
+[NOTE]
+Local file paths must be absolute paths.
+
 [[url-connection-seed-provider]]
 === URLConnectionSeedProvider
 

--- a/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
@@ -1,7 +1,6 @@
 :page-role: enterprise-edition
 :description: How to create a database using a seed from URI.
 
-[[database-seed-uri]]
 = Create a database from a URI
 
 This method seeds all databases with an identical seed from an external source, specified by a URI.
@@ -16,14 +15,12 @@ CREATE DATABASE foo OPTIONS { seedURI:'s3://myBucket/myBackup.backup' }
 Download and validation of the seed is only performed as the new database is started.
 If it fails, the database is not available and it has the `statusMessage`: `Unable to start database` of the `SHOW DATABASES` command.
 
-[source, cypher]
+.Example failure output for `SHOW DATABASES`
+[source, role="queryresult"]
 ----
-neo4j@neo4j> SHOW DATABASES;
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | name    | type       | aliases | access       | address          | role      | writer | requestedStatus | currentStatus | statusMessage                                            | default | home  | constituents |
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | "seed3" | "standard" | []      | "read-write" | "localhost:7682" | "unknown" | FALSE  | "online"        | "offline"     | "Unable to start database `DatabaseId{3fe1a59b[seed3]}`" | FALSE   | FALSE | []           |
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ----
 
 To determine the cause of the problem, check the `debug.log` file.
@@ -32,6 +29,7 @@ To determine the cause of the problem, check the `debug.log` file.
 ====
 Starting from Neo4j 2025.01, seed from URI can also be used in combination with xref:database-administration/standard-databases/create-databases.adoc[`CREATE OR REPLACE DATABASE`].
 ====
+
 
 [[neo4j-seed-providers]]
 == Seed providers in Neo4j
@@ -48,6 +46,7 @@ The product has built-in support for seed from a mounted file system (file), FTP
 Amazon S3, Google Cloud Storage, and Azure Cloud Storage are supported by default, but the other providers require configuration of xref:configuration/configuration-settings.adoc#config_dbms.databases.seed_from_uri_providers[`dbms.databases.seed_from_uri_providers`].
 ====
 
+
 [[file-seed-provider]]
 === FileSeedProvider
 
@@ -56,7 +55,10 @@ The `FileSeedProvider`  supports:
 ** `file:`
 
 [NOTE]
+====
 Local file paths must be absolute paths.
+====
+
 
 [[url-connection-seed-provider]]
 === URLConnectionSeedProvider
@@ -69,6 +71,7 @@ The `URLConnectionSeedProvider` supports the following:
 
 Starting from Neo4j 2025.01, the `URLConnectionSeedProvider` does not support `file`.
 // This is true for both Cypher 5 and Cypher 25.
+
 
 [[cloud-seed-provider]]
 === CloudSeedProvider
@@ -125,6 +128,7 @@ CREATE DATABASE foo OPTIONS { seedURI: 'azb://myStorageAccount/myContainer/myBac
 ======
 =====
 
+
 ==== Support for seeding up to a date or a transaction ID
 
 Starting from Neo4j 2025.01, the `CloudSeedProvider` supports seeding up to a specific date or transaction ID using the `seedRestoreUntil` option.
@@ -158,6 +162,7 @@ CREATE DATABASE foo OPTIONS {
 ----
 +
 This will seed the database with transactions up to (but not including) transaction 123.
+
 
 [role=label--deprecated]
 [[s3-seed-provider]]
@@ -205,6 +210,7 @@ CREATE DATABASE foo OPTIONS {
 ----
 Where `<accessKey>` and `<secretKey>` are provided by AWS.
 
+
 === Seed provider reference
 
 [cols="1,2,2",options="header"]
@@ -215,7 +221,7 @@ Where `<accessKey>` and `<secretKey>` are provided by AWS.
 
 | `file:`
 | `FileSeedProvider`
-| `\file:/tmp/backup1.backup`
+| `file:/tmp/backup1.backup`
 
 | `ftp:`
 | `URLConnectionSeedProvider`

--- a/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
@@ -203,7 +203,7 @@ Where `accessKey` and `secretKey` are provided by AWS.
 
 | `file:`
 | `FileSeedProvider`
-| `\file://tmp/backup1.backup`
+| `\file:/tmp/backup1.backup`
 
 | `ftp:`
 | `URLConnectionSeedProvider`

--- a/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
@@ -8,15 +8,15 @@ This method seeds all databases with an identical seed from an external source, 
 
 You specify the seed URI as an argument of the `CREATE DATABASE` command:
 
-[source, cypher, role="noplay"]
+[source, cypher]
 ----
-CREATE DATABASE foo OPTIONS {existingData: 'use', seedURI:'s3://myBucket/myBackup.backup'}
+CREATE DATABASE foo OPTIONS { seedURI:'s3://myBucket/myBackup.backup' }
 ----
 
 Download and validation of the seed is only performed as the new database is started.
 If it fails, the database is not available and it has the `statusMessage`: `Unable to start database` of the `SHOW DATABASES` command.
 
-[source, cypher, role="noplay"]
+[source, cypher]
 ----
 neo4j@neo4j> SHOW DATABASES;
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -26,7 +26,7 @@ neo4j@neo4j> SHOW DATABASES;
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ----
 
-To determine the cause of the problem, it is recommended to look at the `debug.log`.
+To determine the cause of the problem, check the `debug.log` file.
 
 [NOTE]
 ====
@@ -93,9 +93,9 @@ include::partial$/aws-s3-credentials.adoc[]
 
 . Create database from `myBackup.backup`.
 +
-[source,shell, role="nocopy"]
+[source,cypher]
 ----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3://myBucket/myBackup.backup' }
+CREATE DATABASE foo OPTIONS { seedURI: 's3://myBucket/myBackup.backup' }
 ----
 
 ======
@@ -106,9 +106,9 @@ include::partial$/gcs-credentials.adoc[]
 
 . Create database from `myBackup.backup`.
 +
-[source,shell]
+[source,cypher]
 ----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'gs://myBucket/myBackup.backup' }
+CREATE DATABASE foo OPTIONS { seedURI: 'gs://myBucket/myBackup.backup' }
 ----
 ======
 [role=include-with-Azure-cloud-storage]
@@ -118,9 +118,9 @@ include::partial$/azb-credentials.adoc[]
 
 . Create database from `myBackup.backup`.
 +
-[source,shell]
+[source,cypher]
 ----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAccount/myContainer/myBackup.backup' }
+CREATE DATABASE foo OPTIONS { seedURI: 'azb://myStorageAccount/myContainer/myBackup.backup' }
 ----
 ======
 =====
@@ -132,11 +132,14 @@ Starting from Neo4j 2025.01, the `CloudSeedProvider` supports seeding up to a sp
 [role=label--new-2025.01]
 Seed up to a specific date::
 
-To seed up to a specific date, you need to pass the differential backup, which contains the data up to that date.
+To seed up to a specific date, provide the differential backup containing the data up to that date.
 +
 [source,cypher]
 ----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3://myBucket/myBackup.backup', seedRestoreUntil: datetime("2019-06-01T18:40:32.142+0100") }
+CREATE DATABASE foo OPTIONS {
+    seedURI: 's3://myBucket/myBackup.backup',
+    seedRestoreUntil: datetime('2019-06-01T18:40:32.142+0100')
+}
 ----
 +
 This will seed the database with transactions committed before the provided timestamp.
@@ -148,10 +151,13 @@ To seed up to a specific transaction ID, provide the differential backup contain
 +
 [source,cypher]
 ----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3://myBucket/myBackup.backup', seedRestoreUntil: 123 }
+CREATE DATABASE foo OPTIONS {
+    seedURI: 's3://myBucket/myBackup.backup',
+    seedRestoreUntil: 123
+}
 ----
 +
-This will seed the database with transactions up to, but not including transaction 123.
+This will seed the database with transactions up to (but not including) transaction 123.
 
 [role=label--deprecated]
 [[s3-seed-provider]]
@@ -167,17 +173,19 @@ The `S3SeedProvider` supports:
 [NOTE]
 ====
 Neo4j comes bundled with necessary libraries for AWS S3 connectivity.
-Therefore, if you use `S3SeedProvider`,`aws cli` is not required but can be used with the `CloudSeedProvider`.
+Therefore, if you use `S3SeedProvider`, `aws cli` is not required (as it instead is with `CloudSeedProvider`).
 ====
 
 The `S3SeedProvider` requires additional configuration.
-This is specified with the `seedConfig` option.
-This option expects a comma-separated list of configurations.
-Each configuration value is specified as a name followed by `=` and the value, as such:
+This is specified with the `seedConfig` option, which expects a comma-separated list of configurations.
+Each configuration entry is specified in the format `key=value`, as such:
 
-[source, cypher, role="noplay"]
+[source, cypher]
 ----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3://myBucket/myBackup.backup', seedConfig: 'region=eu-west-1' }
+CREATE DATABASE foo OPTIONS {
+    seedURI: 's3://myBucket/myBackup.backup',
+    seedConfig: 'region=eu-west-1'
+}
 ----
 
 `S3SeedProvider` also requires passing in credentials.
@@ -185,13 +193,17 @@ These are specified with the `seedCredentials` option.
 Seed credentials are securely passed from the Cypher command to each server hosting the database.
 For this to work, Neo4j on each server in the cluster must be configured with identical keystores.
 This is identical to the configuration required by remote aliases, see xref:database-administration/aliases/remote-database-alias-configuration.adoc#remote-alias-config-DBMS_admin-A[Configuration of DBMS with remote database alias].
-If this configuration is not performed, the `seedCredentials` option fails.
+Without this configuration, the `seedCredentials` option fails.
 
-[source, cypher, role="noplay"]
+[source, cypher]
 ----
-CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3://myBucket/myBackup.backup', seedConfig: 'region=eu-west-1', seedCredentials: [accessKey];[secretKey] }
+CREATE DATABASE foo OPTIONS {
+    seedURI: 's3://myBucket/myBackup.backup',
+    seedConfig: 'region=eu-west-1',
+    seedCredentials: <accessKey>;<secretKey>
+}
 ----
-Where `accessKey` and `secretKey` are provided by AWS.
+Where `<accessKey>` and `<secretKey>` are provided by AWS.
 
 === Seed provider reference
 

--- a/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
@@ -1,5 +1,5 @@
 :page-role: enterprise-edition
-:description: How to create a database using a seed from URI. 
+:description: How to create a database using a seed from URI.
 
 [[database-seed-uri]]
 = Create a database from a URI
@@ -131,7 +131,7 @@ Seed up to a specific date::
 
 To seed up to a specific date, you need to pass the differential backup, which contains the data up to that date.
 +
-[source,shell]
+[source,cypher]
 ----
 CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3://myBucket/myBackup.backup', seedRestoreUntil: datetime("2019-06-01T18:40:32.142+0100") }
 ----
@@ -141,9 +141,9 @@ This will seed the database with transactions committed before the provided time
 [role=label--new-2025.01]
 Seed up to a specific transaction ID::
 
-To seed up to a specific transaction ID, you need to pass the differential backup that contains the data up to that transaction ID.
+To seed up to a specific transaction ID, provide the differential backup containing the data up to that transaction ID.
 +
-[source,shell]
+[source,cypher]
 ----
 CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3://myBucket/myBackup.backup', seedRestoreUntil: 123 }
 ----


### PR DESCRIPTION
Spinoff of #2287 , on the `cypher-25` base branch as the option is deprecated then.