### PR TITLE
Fix Cypher examples to show its both versions

### DIFF
--- a/modules/ROOT/pages/backup-restore/restore-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-backup.adoc
@@ -177,7 +177,6 @@ That means, if you restore `neo4j-2023-06-29T14-50-45.backup`, your database wil
 The following examples assume that you want to restore your data in a new database, called `mydatabase`.
 If you want to replace an existing database, you need to stop it first and add the option `--overwrite-destination=true` to the restore command.
 
-+
 . Restore a database backup by running the following command:
 +
 [source, shell,role=nocopy noplay]

--- a/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
@@ -7,10 +7,28 @@ This method seeds all databases with an identical seed from an external source, 
 
 You specify the seed URI as an argument of the `CREATE DATABASE` command:
 
-[source, cypher]
+[.tabbed-example]
+=====
+[role=include-with-Cypher-5]
+======
+
+[source, cypher5]
+----
+CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI:'s3://myBucket/myBackup.backup' }
+----
+
+======
+[role=include-with-Cypher-25]
+======
+
+[source, cypher25]
 ----
 CREATE DATABASE foo OPTIONS { seedURI:'s3://myBucket/myBackup.backup' }
 ----
+======
+=====
+
+Note that the `existingData` option is required in Cypher 5 and deprecated in Cypher 25.
 
 Download and validation of the seed is only performed as the new database is started.
 If it fails, the database is not available and it has the `statusMessage`: `Unable to start database` of the `SHOW DATABASES` command.
@@ -96,7 +114,16 @@ include::partial$/aws-s3-credentials.adoc[]
 
 . Create database from `myBackup.backup`.
 +
-[source,cypher]
+Using Cypher 5:
++
+[source,cypher5]
+----
+CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3://myBucket/myBackup.backup' }
+----
++
+Using Cypher 25:
++
+[source,cypher25]
 ----
 CREATE DATABASE foo OPTIONS { seedURI: 's3://myBucket/myBackup.backup' }
 ----
@@ -109,7 +136,16 @@ include::partial$/gcs-credentials.adoc[]
 
 . Create database from `myBackup.backup`.
 +
-[source,cypher]
+Using Cypher 5:
++
+[source,cypher5]
+----
+CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'gs://myBucket/myBackup.backup' }
+----
++
+Using Cypher 25:
++
+[source,cypher25]
 ----
 CREATE DATABASE foo OPTIONS { seedURI: 'gs://myBucket/myBackup.backup' }
 ----
@@ -121,7 +157,16 @@ include::partial$/azb-credentials.adoc[]
 
 . Create database from `myBackup.backup`.
 +
-[source,cypher]
+Using Cypher 5:
++
+[source,cypher5]
+----
+CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAccount/myContainer/myBackup.backup' }
+----
++
+Using Cypher 25:
++
+[source,cypher25]
 ----
 CREATE DATABASE foo OPTIONS { seedURI: 'azb://myStorageAccount/myContainer/myBackup.backup' }
 ----
