### PR TITLE
Explain list handling differences between Parquet and CSV

### DIFF
--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1288,6 +1288,12 @@ A different delimiter can be specified with `--array-delimiter`.
 Arrays are not affected by the `--normalize-types` flag.
 For example, if you want a byte array to be stored as a Cypher long array, you must explicitly declare the property as `long[]`.
 
+[NOTE]
+====
+CSV based import will not import empty arrays, because they cannot be distinguished from arrays that are set to `null`.
+The Parquet import distinguishes between them, and will import empty arrays as empty arrays and `null` as `null`.
+====
+
 Boolean values are _true_ if they match exactly the text `true`. All other values are _false_.
 Values that contain the delimiter character need to be escaped by enclosing in double quotation marks, or by using a different delimiter character with the `--delimiter` option.
 

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1290,7 +1290,7 @@ For example, if you want a byte array to be stored as a Cypher long array, you m
 
 [NOTE]
 ====
-CSV based import will not import empty arrays, because they cannot be distinguished from arrays that are set to `null`.
+CSV-based import does not import empty arrays, because they cannot be distinguished from arrays that are set to `null`.
 The Parquet import distinguishes between them, and will import empty arrays as empty arrays and `null` as `null`.
 ====
 

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1291,7 +1291,7 @@ For example, if you want a byte array to be stored as a Cypher long array, you m
 [NOTE]
 ====
 CSV-based import does not import empty arrays, because they cannot be distinguished from arrays that are set to `null`.
-The Parquet import distinguishes between them, and will import empty arrays as empty arrays and `null` as `null`.
+However, the Parquet import distinguishes between them and will import empty arrays as empty arrays and `null` as `null`.
 ====
 
 Boolean values are _true_ if they match exactly the text `true`. All other values are _false_.


### PR DESCRIPTION
Clarify that CSV imports empty lists as null whereas Parquet handles empty as empty.