### PR TITLE
Add tabbed examples for multiple node IDs (#2512)

### DIFF
--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1464,30 +1464,30 @@ Now use the previously defined ID spaces when connecting the actors to movies.
 == Using multiple node IDs
 
 A node header can contain multiple `ID` columns.
-The relationship data must then use a matching number of `START_ID` / `END_ID` columns as references to the composite value of those ID columns.
+
+Starting from 2025.07, the relationship data must then use a matching number of `START_ID` / `END_ID` columns as references to the composite value of those ID columns.
 This implies using `string` as `id-type`.
 
 For each `ID` column, you can specify to store its values as different node properties.
 However, the composite value cannot be stored as a node property.
 
-[NOTE]
+[IMPORTANT]
 ====
 Incremental import doesn't support the use of multiple node identifiers.
 This functionality is only available with a full import.
 ====
 
 
-.Define multiple IDs as node properties
-====
-You can define multiple `ID` columns in the node header.
-For example, you can define a node header with two `ID` columns.
+=== Define multiple IDs as node properties
 
+. Define multiple `ID` columns in the node header.
++
 .nodes_header.csv
 [source, csv]
 ----
 :ID,:ID,name
 ----
-
++
 .nodes.csv
 [source, csv]
 ----
@@ -1495,7 +1495,34 @@ aa,11,John
 bb,22,Paul
 ----
 
+. Define the relationship between two established nodes.
++
+[.tabbed-example]
+=====
+[role=include-with-single-ID-column]
+======
+
 Now use both IDs when defining the relationship:
+
+.relationships_header.csv
+[source, csv]
+----
+:START_ID,:TYPE,:END_ID
+----
+
+.relationships.csv
+[source, csv]
+----
+aa11,WORKS_WITH,bb22
+----
+
+======
+[role=include-with-multiple-ID-columns label--new-2025.07]
+======
+
+Starting from 2025.07, you can use a matching number of `START_ID` / `END_ID` columns when defining the relationship.
+However, do not mix how to refer to composite IDs.
+Either all references must use a single `START_ID` / `END_ID` column or all references must use a matching number of them.
 
 .relationships_header.csv
 [source, csv]
@@ -1508,20 +1535,20 @@ Now use both IDs when defining the relationship:
 ----
 aa,11,WORKS_WITH,bb,22
 ----
-====
+======
+=====
 
 [[multiple-IDs-Id-spaces]]
-.Define multiple IDs stored in ID spaces
-====
+=== Define multiple IDs stored in ID spaces
 
-Define a `MyGroup` ID space in the _nodes_header.csv_ file.
-
+. Define a `MyGroup` ID space in the _nodes_header.csv_ file.
++
 .nodes_header.csv
 [source, csv]
 ----
 personId:ID(MyGroup),memberId:ID(MyGroup),name
 ----
-
++
 .nodes.csv
 [source, csv]
 ----
@@ -1529,7 +1556,30 @@ aa,11,John
 bb,22,Paul
 ----
 
-Now use the defined ID space when connecting John with Paul, and use both IDs in the relationship.
+. Now use the defined ID space when connecting John with Paul, and use both IDs in the relationship.
++
+[.tabbed-example]
+=====
+[role=include-with-single-ID-column]
+======
+
+.relationships_header.csv
+[source, csv]
+----
+:START_ID(MyGroup),:TYPE,:END_ID(MyGroup)
+----
+
+.relationships.csv
+[source, csv]
+----
+aa11,WORKS_WITH,bb22
+----
+
+======
+[role=include-with-multiple-ID-columns label--new-2025.07]
+======
+
+Starting from 2025.07, you have to use a matching number of `START_ID` / `END_ID` columns when defining the relationship:
 
 .relationships_header.csv
 [source, csv]
@@ -1542,7 +1592,9 @@ Now use the defined ID space when connecting John with Paul, and use both IDs in
 ----
 aa,11,WORKS_WITH,bb,22
 ----
-====
+======
+=====
+
 
 [[import-tool-id-types-header]]
 == Storing a different value type for IDs in a group


### PR DESCRIPTION
The Operations manual covers all releases of 2025.xx series. That's why we cannot simply replace examples with new ones, as new functionality has been added. We also need to retain examples for earlier versions of Neo4j.