### PR TITLE
Fix formatting of the listing db output (#2339)

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -41,7 +41,7 @@ Depending on what you want to see, you can list:
 These commands return the following columns:
 
 .Listing databases output
-[options="header", width="100%", cols="4m,6,2m"]
+[options="header", width="100%", cols="3m,6,2m"]
 |===
 | Column | Description | Type
 
@@ -95,7 +95,7 @@ The value can be either `online` or `offline`. label:default-output[]
 | STRING
 
 | currentStatus
-| The actual status of the database. label:default-output[]
+a| The actual status of the database. label:default-output[]
 
 The possible statuses are:
 
@@ -173,12 +173,8 @@ The value for composite databases is `NULL` because it does not apply to them.
 |
 Information about the storage engine and the store format.
 
-The value is a string formatted as:
+The value is a string formatted as `{storage engine}-{store format}-{major version}.{minor version}`.
 
-[source, syntax, role="noheader"]
-----
-{storage engine}-{store format}-{major version}.{minor version}
-----
 A database must be `online` or `deallocating` for this value to be available.
 For other database states the value will be `NULL`.
 


### PR DESCRIPTION
Removing `a` in the table header (see line 44 in the PR #2212) led to the formatting issues: lists and code blocks are not rendered as they should be.
This PR fixes those issues