### PR TITLE
Add tabbed examples for multiple node IDs

### DIFF
--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1520,7 +1520,9 @@ aa11,WORKS_WITH,bb22
 [role=include-with-multiple-ID-columns label--new-2025.07]
 ======
 
-Starting from 2025.07, you have to use a matching number of `START_ID` / `END_ID` columns when defining the relationship:
+Starting from 2025.07, you can use a matching number of `START_ID` / `END_ID` columns when defining the relationship.
+However, do not mix how to refer to composite IDs.
+Either all references must use a single `START_ID` / `END_ID` column or all references must use a matching number of them.
 
 .relationships_header.csv
 [source, csv]

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1499,7 +1499,7 @@ bb,22,Paul
 +
 [.tabbed-example]
 =====
-[role=include-with-multiple-node-IDs]
+[role=include-with-single-ID-column]
 ======
 
 Now use both IDs when defining the relationship:
@@ -1558,7 +1558,7 @@ bb,22,Paul
 +
 [.tabbed-example]
 =====
-[role=include-with-multiple-node-IDs]
+[role=include-with-single-ID-column]
 ======
 
 .relationships_header.csv
@@ -1576,6 +1576,8 @@ aa11,WORKS_WITH,bb22
 ======
 [role=include-with-multiple-ID-columns label--new-2025.07]
 ======
+
+Starting from 2025.07, you have to use a matching number of `START_ID` / `END_ID` columns when defining the relationship:
 
 .relationships_header.csv
 [source, csv]

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1578,8 +1578,8 @@ aa11,WORKS_WITH,bb22
 ----
 aa,11,WORKS_WITH,bb,22
 ----
-=====
 ======
+=====
 
 
 [[import-tool-id-types-header]]

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1517,7 +1517,7 @@ aa11,WORKS_WITH,bb22
 ----
 
 ======
-[role=include-with-multiple-node-IDs-2025.07]
+[role=include-with-multiple-ID-columns label--new-2025.07]
 ======
 
 Starting from 2025.07, you have to use a matching number of `START_ID` / `END_ID` columns when defining the relationship:

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1504,27 +1504,31 @@ bb,22,Paul
 
 Now use both IDs when defining the relationship:
 
+.relationships_header.csv
 [source, csv]
 ----
 :START_ID,:TYPE,:END_ID
 ----
 
+.relationships.csv
 [source, csv]
 ----
 aa11,WORKS_WITH,bb22
 ----
 
 ======
-[role=include-with-multiple-IDs label--new-2025.07]
+[role=include-with-multiple-node-IDs-2025.07]
 ======
 
-Starting from 2025.07, you can use multiple IDs when defining the relationship:
+Starting from 2025.07, you have to use a matching number of `START_ID` / `END_ID` columns when defining the relationship:
 
+.relationships_header.csv
 [source, csv]
 ----
 :START_ID,:START_ID,:TYPE,:END_ID,:END_ID
 ----
 
+.relationships.csv
 [source, csv]
 ----
 aa,11,WORKS_WITH,bb,22
@@ -1555,25 +1559,29 @@ bb,22,Paul
 [role=include-with-multiple-node-IDs]
 ======
 
+.relationships_header.csv
 [source, csv]
 ----
 :START_ID(MyGroup),:TYPE,:END_ID(MyGroup)
 ----
 
+.relationships.csv
 [source, csv]
 ----
 aa11,WORKS_WITH,bb22
 ----
 
 ======
-[role=include-with-multiple-IDs label--new-2025.07]
+[role=include-with-multiple-node-IDs-2025.07]
 ======
 
+.relationships_header.csv
 [source, csv]
 ----
 :START_ID(MyGroup),:START_ID(MyGroup),:TYPE,:END_ID(MyGroup),:END_ID(MyGroup)
 ----
 
+.relationships.csv
 [source, csv]
 ----
 aa,11,WORKS_WITH,bb,22

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1480,16 +1480,14 @@ This functionality is only available with a full import.
 
 === Define multiple IDs as node properties
 
-You can define multiple `ID` columns in the node header.
-
-For example, you can define a node header with two `ID` columns.
-
+. Define multiple `ID` columns in the node header.
++
 .nodes_header.csv
 [source, csv]
 ----
 :ID,:ID,name
 ----
-
++
 .nodes.csv
 [source, csv]
 ----
@@ -1497,6 +1495,8 @@ aa,11,John
 bb,22,Paul
 ----
 
