### PR TITLE
Update docs to clarify that `IF NOT EXISTS` check for both databases and database aliases (#2573)

### DIFF
--- a/modules/ROOT/pages/database-administration/aliases/manage-aliases-standard-databases.adoc
+++ b/modules/ROOT/pages/database-administration/aliases/manage-aliases-standard-databases.adoc
@@ -316,10 +316,10 @@ SHOW ALIAS `northwind` FOR DATABASE
 
 The `CREATE ALIAS` command is optionally idempotent, with the default behavior to fail with an error if the database alias already exists.
 To work around this, you can append `IF EXISTS` or `OR REPLACE` to the command.
-Both check for any remote or local database aliases.
+Both check for any remote or local database aliases with the given name, `IF NOT EXISTS` also check for existing databases with the given name.
 
 * Appending `IF NOT EXISTS` to the command.
-This ensures that no error is returned and nothing happens should the database alias already exist.
+This ensures that no error is returned and nothing happens should a database or database alias with that name already exist.
 +
 .Query
 [source, cypher]
@@ -328,7 +328,7 @@ CREATE ALIAS `northwind` IF NOT EXISTS  FOR DATABASE `northwind-graph-2021`
 ----
 
 * Appending `OR REPLACE` to the command.
-This means that if the database alias already exists, it will be replaced with the new one.
+This means that if a database alias with that name already exists, it will be replaced with the new one.
 +
 .Query
 [source, cypher]
@@ -417,7 +417,7 @@ FOR DATABASE
 
 You can also use `IF EXISTS` or `OR REPLACE` when creating remote database aliases.
 It works the same way as described in the <<_use_if_exists_or_or_replace_when_creating_database_aliases, Use `IF EXISTS` or `OR REPLACE` when creating database aliases>> section.
-Both check for any remote or local database aliases.
+Both check for any remote or local database aliases (with `IF NOT EXISTS` also checking for databases).
 
 
 [[alias-management-create-remote-database-alias-driver-settings]]

--- a/modules/ROOT/pages/database-administration/composite-databases/create-composite-databases.adoc
+++ b/modules/ROOT/pages/database-administration/composite-databases/create-composite-databases.adoc
@@ -7,7 +7,7 @@
 Composite databases are managed using Cypher(R) administrative commands.
 Note that it is not possible to modify access options or database topologies for composite databases as these are inherited from the constituent databases.
 For information about modifying access options, see xref:database-administration/standard-databases/alter-databases.adoc#manage-databases-alter[Alter database access mode].
-For information about about topologies for databases, see xref:clustering/setup/deploy.adoc#cluster-example-create-databases-on-cluster[Create databases in a cluster].
+For information about topologies for databases, see xref:clustering/setup/deploy.adoc#cluster-example-create-databases-on-cluster[Create databases in a cluster].
 
 Drivers and client applications connect to composite databases just like standard databases.
 For more information, see the manuals for the different link:{neo4j-docs-base-uri}/create-applications/[Neo4j drivers and applications].
@@ -18,8 +18,8 @@ For more information, see the manuals for the different link:{neo4j-docs-base-ur
 Composite databases can be created using `CREATE COMPOSITE DATABASE`.
 
 Composite database names are subject to the same rules as xref:database-administration/standard-databases/naming-databases.adoc[standard databases].
-One difference is however that the deprecated syntax using dots without enclosing the name in backticks is not available.
-Both dots and dashes need to be enclosed within backticks when using composite databases.
+One difference is however that in Cypher 5, the syntax using dots without enclosing the name in backticks is not available.
+Both dots and dashes need to be enclosed within backticks when using composite databases in Cypher 5.
 
 [NOTE]
 ====
@@ -66,7 +66,7 @@ For information about creating aliases in composite databases, see xref:database
 The `CREATE COMPOSITE DATABASE` command is optionally idempotent, with the default behavior to fail with an error if the database already exists.
 There are two ways to circumvent this behavior.
 
-First, appending `IF NOT EXISTS` to the command ensures that no error is returned and nothing happens should the database already exist.
+First, appending `IF NOT EXISTS` to the command ensures that no error is returned and nothing happens should a database or database alias with the given name already exist.
 
 .Query
 [source, cypher]
@@ -87,6 +87,7 @@ CREATE OR REPLACE COMPOSITE DATABASE inventory
 This is equivalent to running `DROP DATABASE inventory IF EXISTS` followed by `CREATE COMPOSITE DATABASE inventory`.
 
 The behavior of `IF NOT EXISTS` and `OR REPLACE` apply to both standard and composite databases (e.g. a composite database may replace a standard database or another composite database).
+`IF NOT EXISTS` also catches if any database aliases with the given name exists and does nothing instead of throwing an error on existing alias sharing the name.
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/create-databases.adoc
@@ -334,7 +334,7 @@ In this example, all three cluster members have returned `03N85 (Neo.ClientNotif
 The `CREATE DATABASE` command is optionally idempotent, with the default behavior to fail with an error if the database already exists.
 There are two ways to circumvent this behavior.
 
-First, appending `IF NOT EXISTS` to the command ensures that no error is returned and that nothing happens if the database already exists.
+First, appending `IF NOT EXISTS` to the command ensures that no error is returned and that nothing happens if a database or database alias with the given name already exist.
 
 [source, cypher]
 ----
@@ -366,6 +366,7 @@ RETURN createStatement AS statement
 ----
 
 The behavior of `IF NOT EXISTS` and `OR REPLACE` apply to both standard and composite databases (e.g. a composite database may replace a standard database or another composite database).
+`IF NOT EXISTS` also catches if any database aliases with the given name exists and does nothing instead of throwing an error on existing alias sharing the name.
 
 [NOTE]
 ====


### PR DESCRIPTION
catching all graph references and not just within their own category

also fix other minor things I noticed