### PR TITLE
Document the unbind-system-db command and add details about the syste…

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -147,6 +147,7 @@
 *** xref:clustering/setup/encryption.adoc[]
 ** xref:clustering/servers.adoc[]
 ** xref:clustering/databases.adoc[]
+** xref:clustering/unbind-system-database.adoc[]
 ** Monitoring
 *** xref:clustering/monitoring/show-servers-monitoring.adoc[]
 *** xref:clustering/monitoring/show-databases-monitoring.adoc[]

--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -8,6 +8,23 @@ The number of both primary and secondary servers to host a database can be set w
 The command `CREATE DATABASE` can be used to specify the initial topology and `ALTER DATABASE` can be used to change the topology once the database is created.
 If a database is no longer needed, the command `DROP DATABASE` deletes the database from the cluster.
 
+[[cluster-system-db]]
+== The `system` database in a cluster
+
+The `system` database contains metadata on the DBMS and security configuration.
+When connected to this database you can only perform a specific set of administrative tasks, such as managing databases, servers, and access control.
+
+In the clustered environment, the `system` database can be in a primary or secondary mode.
+To configure its mode, use the xref:configuration/configuration-settings.adoc#config_server.cluster.system_database_mode[`server.cluster.system_database_mode`] setting.
+
+Deploying a cluster for the first time, consider configuring the xref:configuration/configuration-settings.adoc#config_dbms.cluster.minimum_initial_system_primaries_count[`dbms.cluster.minimum_initial_system_primaries_count`].
+This setting defaults to `3`.
+See xref:clustering/setup/deploy.adoc[] for details.
+
+For information on how to recover the `system` database, refer to the xref:clustering/multi-region-deployment/disaster-recovery.adoc[Disaster recovery guide].
+
+
+
 [[create-database]]
 == `CREATE DATABASE`
 

--- a/modules/ROOT/pages/clustering/unbind-system-database.adoc
+++ b/modules/ROOT/pages/clustering/unbind-system-database.adoc
@@ -1,0 +1,82 @@
+:description: The page describes the neo4j-admin command `dbms unbind-system-db`.
+[role=enterprise-edition]
+
+= Unbind the `system` database
+
+You can use the `neo4j-admin dbms unbind-system-db` command to remove and archive the cluster state for the `system` database, so that the server can rebind to a new `system` database in the cluster.
+
+[CAUTION]
+====
+Executing the `neo4j-admin dbms unbind-system-db` command does not affect the cluster state of other standard databases.
+However, since all servers in the DBMS need to be shut down to run the command, downtime will occur for all databases inside of the DBMS.
+====
+[[unbind-system-db-syntax]]
+== Syntax
+
+The `neo4j-admin dbms unbind-system-db` command has the following syntax:
+
+----
+neo4j-admin dbms unbind-system-db [-h] [--expand-commands] [--verbose] [--archive-cluster-state[=true|false]]
+                                  [--additional-config=<file>] [--archive-path=<path>]
+----
+
+
+[[unbind-system-db-description]]
+== Description
+
+Removes and archives cluster state for `system` database.
+
+[[unbind-system-db-options]]
+== Options
+
+
+The `neo4j-admin dbms unbind-system-db` command has the following options:
+
+.`neo4j-admin dbms unbind-system-db` options
+[options="header", cols="5m,6a,2m"]
+|===
+| Option
+| Description
+| Default
+
+|--additional-config=<file>
+|Configuration file with additional configuration.
+|
+
+|--archive-cluster-state[=true\|false]
+|Enable or disable the cluster state archiving.
+|false
+
+|--archive-path=<path>
+|Destination (file or folder) of the cluster state archive.
+|
+
+|--expand-commands
+|Allow command expansion in config value evaluation.
+|
+
+|-h, --help
+|Show this help message and exit.
+|
+
+|--verbose
+|Enable verbose output.
+|
+|===
+
+[[unbind-system-db-limitations]]
+== Limitations
+
+The Neo4j process must be shut down on all servers before running the `neo4j-admin dbms unbind-system-db` command.
+
+[[unbind-system-db-usage]]
+== Usage
+
+The `neo4j-admin dbms unbind-system-db` command removes and archives cluster state for the `system` database, so that the server can rebind to a new `system` database in a cluster.
+
+You must shut down all cluster members before running the command on each of them.
+For details, see xref:clustering/multi-region-deployment/disaster-recovery.adoc#make-the-system-database-write-available[Disaster recovery guide -> Make the `system` database write-available].
+
+The `neo4j-admin dbms unbind-system-db` command does not affect the cluster state of the standard databases.
+However, since all servers in the DBMS must be shut down before the command is issued, downtime is expected for all databases within the DBMS.
+

--- a/modules/ROOT/pages/database-administration/index.adoc
+++ b/modules/ROOT/pages/database-administration/index.adoc
@@ -74,6 +74,8 @@ image::manage-dbs-community.png[title="A default Neo4j installation.", role="mid
 .An installation of Neo4j with multiple active databases, named `marketing`, `sales`, and `hr`:
 image::manage-dbs-enterprise.png[title="A multiple database Neo4j installation.", role="middle"]
 
+For details about the `system` database in a clustered environment, refer to xref:clustering/databases.adoc#cluster-system-db[Managing databases in a cluster -> The `system` database]. 
+
 == Composite databases
 
 A Composite database is a logical grouping of multiple graphs contained in other, standard databases.

--- a/modules/ROOT/pages/tools/neo4j-admin/index.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/index.adoc
@@ -59,6 +59,7 @@ For details, see xref:configuration/set-initial-password.adoc[Set an initial pas
 
 | `unbind-system-db`
 | Removes and archives the cluster state of the `system` database so the instance can rebind to a new cluster state of the `system` database.
+For details, see xref:clustering/unbind-system-database.adoc[].
 
 .13+| `server`
 


### PR DESCRIPTION
…m db in cluster (#2631)

Add a new page covering the `neo4j-admin dbms unbind-system-db` command. Add a section about the `system` database role in a cluster to the page 'Managing databases in a cluster'.

This PR should be copied to the 5.x branch with a few adjustments: the label `Introduced in 5.0` should be added.

---------