### PR TITLE
Add `dbms.routing.load_balancing.config.server_policies` to the configs reference page

### DIFF
--- a/modules/ROOT/pages/clustering/clustering-advanced/multi-data-center-routing.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/multi-data-center-routing.adoc
@@ -180,8 +180,10 @@ If no rule is able to produce a usable result then the driver is signalled a fai
 === Policy names
 
 The policies are configured under the namespace of the `server_policies` plugin and named as desired.
+You can find them in the _neo4j.conf_ file.
+
 Policy names can contain alphanumeric characters and underscores, and they are case sensitive.
-Below is the property key for a policy with the name `mypolicy`.
+Below is the property key for a policy with the name `mypolicy`:
 
 `dbms.routing.load_balancing.config.server_policies.mypolicy=`
 

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -8,6 +8,8 @@ Refer to xref:configuration/neo4j-conf.adoc#_configuration_settings[The neo4j.co
 
 For lists of deprecated and removed configuration settings in 2025.x, refer to the page xref:changes-deprecations-removals.adoc[Changes, deprecations, and removals in Neo4j 2025.x].
 
+To list all available configuration settings on a Neo4j server, run the link:https://neo4j.com/docs/cypher-manual/5/clauses/listing-settings[`SHOW SETTINGS`] command.
+
 
 == Dynamic configuration settings
 
@@ -28,6 +30,38 @@ It is recommended that the settings for a database are the same across all membe
 ====
 
 For more information on how to update dynamic configuration settings, see xref:configuration/dynamic-settings.adoc[Update dynamic settings].
+
+
+[role=label--enterprise]
+== Configuration setting group
+
+When deploying a multi-data cluster in Neo4j, you can configure the load balancing framework.
+
+In Neo4j, the load balancing system is based on a plugin architecture.
+The primary built-in plugin is `server_policies`.
+
+`server_policies` plugin determines which servers are eligible to serve client requests based on predefined routing policies.
+If a client does not specify a routing policy, the system defaults to using all available servers.
+
+You can define routing policies using the following property format:
+
+[source, shell]
+----
+dbms.routing.load_balancing.config.server_policies.<policy-name>=<policy-definition>
+----
+
+Where `<policy-name>` is the name of the routing policy, and `<policy-definition>` specifies the server selection logic.
+
+
+For the default policy, the `default` policy name is reserved.
+Its default value is `all()`:
+
+[source, shell]
+----
+dbms.routing.load_balancing.config.server_policies.default=all()
+----
+
+See xref:clustering/clustering-advanced/multi-data-center-routing.adoc#mdc-load-balancing-framework[Clustering -> Multi-data center routing] for more details.
 
 
 == Checkpoint settings


### PR DESCRIPTION
We state that the _Configuration settings_ page lists all config settings in Neo4j. But we miss `dbms.routing.load_balancing.config.server_policies`, which is not a setting (strictly speaking) but a setting group. Nevertheless, we need to include this setting/property/plugin on the page.