### PR TITLE
Fix broken links

### DIFF
--- a/modules/ROOT/pages/cloud-deployments/neo4j-aws.adoc
+++ b/modules/ROOT/pages/cloud-deployments/neo4j-aws.adoc
@@ -24,7 +24,7 @@ The  CloudFormation template always installs the latest available version.
 
 AWS CloudFormation is a declarative Infrastructure as Code (IaC) language that is based on YAML and instructs AWS to deploy a set of cloud resources.
 
-The Neo4j CloudFormation template's code is available on link:https://github.com/neo4j-partners/amazon-cloud-formation-neo4j/blob/main/marketplace/neo4j-enterprise/neo4j.template.yaml[GitHub].
+The Neo4j CloudFormation template's code is available on link:https://github.com/neo4j-partners/amazon-cloud-formation-neo4j/blob/main/neo4j.template.yaml[GitHub].
 It takes several parameters as inputs, deploys a set of cloud resources, and provides outputs that can be used to connect to a Neo4j DBMS.
 
 === Important considerations

--- a/modules/ROOT/pages/kubernetes/import-data.adoc
+++ b/modules/ROOT/pages/kubernetes/import-data.adoc
@@ -17,7 +17,7 @@ To import data from CSV files into Neo4j, use the command `neo4j-admin database 
 * The xref:import.adoc[`neo4j-admin database import`] command can be used to do batch imports of large amounts of data into a previously unused database and can only be performed once per database.
 * `LOAD CSV` Cypher statement can be used to import small to medium-sized CSV files into an existing database.
 `LOAD CSV` can be run as many times as needed and does not require an empty database.
-For a simple example, see link:https://neo4j.com/docs/getting-started/cypher-intro/load-csv/[Getting Started Guide -> Import data].
+For details, see link:https://neo4j.com/docs/cypher-manual/current/clauses/load-csv/[Cypher manual -> `LOAD CSV`].
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -534,7 +534,7 @@ There are also a couple of built-in templates available from the classpath, for 
 | https://github.com/logstash/log4j-jsonevent-layout[Logstash `json_event` pattern for Log4j]
 
 | classpath:GelfLayout.json
-| https://go2docs.graylog.org/current/getting_in_log_data/gelf.html#GELFPayloadSpecification[Graylog Extended Log Format (GELF) payload specification] with additional `_thread` and `_logger` fields.
+| https://go2docs.graylog.org/5-0/getting_in_log_data/gelf.html?Highlight=Payload#GELFPayloadSpecification[Graylog Extended Log Format (GELF) payload specification] with additional `_thread` and `_logger` fields.
 
 | classpath:GcpLayout.json
 | https://cloud.google.com/logging/docs/structured-logging[Google Cloud Platform structured logging] with additional `_thread`, `_logger`, and `_exception` fields.


### PR DESCRIPTION
Several links in the Ops manual were broken due to recent changes:
- The `github.com/neo4j-partners/amazon-cloud-formation-neo4j` repo was restructured.
- The GELF documentation was updated, resulting in moved pages.
- The 'Import data` tutorial was removed from the Getting Started Guide.