### PR TITLE
docs(browser): add “Clear cached credentials now” how-to

### DIFF
--- a/modules/ROOT/pages/security/browser.adoc
+++ b/modules/ROOT/pages/security/browser.adoc
@@ -23,3 +23,22 @@ If the user issues a `:server disconnect` command then any existing session is t
 ====
 For more information on how to administer and use Neo4j Browser, see the link:https://neo4j.com/docs/browser/operations/credentials-handling/[Neo4j Browser manual -> Browser operations].
 ====
+
+== Clear cached credentials now
+
+To immediately drop the current session and remove any cached credentials:
+
+. In Neo4j Browser, open the command prompt.
+. Run:
++
+[source,subs=+quotes]
+----
+:server disconnect
+----
+. Refresh the Browser tab.
+
+[NOTE]
+====
+Credential caching (when enabled) stores credentials in the web browser’s local storage and is subject to the `browser.credential_timeout` setting. See this page for details.
+====
+


### PR DESCRIPTION
This adds a short step-by-step to the Browser credentials handling page so users can immediately clear cached credentials without waiting for timeouts. It’s based on existing behavior documented on the page (:server disconnect clears credentials; caching can be disabled with browser.retain_connection_credentials=false).

Page: Operations Manual → Security → Browser credentials handling

Rationale: improves task-oriented guidance and reduces user confusion after changing auth settings.