### PR TITLE
Update descriptions of the `initial.` settings

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -2300,7 +2300,7 @@ The DBMS settings must be consistent across all configuration files in a cluster
 |===
 |Description
 a|Specifies the default database name *before* the first DBMS startup.
-Once the initial default database is created, the setting is not valid anymore.
+After the initial default database is created, changing this setting has no effect.
 To change the default database, use the xref:/clustering/databases.adoc#cluster-default-database[`dbms.setDefaultDatabase()`] procedure instead.
 
 NOTE: This setting is not the same as `dbms.default_database`, which was used to set the default database in Neo4j 4.x and earlier versions.


### PR DESCRIPTION
Improve the descriptions of the `initial..` settings to emphasize that they occur only in two cases:
- When a DBMS is created (at the first DBMS startup)
- When a server is enabled (when you add a new server to the existing cluster)