### PR TITLE
Clarify not running in single to cluster migration

### DIFF
--- a/modules/ROOT/pages/clustering/setup/single-to-cluster.adoc
+++ b/modules/ROOT/pages/clustering/setup/single-to-cluster.adoc
@@ -17,7 +17,8 @@ See xref:clustering/setup/analytics-cluster.adoc[] for more information on analy
 .Move from a single `system` database to a cluster with three `system` primaries
 
 In this example, a standalone server named `server01` is running and two additional servers, `server02` and `server03`, are to be added to form a cluster.
-The two additional servers are configured according to xref:clustering/setup/deploy.adoc#cluster-example-configure-a-three-primary-cluster[Configure a cluster with three servers] and are _not_ running.
+The two additional servers are configured according to xref:clustering/setup/deploy.adoc#cluster-example-configure-a-three-primary-cluster[Configure a cluster with three servers].
+These two new servers should _not_ be started up yet.
 Neo4j Enterprise Edition is installed on all three servers.
 
 Start by stopping the standalone server.


### PR DESCRIPTION
Related to this card here: https://trello.com/c/EfPPJ5QJ/9449-strange-behavior-when-going-from-single-instance-to-cluster, field would like some clarification what is meant by not running