### PR TITLE
DOCCORE-103 Remove inconsistencies with the published version

### DIFF
--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -1431,7 +1431,7 @@ This overrides the header definition for `date1`, as well as the configured defa
 
 ====
 
-Special considerations for vector data types::
+Special considerations for vector data types introduced in 2025.10::
 +
 --
 A vector is specified using the Cypher syntax for maps.


### PR DESCRIPTION
See the page in the `main` branch. This info about the Neo4j version was added in the PR #2694