### PR TITLE
Add clarification about require_local_user and plugin auth

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -4709,8 +4709,8 @@ m|++++++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|This controls if a local user has to be created for external authentication. If set to the default (`false`), no user has to be created to authenticate with an external authentication provider. If set to `true`, a user representing the external user must be created before they can authenticate successfully.+
-The external users are required to be explicitly mapped to local users. See xref:/authentication-authorization/auth-providers.adoc[User auth providers] for details.+
+a|This controls if a local user has to be created for external authentication. If set to the default (`false`), no user has to be created to authenticate with an external authentication provider. If set to `true`, a user representing the external user must be created before they can authenticate successfully. +
+External users must be explicitly mapped to local users. See xref:/authentication-authorization/auth-providers.adoc[User auth providers] for details. +
 +NOTE+: This setting only works with the built-in auth providers (LDAP, SSO/OIDC).
 Plugin authentication does not have access to validate whether a local user exists and can therefore not ensure this setting.
 |Valid values


### PR DESCRIPTION
https://linear.app/neo4j/issue/COPS-155/clarify-that-dbmssecurityrequire-local-user-does-not-work-with-plugin