### PR TITLE
Add details about the GDS plugin in CE (#2654)

### DIFF
--- a/modules/ROOT/pages/configuration/plugins.adoc
+++ b/modules/ROOT/pages/configuration/plugins.adoc
@@ -18,6 +18,10 @@ Also, it is offered on a best-effort basis.
 Neo4j does not offer any technical support for it.
 ====
 
+If your Neo4j CE installation does not include the bundled GDS plugin, check the link:{neo4j-docs-base-uri}/graph-data-science/current/installation/supported-neo4j-versions[Neo4j Graph Data Science Library Manual -> Supported Neo4j versions] to find your matching GDS library version and download it separately.
+For detailed installation, refer to the corresponding Neo4j GDS manual.
+
+
 Some of these plugins, such as Bloom and GDS Enterprise require a license activation key.
 Reach out to your Neo4j account representative or request a representative to link:https://neo4j.com/contact-us/#sales-inquiry[contact you].
 


### PR DESCRIPTION
Neo4j CE 5.26.x (including up to the current 5.26.13) and Neo4j CE releases 2025.01-2025.04 do not include the GDS plugin. To use it, you have to download it separately.
At this time, we don’t have specific download links to direct users to. Currently the best available resource is the GDS documentation.