### PR TITLE
Deprecate lz4 from network compression

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -560,10 +560,10 @@ m|+++32768+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|Network compression algorithms that this instance will allow in negotiation as a comma-separated list. +
+a|Network compression algorithms that this server will allow in negotiation as a comma-separated list. +
 For incoming connections, the algorithms are listed in descending order of preference. An empty list implies no compression. +
 For outgoing connections, this merely specifies the allowed set of algorithms and the preference of the remote peer will be used for making the decision. +
-Allowable values: [Snappy, Snappy_validating, LZ4(deprecated-2026.01), LZ4_high_compression(deprecated-2026.01), LZ_validating(deprecated-2026.01), LZ4_high_compression_validating(deprecated-2026.01)]
+Allowable values: [Snappy, Snappy_validating, LZ4 label:deprecated[Deprecated in 2026.01], LZ4_high_compression label:deprecated[Deprecated in 2026.01], LZ_validating label:deprecated[Deprecated in 2026.01], LZ4_high_compression_validating label:deprecated[Deprecated in 2026.01]].
 |Valid values
 a|A comma-separated list where each element is a string.
 |Default value


### PR DESCRIPTION
Lz4 is no longer officially supported and we want to remove this option in the next LTS