### PR TITLE
Fix: place label in description column

### DIFF
--- a/modules/ROOT/pages/database-administration/aliases/manage-aliases-standard-databases.adoc
+++ b/modules/ROOT/pages/database-administration/aliases/manage-aliases-standard-databases.adoc
@@ -125,7 +125,7 @@ List of xref::database-administration/aliases/manage-aliases-standard-databases.
 
 | defaultLanguage
 |
-The default language for non-constituent remote database aliases or `null` if it is a constituent or local database alias. label:new[Introduced in 2025.06]
+label:new[Introduced in 2025.06] The default language for non-constituent remote database aliases or `null` if it is a constituent or local database alias.
 | STRING
 
 | properties


### PR DESCRIPTION
Noticed that we have all other "introduced in" labels in the description  column. Moved this one there as well.