### PR TITLE
Fix broken links

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/built-in-roles.adoc
+++ b/modules/ROOT/pages/authentication-authorization/built-in-roles.adoc
@@ -827,7 +827,7 @@ These include the rights to perform the following classes of tasks:
 
 * Manage xref:authentication-authorization/database-administration.adoc[database privileges] to control the rights to perform actions on specific databases:
 ** Manage access to a database and the right to start and stop a database.
-** Manage link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/overview/[indexes] and link:{neo4j-docs-base-uri}/cypher-manual/current/constraints/[constraints].
+** Manage link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/[indexes] and link:{neo4j-docs-base-uri}/cypher-manual/current/constraints/[constraints].
 ** Allow the creation of labels, relationship types, or property names.
 ** Manage transactions.
 * Manage xref:authentication-authorization/dbms-administration.adoc[DBMS privileges] to control the rights to perform actions on the entire system:

--- a/modules/ROOT/pages/introduction.adoc
+++ b/modules/ROOT/pages/introduction.adoc
@@ -160,7 +160,7 @@ a| APOC 450+ link:https://neo4j.com/docs/apoc/5/[Core Procedures and Functions]
 
 3+^s| Indexes and constraints
 
-| link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/overview/[Fast writes via native label indexes]
+| link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/[Fast writes via native label indexes]
 | {check-mark}
 | {check-mark}
 

--- a/modules/ROOT/pages/monitoring/metrics/essential.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/essential.adoc
@@ -19,7 +19,7 @@ Reading the xref:performance/index.adoc[] section is recommended to better under
 
 Monitoring the hardware resources shows the strain on the server running Neo4j.
 
-You can use utilities, such as the https://www.collectd.org/[collectd] daemon or `systemd` on Linux, to gather information about the system.
+You can use utilities, such as the http://www.collectd.org/[collectd] daemon or `systemd` on Linux, to gather information about the system.
 These metrics can help with capacity planning as your workload grows.
 
 [options="header", cols="1,3a"]

--- a/modules/ROOT/pages/monitoring/metrics/essential.adoc
+++ b/modules/ROOT/pages/monitoring/metrics/essential.adoc
@@ -19,7 +19,7 @@ Reading the xref:performance/index.adoc[] section is recommended to better under
 
 Monitoring the hardware resources shows the strain on the server running Neo4j.
 
-You can use utilities, such as the http://www.collectd.org/[collectd] daemon or `systemd` on Linux, to gather information about the system.
+You can use utilities, such as the https://collectd.org/[collectd] daemon or `systemd` on Linux, to gather information about the system.
 These metrics can help with capacity planning as your workload grows.
 
 [options="header", cols="1,3a"]

--- a/modules/ROOT/pages/performance/index-configuration.adoc
+++ b/modules/ROOT/pages/performance/index-configuration.adoc
@@ -21,7 +21,7 @@ When you write a Cypher query, you do not need to specify which indexes to use.
 Cypher's query planner decides which of the available indexes to use.
 
 The rest of this page provides information on the available indexes and their configuration aspects.
-For further details on creating, querying, and dropping indexes, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/[Cypher Manual -> Indexes for search performance] and link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/full-text-indexes/[Cypher Manual -> Indexes to support full-text search].
+For further details on creating, querying, and dropping indexes, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/[Cypher Manual -> Indexes for search performance], link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/full-text-indexes/[Full-text indexes],  and  link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/vector-indexes/[Vector indexes].
 
 The type of an index can be identified according to the table below:
 

--- a/modules/ROOT/pages/performance/index-configuration.adoc
+++ b/modules/ROOT/pages/performance/index-configuration.adoc
@@ -21,7 +21,7 @@ When you write a Cypher query, you do not need to specify which indexes to use.
 Cypher's query planner decides which of the available indexes to use.
 
 The rest of this page provides information on the available indexes and their configuration aspects.
-For further details on creating, querying, and dropping indexes, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/overview/[Cypher Manual -> Indexes for search performance] and link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/full-text-indexes/[Cypher Manual -> Indexes to support full-text search].
+For further details on creating, querying, and dropping indexes, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/[Cypher Manual -> Indexes for search performance] and link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/full-text-indexes/[Cypher Manual -> Indexes to support full-text search].
 
 The type of an index can be identified according to the table below:
 
@@ -77,7 +77,7 @@ Exact lookups are the only non-spatial query that this index type supports.
 For more information on the queries a point index can be used for, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/using-indexes/[Cypher Manual -> Query Tuning -> The use of indexes].
 
 Point indexes optionally accept configuration properties for tuning the behavior of spatial search.
-For more information on configuring point index, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/overview/[Cypher Manual -> Indexes for search performance].
+For more information on configuring point index, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/[Cypher Manual -> Indexes for search performance].
 
 
 [[index-configuration-text]]
@@ -94,7 +94,7 @@ The default provider is `text-2.0`.
 
 For more information on the queries a text index can be used for, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/using-indexes/[Cypher Manual -> Query Tuning -> The use of indexes].
 
-For more information on the different index types, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/overview/[Cypher Manual -> Indexes for search performance].
+For more information on the different index types, refer to link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/[Cypher Manual -> Indexes for search performance].
 
 [[index-configuration-text-limitations]]
 === Limitations

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -1432,7 +1432,7 @@ The types are still enforced as `LIST<INTEGER | FLOAT>`.
 For more information, see:
 
 * xref:performance/index-configuration.adoc[]
-* link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/overview/[Cypher Manual -> Search performance indexes]
+* link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/[Cypher Manual -> Search performance indexes]
 * link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/semantic-indexes/full-text-indexes[Cypher Manual -> Full-text indexes]
 
 [[procedure_db_awaitIndex]]


### PR DESCRIPTION
To update the links to the Cypher manual following the renaming of several pages.