### PR TITLE
Update RBAC limitations page to include vector indexes

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/limitations.adoc
+++ b/modules/ROOT/pages/authentication-authorization/limitations.adoc
@@ -52,7 +52,7 @@ In previous versions, they could only be on a single property and a single label
 === Example with denied labels and index on multiple properties
 
 Consider the following full-text example.
-The database has nodes with labels `:User` and `:Person`, and they have properties `name` and `surname`.
+The database contains nodes with the labels `:User` and `:Person`, and the properties `name` and `surname`.
 There are indexes on both properties:
 
 [source, cypher]


### PR DESCRIPTION
Multiple labels/reltypes/additional properties for vector indexes were introduced in https://github.com/neo4j/docs-cypher/pull/1454.