### PR TITLE
docs: add info about suspended status whit user auth providers (COPS-12)

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/manage-users.adoc
+++ b/modules/ROOT/pages/authentication-authorization/manage-users.adoc
@@ -22,7 +22,7 @@ If suspended while using Neo4j, they lose all assigned roles with their privileg
 If suspended while using Neo4j, they retain the roles and the privileges assigned by the external provider, including the `PUBLIC` role.
 To prevent any of these, you need to use the mechanisms of their identity provider.
 * Users who authenticate and authorize against an external ID provider and have xref:authentication-authorization/auth-providers.adoc[user auth providers] set up cannot log into Neo4j.
-If suspended while using Neo4j, they lose all assigned roles with their privileges, including the `PUBLIC` role, until reactivated.
+If suspended while using Neo4j, they lose all assigned roles and associated privileges, including the `PUBLIC` role, until reactivated.
 
 [[access-control-user-syntax]]
 == User management command syntax


### PR DESCRIPTION
Adding info about the behavior if a user with user auth provider is suspended.

Linear issue [COPS-12](https://linear.app/neo4j/issue/COPS-12/add-a-note-about-linked-users-to-suspend-user-docs)