### PR TITLE
Update the steps for adding the neo4j repo to the apt manager

### DIFF
--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -77,7 +77,7 @@ sudo mkdir -p /etc/apt/keyrings
 +
 [source,bash]
 ----
-wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo tee /etc/apt/keyrings/neotechnology.gpg > /dev/null
+wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/neotechnology.gpg > /dev/null
 ----
 . Ensure the key file is world-readable:
 +


### PR DESCRIPTION
Trello card: https://trello.com/c/JN3MgzRE/990-update-debian-based-distribution, which is about a problem with the location where the key is stored after dearmoring, which Debian states as being deprecated.