### PR TITLE
Restore page-aliases for the pages on neo4j-admin cmds (#2600)

### DIFF
--- a/modules/ROOT/pages/backup-restore/consistency-checker.adoc
+++ b/modules/ROOT/pages/backup-restore/consistency-checker.adoc
@@ -1,4 +1,5 @@
 :description: Describes the Neo4j consistency checker.
+:page-aliases: tools/neo4j-admin/consistency-checker.adoc
 [[consistency-checker]]
 = Check database consistency
 

--- a/modules/ROOT/pages/clustering/unbind.adoc
+++ b/modules/ROOT/pages/clustering/unbind.adoc
@@ -1,4 +1,5 @@
 :description: How to remove cluster state data from a Neo4j server using `neo4j-admin server unbind`.
+:page-aliases: tools/neo4j-admin/unbind.adoc
 [role=enterprise-edition]
 [[neo4j-admin-unbind]]
 = Unbind a server

--- a/modules/ROOT/pages/configuration/migrate-configuration.adoc
+++ b/modules/ROOT/pages/configuration/migrate-configuration.adoc
@@ -1,6 +1,7 @@
 [[neo4j-admin-migrate-configuration]]
 = Migrate configurations
 :description: This chapter describes the `neo4j-admin server migrate-configuration` command.
+:page-aliases: tools/neo4j-admin/migrate-configuration.adoc
 
 You can use the `migrate-configuration` command to migrate a legacy Neo4j configuration file to the current format.
 The new version will be written in a target configuration directory.

--- a/modules/ROOT/pages/configuration/neo4j-admin-memrec.adoc
+++ b/modules/ROOT/pages/configuration/neo4j-admin-memrec.adoc
@@ -1,4 +1,5 @@
 :description: This chapter describes the `memory-recommendation` command of Neo4j Admin.
+:page-aliases: tools/neo4j-admin/neo4j-admin-memrec.adoc
 [[neo4j-admin-memrec]]
 = Get initial memory recommendations
 

--- a/modules/ROOT/pages/configuration/validate-config.adoc
+++ b/modules/ROOT/pages/configuration/validate-config.adoc
@@ -1,7 +1,7 @@
 [[neo4j-admin-validate-config]]
 = Validate configurations
-:page-role: new-5.5
 :description: How to validate configurations using Neo4j Admin.
+:page-aliases: tools/neo4j-admin/validate-config.adoc
 
 
 The `neo4j-admin server validate-config` command validates the Neo4j and Log4j configurations.

--- a/modules/ROOT/pages/cypher-shell.adoc
+++ b/modules/ROOT/pages/cypher-shell.adoc
@@ -1,4 +1,5 @@
 :description: Describes Neo4j Cypher Shell command-line interface (CLI) and how to use it.
+:page-aliases: tools/cypher-shell.adoc
 [[cypher-shell]]
 = Cypher Shell
 

--- a/modules/ROOT/pages/database-administration/standard-databases/migrate-database.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/migrate-database.adoc
@@ -1,4 +1,5 @@
 :description: This chapter describes the `neo4j-admin database migrate` command.
+:page-aliases: tools/neo4j-admin/migrate-database.adoc
 [[neo4j-admin-migrate]]
 = Migrate a database
 

--- a/modules/ROOT/pages/database-internals/neo4j-admin-store-info.adoc
+++ b/modules/ROOT/pages/database-internals/neo4j-admin-store-info.adoc
@@ -1,5 +1,5 @@
 :description: This chapter describes the `neo4j-admin database info` command.
-
+:page-aliases: tools/neo4j-admin/neo4j-admin-store-info.adoc
 [[neo4j-admin-store-info]]
 = Display store information
 

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1,4 +1,5 @@
 :description: This section describes how to perform bulk offline imports of data into Neo4j using the command line tool `neo4j-admin database import`.
+:page-aliases: tools/neo4j-admin/neo4j-admin-import.adoc
 [[neo4j-admin-import]]
 = Import
 

--- a/modules/ROOT/pages/neo4j-admin-neo4j-cli.adoc
+++ b/modules/ROOT/pages/neo4j-admin-neo4j-cli.adoc
@@ -1,4 +1,5 @@
 :description: This section describes commands for managing and administering a Neo4j DBMS.
+:page-aliases: tools/neo4j-admin/index.adoc
 [[neo4j-admin]]
 = Neo4j Admin and Neo4j CLI
 


### PR DESCRIPTION
This PR repeats the PR #2290, except for the following two pages:
* modules/ROOT/pages/monitoring/neo4j-admin-report.adoc *
modules/ROOT/pages/database-administration/standard-databases/upload-to-aura.adoc. They have necessary `page-aliases`.