### PR TITLE
Add details about the GDS plugin in CE

### DIFF
--- a/modules/ROOT/pages/configuration/plugins.adoc
+++ b/modules/ROOT/pages/configuration/plugins.adoc
@@ -9,7 +9,7 @@ Plugins are Java Archive (_.jar_) files that extend the functionality of Neo4j b
 Both Neo4j Community Edition (CE) and Enterprise Edition (EE) come with a range of pre-installed products, such as Gen AI, Graph Data Science, and Fleet management in the _products_ directory and the APOC Core jar file in the _labs_ directory. +
 The Fleet management jar file is bundled with the Neo4j server starting with Neo4j 5.26.10 and 2025.07.0 onwards.
 If you are using an earlier version of Neo4j, you can get the matching version of the Fleet management plugin by following the download link that matches your server version in the *Monitor Deployment* wizard in the Aura console.
-See link:{neo4j-docs-base-uri}/aura/fleet-management/setup/[Aura documentation -> Fleet Management -> Add a deployment] for more information. 
+See link:{neo4j-docs-base-uri}/aura/fleet-management/setup/[Aura documentation -> Fleet Management -> Add a deployment] for more information.
 
 [NOTE]
 ====


### PR DESCRIPTION
Neo4j CE 5.26.x (including up to the current 5.26.13) and Neo4j CE releases 2025.01-2025.04 do not include the GDS plugin. To use it, you have to download it separately.
At this time, we don’t have specific download links to direct users to.
Currently the best available resource is the GDS documentation.