### PR TITLE
Explain list handling differences between Parquet and CSV (#2395)

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -1148,6 +1148,12 @@ A different delimiter can be specified with `--array-delimiter`.
 Arrays are not affected by the `--normalize-types` flag.
 For example, if you want a byte array to be stored as a Cypher long array, you must explicitly declare the property as `long[]`.
 
+[NOTE]
+====
+CSV-based import does not import empty arrays, because they cannot be distinguished from arrays that are set to `null`.
+However, the Parquet import distinguishes between them and will import empty arrays as empty arrays and `null` as `null`.
+====
+
 Boolean values are _true_ if they match exactly the text `true`. All other values are _false_.
 Values that contain the delimiter character need to be escaped by enclosing in double quotation marks, or by using a different delimiter character with the `--delimiter` option.
 


### PR DESCRIPTION
Clarify that CSV imports empty lists as null whereas Parquet handles empty as empty.

---------