@@ -133,38 +178,73 @@ CREATE DATABASE foo OPTIONS { seedURI: 'azb://myStorageAccount/myContainer/myBac
 
 Starting from Neo4j 2025.01, the `CloudSeedProvider` supports seeding up to a specific date or transaction ID using the `seedRestoreUntil` option.
 
-[role=label--new-2025.01]
+
 Seed up to a specific date::
 
 To seed up to a specific date, provide the differential backup containing the data up to that date.
 +
-[source,cypher]
+[.tabbed-example]
+=====
+[role=include-with-Cypher-5]
+======
+[source,cypher5]
+----
+CREATE DATABASE foo OPTIONS {
+    existingData: 'use',
+    seedURI: 's3://myBucket/myBackup.backup',
+    seedRestoreUntil: datetime('2019-06-01T18:40:32.142+0100')
+}
+----
+======
+[role=include-with-Cypher-25]
+======
+
+[source,cypher25]
 ----
 CREATE DATABASE foo OPTIONS {
     seedURI: 's3://myBucket/myBackup.backup',
     seedRestoreUntil: datetime('2019-06-01T18:40:32.142+0100')
 }
 ----
+======
+=====
 +
 This will seed the database with transactions committed before the provided timestamp.
 
-[role=label--new-2025.01]
+
 Seed up to a specific transaction ID::
 
 To seed up to a specific transaction ID, provide the differential backup containing the data up to that transaction ID.
 +
-[source,cypher]
+[.tabbed-example]
+=====
+[role=include-with-Cypher-5]
+======
+[source,cypher5]
+----
+CREATE DATABASE foo OPTIONS {
+    existingData: 'use',
+    seedURI: 's3://myBucket/myBackup.backup',
+    seedRestoreUntil: 123
+}
+----
+======
+[role=include-with-Cypher-25]
+======
+[source,cypher25]
 ----
 CREATE DATABASE foo OPTIONS {
     seedURI: 's3://myBucket/myBackup.backup',
     seedRestoreUntil: 123
 }
 ----
+======
+=====
 +
 This will seed the database with transactions up to (but not including) transaction 123.
 
 
-[role=label--deprecated]
+[role=label--deprecated label--cypher-5]
 [[s3-seed-provider]]
 === S3SeedProvider
 
@@ -185,9 +265,10 @@ The `S3SeedProvider` requires additional configuration.
 This is specified with the `seedConfig` option, which expects a comma-separated list of configurations.
 Each configuration entry is specified in the format `key=value`, as such:
 
-[source, cypher]
+[source, cypher5]
 ----
 CREATE DATABASE foo OPTIONS {
+    existingData: 'use',
     seedURI: 's3://myBucket/myBackup.backup',
     seedConfig: 'region=eu-west-1'
 }
@@ -200,9 +281,10 @@ For this to work, Neo4j on each server in the cluster must be configured with id
 This is identical to the configuration required by remote aliases, see xref:database-administration/aliases/remote-database-alias-configuration.adoc#remote-alias-config-DBMS_admin-A[Configuration of DBMS with remote database alias].
 Without this configuration, the `seedCredentials` option fails.
 
-[source, cypher]
+[source, cypher5]
 ----
 CREATE DATABASE foo OPTIONS {
+    existingData: 'use',
     seedURI: 's3://myBucket/myBackup.backup',
     seedConfig: 'region=eu-west-1',
     seedCredentials: <accessKey>;<secretKey>

--- a/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
@@ -124,7 +124,7 @@ Using Cypher 5:
 CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 's3://myBucket/myBackup.backup' }
 ----
 +
-Using Cypher 25:
+Using Cypher 25 label:new[Introduced in 2025.06]:
 +
 [source,cypher25]
 ----
@@ -271,6 +271,8 @@ Where `<accessKey>` and `<secretKey>` are provided by AWS.
 Starting from Neo4j 2025.01, when creating a database you can seed up to a specific date or transaction ID via the `seedRestoreUntil` option.
 
 The `seedRestoreUntil` option is supported by the `CloudSeedProvider` and the `FileSeedProvider`.
+
+Seed up to a specific date::
 
 To seed up to a specific date, provide the differential backup containing the data up to that date.
 +

--- a/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
@@ -18,7 +18,7 @@ CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI:'s3://myBucket/myBack
 ----
 
 ======
-[role=include-with-Cypher-25]
+[role=include-with-Cypher-25 label--new-2025.06]
 ======
 
 [source, cypher25]
@@ -146,7 +146,7 @@ Using Cypher 5:
 CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'gs://myBucket/myBackup.backup' }
 ----
 +
-Using Cypher 25:
+Using Cypher 25 label:new[Introduced in 2025.06]:
 +
 [source,cypher25]
 ----
@@ -167,7 +167,7 @@ Using Cypher 5:
 CREATE DATABASE foo OPTIONS { existingData: 'use', seedURI: 'azb://myStorageAccount/myContainer/myBackup.backup' }
 ----
 +
-Using Cypher 25:
+Using Cypher 25 label:new[Introduced in 2025.06]:
 +
 [source,cypher25]
 ----
@@ -287,7 +287,7 @@ CREATE DATABASE foo OPTIONS {
 }
 ----
 ======
-[role=include-with-Cypher-25]
+[role=include-with-Cypher-25 label--new-2025.06]
 ======
 
 [source,cypher25]
@@ -320,7 +320,7 @@ CREATE DATABASE foo OPTIONS {
 }
 ----
 ======
-[role=include-with-Cypher-25]
+[role=include-with-Cypher-25 label--new-2025.06]
 ======
 [source,cypher25]
 ----


### PR DESCRIPTION
When Cypher 25 is released, we'll continue to show query examples for Cypher 5.

When PR #2368 is merged, this one needs to be updated