### PR TITLE
DOCCORE-53:issues relative to executableQueryCacheHit (#2786)

### DIFF
--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -1199,7 +1199,7 @@ The `QueryLogJsonLayout.json` template mimics the 4.x layout and contains the fo
 If the type of the log entry is `query`, these additional fields are available:
 
 .JSON format log entries for log type `query`
-[cols="1m,3a", options="header"]
+[cols="2m,3a", options="header"]
 |===
 | Name
 | Description
@@ -1281,8 +1281,9 @@ Enabled by default only in the JSON format.
 If multiple query executions use the same cached execution plan, their hashes should match.
 For `event=start`, the value is `00000000`.
 
-| executableQueryCacheHit
-| Whether the query string matched a cached execution plan.
+//####Hiding the `executableQueryCacheHit` because it requires the internal setting `internal.dbms.logs.query.query_cache_usage=true` to be enabled in order to be logged.####
+// | executableQueryCacheHit
+// | Whether the query string matched a cached execution plan.
 
 |===
 


### PR DESCRIPTION
This PR hides `executableQueryCacheHit` as it requires the internal setting `internal.dbms.logs.query.query_cache_usage=true` to be enabled in order to be logged in the JSON log. We don't document internal settings.

Related to: https://github.com/neo4j/docs-operations/pull/2064