### PR TITLE
Update the steps for adding the neo4j repo to the apt manager (#2736)

### DIFF
--- a/modules/ROOT/pages/installation/linux/debian.adoc
+++ b/modules/ROOT/pages/installation/linux/debian.adoc
@@ -58,21 +58,45 @@ sudo update-java-alternatives --jre --set <java21name>
 [[debian-installation]]
 == Installation
 
+To install Neo4j using the Debian package manager `apt`, you need to add the Neo4j repository to your system's list of package sources, and then install the desired Neo4j package.
+The Debian package is available from https://debian.neo4j.com.
 
 [[debian-add-repository]]
 === Add the repository
 
-The Debian package is available from https://debian.neo4j.com.
+Run the following commands as a sudo user to add the Neo4j repository to the package manager:
 
-. To add the Neo4j repository to the package manager, run the following as a `sudo` user:
+. Create the keyrings directory for the Neo4j GPG key if it does not already exist:
 +
-[source, bash]
+[source,bash]
 ----
-wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/neotechnology.gpg
-echo 'deb [signed-by=/etc/apt/keyrings/neotechnology.gpg] https://debian.neo4j.com stable latest' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
+sudo mkdir -p /etc/apt/keyrings
+----
+
+. Download and install the Neo4j GPG key:
++
+[source,bash]
+----
+wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/neotechnology.gpg > /dev/null
+----
+. Ensure the key file is world-readable:
++
+[source,bash]
+----
+sudo chmod a+r /etc/apt/keyrings/neotechnology.gpg
+----
+. Add the Neo4j APT repository:
++
+[source,bash]
+----
+echo 'deb [signed-by=/etc/apt/keyrings/neotechnology.gpg] https://debian.neo4j.com stable latest' | sudo -a tee /etc/apt/sources.list.d/neo4j.list > /dev/null
+----
+. Update package lists:
++
+[source,bash]
+----
 sudo apt-get update
 ----
-+
 . Once the repository has been added to `apt`, you can verify which Neo4j versions are available by running:
 +
 [source, bash]


### PR DESCRIPTION
Trello card:
https://trello.com/c/JN3MgzRE/990-update-debian-based-distribution, which is about a problem with the location where the key is stored after dearmoring, which Debian states as being deprecated.