### PR TITLE
Restore labels according to the 5.x reality

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/seed-from-uri.adoc
@@ -32,7 +32,7 @@ To determine the cause of the problem, it is recommended to look at the `debug.l
 [[neo4j-seed-providers]]
 == Seed providers in Neo4j
 
-The seed can either be a full backup, a differential backup (see <<cloud-seed-provider, `CloudSeedProvider`>>, introduced in Neo4j 5.25), or a dump from an existing database.
+The seed can either be a full backup, a differential backup (see <<cloud-seed-provider, `CloudSeedProvider`>>, introduced in Neo4j 5.26), or a dump from an existing database.
 The sources of seeds are called _seed providers_.
 
 The mechanism is pluggable, allowing new sources of seeds to be supported (see link:https://www.neo4j.com/docs/java-reference/current/extending-neo4j/project-setup/#extending-neo4j-plugin-seed-provider[Java Reference -> Implement custom seed providers] for more information).


### PR DESCRIPTION
When we moved content around, we lost labels (introduced and deprecated) that are meaningful for the Neo4j 5.x series.

I restored labels based on https://github.com/neo4j/docs-operations/blame/1b83460bcc76d014c2a60079b3a756d77b801cd1/modules/ROOT/pages/clustering/databases.adoc.

Besides, I removed mentions about 2025.x functionality.