### PR TITLE
Add docs configuration dbms.security.allow_oidc_credential_forwarding_enabled

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -4724,12 +4724,12 @@ m|+++false+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|When set to `true`, remote database aliases are allowed to authenticate to remote databases using OIDC credential forwarding. When set to `false`, authentication of remote database aliases using OIDC credential forwarding is disallowed. Existing aliases that rely on this method remain defined but cannot be used to connect until this setting is enabled.
+a|When set to `true`, remote database aliases are allowed to forward OIDC credentials to authenticate on remote Neo4j DBMS. When set to `false`, OIDC credentials are not allowed to be forwarded to remote DBMS. Existing aliases that rely on this method remain defined but cannot be used to connect until this setting is enabled.
 |Valid values
 a|A boolean.
 |Default value
 m|+++false+++
-|===c
+|===
 
 [[config_dbms.netty.ssl.provider]]
 === `dbms.netty.ssl.provider`


### PR DESCRIPTION
This adds documentation about the new configuration dbms.security.allow_oidc_credential_forwarding_enabled introduced in [this](https://github.com/neo-technology/neo4j/pull/32913) PR.