### PR TITLE
DOCCORE-53:issues relative to executableQueryCacheHit

### DIFF
--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -1234,7 +1234,7 @@ The `QueryLogJsonLayout.json` template mimics the 4.x layout and contains the fo
 If the type of the log entry is `query`, these additional fields are available:
 
 .JSON format log entries for log type `query`
-[cols="1m,3a", options="header"]
+[cols="2m,3a", options="header"]
 |===
 | Name
 | Description


### PR DESCRIPTION
This PR hides `executableQueryCacheHit` as it requires the internal setting `internal.dbms.logs.query.query_cache_usage=true` to be enabled in order to be logged in the JSON log. We don't document internal settings.

Related to: https://github.com/neo4j/docs-operations/pull/2064