### PR TITLE
Update descriptions of the `initial.` settings (#2587)

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -838,7 +838,7 @@ m|+++20m+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|Automatically enable free servers.
+a|Automatically enables servers that are in the `FREE` state - not only during the initial DBMS startup but also whenever a new server joins the cluster.
 |Valid values
 a|A boolean.
 |Default value
@@ -870,7 +870,7 @@ m|+++EQUAL_NUMBERS+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|The initial default number of primary servers for the standard databases. If the user does not specify the number of primaries in `CREATE DATABASE`, this value will be used unless overwritten by the `dbms.setDefaultAllocationNumbers` procedure.
+a|The initial default number of primaries for the standard databases. Initialized at the first DBMS startup. If the user does not specify the number of primaries in `CREATE DATABASE`, this value will be used unless overwritten by the `dbms.setDefaultAllocationNumbers` procedure.
 |Valid values
 a|An integer that is minimum `1` and is maximum `11`.
 |Default value
@@ -886,7 +886,7 @@ m|+++1+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|The initial default number of secondary servers for standard databases. If the user does not specify the number of secondaries in `CREATE DATABASE`, this value will be used unless overwritten by the `dbms.setDefaultAllocationNumbers` procedure.
+a|The initial default number of secondaries for the standard databases. Initialized at the first DBMS startup. If the user does not specify the number of secondaries in `CREATE DATABASE`, this value will be used unless overwritten by the `dbms.setDefaultAllocationNumbers` procedure.
 |Valid values
 a|An integer that is minimum `0` and is maximum `20`.
 |Default value
@@ -902,7 +902,7 @@ m|+++0+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|Names of the databases allowed on this server; all others are denied. Empty means all are allowed. This configuration can be overridden when enabling the server or altered at runtime without changing this setting. Exclusive with `server.initial_denied_databases`.
+a|List of database names allowed on this server; all others are denied. Empty means all are allowed. This configuration is initialized at the first DBMS startup and/or when a newly added server is enabled. The setting is used as the default input for the `ENABLE SERVER` command; can be overriden when the command is executed. Exclusive with `server.initial_denied_databases`.
 |Valid values
 a|A comma-separated set where each element is a valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name `system`.
 |Default value
@@ -918,7 +918,7 @@ m|++++++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|Names of the databases not allowed on this server. Empty means nothing is denied. This configuration can be overridden when enabling the server or altered at runtime without changing this setting. Exclusive with `server.initial_allowed_databases`.
+a|List of database names not allowed on this server. Empty means nothing is denied. This configuration is initialized at the first DBMS startup and/or when a newly added server is enabled. The setting is used as the default input for the `ENABLE SERVER` command; can be overriden when the command is executed. Exclusive with `server.initial_allowed_databases`.
 |Valid values
 a|A comma-separated set where each element is a valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name `system`.
 |Default value
@@ -934,7 +934,9 @@ m|++++++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|An server can restrict itself to allow databases to be hosted only as primaries or secondaries. This setting is the default input for the `ENABLE SERVER` command - the user can overwrite it when executing the command.
+a|Determines whether the server is configured to host primary databases only, secondary databases only, or both.
+Initialized at the first DBMS startup and/or when a newly added server is enabled.
+The setting is used as the default input for the `ENABLE SERVER` command; can be overriden when the command is executed.
 |Valid values
 a|One of [PRIMARY, SECONDARY, NONE].
 |Default value
@@ -950,7 +952,7 @@ m|+++NONE+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|A list of tag names for the server used by the database allocation and when configuring load balancing and replication policies. This setting is the default input for the `ENABLE SERVER` command - the user can overwrite it when executing the command.
+a|A list of server tag names used by the database allocation and when configuring load balancing and replication policies. Initialized at the first DBMS startup and/or when a newly added server is enabled. The setting is used as the default input for the `ENABLE SERVER` command; can be overriden when the command is executed.
 |Valid values
 a|A comma-separated list where each element is a string identifying a server tag, which contains no duplicate items.
 |Default value
@@ -2273,18 +2275,20 @@ The DBMS settings must be consistent across all configuration files in a cluster
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|Name of the default database (aliases are not supported). +
-NOTE: This setting is not the same as `dbms.default_database`, which was used to set the default database in Neo4j 4.x and earlier versions.
-
-The `initial.dbms.default_database` setting is meant to set the default database *before* the creation of the DBMS.
-Once it is created, the setting is not valid anymore.
-
-To set the default database, use the xref:/clustering/databases.adoc#cluster-default-database[`dbms.setDefaultDatabase()`] procedure instead.
+a|Specifies the default database name *before* the first DBMS startup.
+After the initial default database is created, changing this setting has no effect.
 |Valid values
 a|A valid database name containing only alphabetic characters, numbers, dots, and dashes with a length between 3 and 63 characters, starting with an alphabetic character but not with the name system.
 |Default value
 m|+++neo4j+++
 |===
+
+[NOTE]
+====
+The `initial.dbms.default_database` is not the same as `dbms.default_database`, which was used to set the default database in Neo4j 4.x and earlier versions.
+
+To change the default database, use the xref:/clustering/databases.adoc#cluster-default-database[`dbms.setDefaultDatabase()`] procedure.
+====
 
 
 [[config_dbms.db.timezone]]


### PR DESCRIPTION
Improve the descriptions of the `initial..` settings to emphasize that they occur only in two cases:
- When a DBMS is created (at the first DBMS startup)
- When a server is enabled (when you add a new server to the existing cluster)