### PR TITLE
Remove problematic part from `unbind` docs (#2570)

### DIFF
--- a/modules/ROOT/pages/clustering/clustering-advanced/unbind.adoc
+++ b/modules/ROOT/pages/clustering/clustering-advanced/unbind.adoc
@@ -12,7 +12,11 @@ Therefore, it is strongly recommended to consult with Neo4j Support before using
 
 Use the `unbind` command only when troubleshooting **a specific server** and remember there is no guarantee that the allocator will reassign the same databases to this server, potentially resulting in orphaned database stores.
 
-The `unbind` command preserves all database stores on the server; and when the unbound server is restarted and enabled, it is seen as an entirely new server.
+The `unbind` command preserves all database stores on the server; and when the unbound server is restarted, it is seen as an entirely new server.
+Therefore, it will not host any of the databases it hosted before the operation.
+
+In 2025.x, the `unbind` command cannot be used to convert a cluster member into a standalone server.
+Instead, it is recommended to take backups, create the standalone server, and then use those backups to restore the databases.
 ====
 
 [[unbind-command-syntax]]
@@ -78,10 +82,6 @@ You can use the `neo4j-admin server unbind` command to remove the cluster state 
 
 To remove the cluster state of a server, run the `neo4j-admin server unbind` command from the _<NEO4J_HOME>_ folder of that server.
 When restarted, an unbound server rejoins the cluster as a new server and has to be enabled using the `ENABLE SERVER` command.
-
-=== Turn a cluster member into a standalone server
-
-To start the Neo4j server in single (standalone) mode after unbinding it from the cluster, verify that xref:configuration/configuration-settings.adoc#config_initial.server.mode_constraint[`initial.server.mode_constraint`] is set to `NONE` in xref:configuration/neo4j-conf.adoc[The neo4j.conf file].
 
 === Archive cluster state
 


### PR DESCRIPTION
Since 5.0 you cannot use `unbind` to turn a cluster member into a standalone server.

---------