### PR TITLE
Fix link: formatting in remote-alias.adoc

### DIFF
--- a/modules/ROOT/pages/manage-databases/remote-alias.adoc
+++ b/modules/ROOT/pages/manage-databases/remote-alias.adoc
@@ -203,7 +203,7 @@ The permission to create an alias can be granted like this:
 GRANT CREATE ALIAS ON DBMS TO administrator
 ----
 
-Here is how to grant the link:link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/administration/access-control/database-administration/#access-control-database-administration-access[`ACCESS` privileges] to use the remote database alias:
+Here is how to grant the link:{neo4j-docs-base-uri}/cypher-manual/{page-version}/administration/access-control/database-administration/#access-control-database-administration-access[`ACCESS` privileges] to use the remote database alias:
 
 [source, Cypher]
 ----


### PR DESCRIPTION
Fixes a duplicate `link:link:` detected by the xref-hash-validator