+. Define the relationship between two established nodes.
++
 [.tabbed-example]
 =====
 [role=include-with-multiple-node-IDs]

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1464,22 +1464,24 @@ Now use the previously defined ID spaces when connecting the actors to movies.
 == Using multiple node IDs
 
 A node header can contain multiple `ID` columns.
-The relationship data must then use a matching number of `START_ID` / `END_ID` columns as references to the composite value of those ID columns.
+
+Starting from 2025.07, the relationship data must then use a matching number of `START_ID` / `END_ID` columns as references to the composite value of those ID columns.
 This implies using `string` as `id-type`.
 
 For each `ID` column, you can specify to store its values as different node properties.
 However, the composite value cannot be stored as a node property.
 
-[NOTE]
+[IMPORTANT]
 ====
 Incremental import doesn't support the use of multiple node identifiers.
 This functionality is only available with a full import.
 ====
 
 
-.Define multiple IDs as node properties
-====
+=== Define multiple IDs as node properties
+
 You can define multiple `ID` columns in the node header.
+
 For example, you can define a node header with two `ID` columns.
 
 .nodes_header.csv
@@ -1495,54 +1497,90 @@ aa,11,John
 bb,22,Paul
 ----
 
+[.tabbed-example]
+=====
+[role=include-with-multiple-node-IDs]
+======
+
 Now use both IDs when defining the relationship:
 
-.relationships_header.csv
+[source, csv]
+----
+:START_ID,:TYPE,:END_ID
+----
+
+[source, csv]
+----
+aa11,WORKS_WITH,bb22
+----
+
+======
+[role=include-with-multiple-IDs label--new-2025.07]
+======
+
+Starting from 2025.07, you can use multiple IDs when defining the relationship:
+
 [source, csv]
 ----
 :START_ID,:START_ID,:TYPE,:END_ID,:END_ID
 ----
 
-.relationships.csv
 [source, csv]
 ----
 aa,11,WORKS_WITH,bb,22
 ----
-====
+======
+=====
 
 [[multiple-IDs-Id-spaces]]
-.Define multiple IDs stored in ID spaces
-====
+=== Define multiple IDs stored in ID spaces
 
-Define a `MyGroup` ID space in the _nodes_header.csv_ file.
-
-.nodes_header.csv
+. Define a `MyGroup` ID space in the _nodes_header.csv_ file.
++
 [source, csv]
 ----
 personId:ID(MyGroup),memberId:ID(MyGroup),name
 ----
-
-.nodes.csv
++
 [source, csv]
 ----
 aa,11,John
 bb,22,Paul
 ----
 
-Now use the defined ID space when connecting John with Paul, and use both IDs in the relationship.
+. Now use the defined ID space when connecting John with Paul, and use both IDs in the relationship.
++
+[.tabbed-example]
+=====
+[role=include-with-multiple-node-IDs]
+======
 
-.relationships_header.csv
+[source, csv]
+----
+:START_ID(MyGroup),:TYPE,:END_ID(MyGroup)
+----
+
+[source, csv]
+----
+aa11,WORKS_WITH,bb22
+----
+
+======
+[role=include-with-multiple-IDs label--new-2025.07]
+======
+
 [source, csv]
 ----
 :START_ID(MyGroup),:START_ID(MyGroup),:TYPE,:END_ID(MyGroup),:END_ID(MyGroup)
 ----
 
-.relationships.csv
 [source, csv]
 ----
 aa,11,WORKS_WITH,bb,22
 ----
-====
+=====
+======
+
 
 [[import-tool-id-types-header]]
 == Storing a different value type for IDs in a group

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1574,7 +1574,7 @@ aa11,WORKS_WITH,bb22
 ----
 
 ======
-[role=include-with-multiple-node-IDs-2025.07]
+[role=include-with-multiple-ID-columns label--new-2025.07]
 ======
 
 .relationships_header.csv

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1541,11 +1541,13 @@ aa,11,WORKS_WITH,bb,22
 
 . Define a `MyGroup` ID space in the _nodes_header.csv_ file.
 +
+.nodes_header.csv
 [source, csv]
 ----
 personId:ID(MyGroup),memberId:ID(MyGroup),name
 ----
 +
+.nodes.csv
 [source, csv]
 ----
 aa,11,John


### PR DESCRIPTION
The Operations manual covers all releases of 2025.xx series. That's why we cannot simply replace examples with new ones, as new functionality has been added. We also need to retain examples for earlier versions of Neo4j.