### PR TITLE
Dots in database name are no longer deprecated.

### DIFF
--- a/modules/ROOT/pages/database-administration/aliases/manage-aliases-composite-databases.adoc
+++ b/modules/ROOT/pages/database-administration/aliases/manage-aliases-composite-databases.adoc
@@ -265,9 +265,11 @@ CREATE ALIAS `my.alias.with.dots` FOR DATABASE `northwind-graph`
 CREATE ALIAS `my.composite.database.with.dots`.`my.other.alias.with.dots` FOR DATABASE `northwind-graph`
 ----
 
-
-[role=label--deprecated]
 === Single dots and local database aliases
+[NOTE]
+====
+As of Neo4j 5.26.9, this feature is no longer deprecated.
+====
 
 There is a special case for local database aliases with a single dot without any existing composite database.
 If a composite database `some` exists, the query below will create a database alias named `alias` within the composite database `some`.

--- a/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/naming-databases.adoc
@@ -19,9 +19,7 @@ Naming rules for databases are as follows:
 The `-` (dash) and `.` (dot) characters are not legal in Cypher variables.
 Names with a `-` in them must be enclosed within backticks.
 For example, `CREATE DATABASE ++`main-db`++` is a valid database name.
-Database names are the only identifier for which dots do not need to be quoted.
-For example `main.db` is a valid database name.
-However, this behavior is deprecated due to the difficulty of determining if a dot is part of the database name or a delimiter for a database alias in a composite database.
+Using dots in database names is not recommended, as it makes it difficult to determine if a dot is part of the database name or a delimiter for a database alias in a composite database.
 ====
 
 It is possible to create an alias to refer to an existing database to avoid these restrictions.


### PR DESCRIPTION
Backporting relevant parts of https://github.com/neo4j/docs-operations/pull/2443 to 5.26 as the previous deprecation has been removed from 5.26.9