### PR TITLE
Document auth rule backup support and add temporal warnings to ABAC docs

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
@@ -92,6 +92,23 @@ The `conditionExpression` can use any valid Cypher expression that evaluates to 
 The functions, `date`, `datetime`, `localdatetime`, `localtime`, and `time` are only supported when you use an input argument.
 ====
 
+[NOTE]
+====
+Transaction time functions such as `datetime.transaction()` always reflect the server's clock time.
+In a cluster, it is important to keep the system clocks synchronized across all nodes to ensure consistent auth rule evaluation.
+====
+
+[WARNING]
+====
+Avoid using `localtime` and `localdatetime` without specifying a timezone, as these functions rely on the server's default timezone.
+====
+
+[WARNING]
+====
+Avoid mixing time values from authentication token claims (via `abac.oidc.user_attribute()`) with server time functions such as `datetime.transaction()` or `time()`.
+Token timestamps are fixed at the time of issuance and may use different formats or timezones, which can lead to unexpected comparison results.
+====
+
 <4> (Optional) The `SET ENABLED` clause allows you to enable or disable the rule upon creation.
 By default, the rule is enabled.
 
@@ -137,6 +154,15 @@ The following example creates an auth rule that temporarily grants the assigned 
 CREATE AUTH RULE temporary_reader
     SET CONDITION abac.oidc.user_attribute('jobTitle') = 'developer'
         AND datetime.transaction().hour >= 19 AND datetime.transaction().hour < 20;
+----
+
+The following example uses zoned time anchored to UTC to avoid dependency on the server's default timezone, granting access to users in the `EMEA` region during European working hours (06:00–18:00 UTC):
+
+[source, cypher25, role="noheader"]
+----
+CREATE AUTH RULE emea_working_hours
+    SET CONDITION abac.oidc.user_attribute('region') = 'EMEA'
+        AND time({timezone: 'UTC'}).hour >= 6 AND time({timezone: 'UTC'}).hour < 18;
 ----
 
 [[assign-roles-auth-rules]]

--- a/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
@@ -109,7 +109,7 @@ Avoid using `localtime` and `localdatetime` without specifying a timezone, as th
 [WARNING]
 ====
 Avoid mixing time values from authentication token claims (via `abac.oidc.user_attribute()`) with server time functions such as `datetime.transaction()` or `time()`.
-Token timestamps are fixed at the time of issuance and may use different formats or timezones, which can lead to unexpected comparison results.
+Token timestamps are fixed at the time of issuance and may use different formats or time zones, which can lead to unexpected comparison results.
 ====
 
 <4> (Optional) The `SET ENABLED` clause allows you to enable or disable the rule upon creation.

--- a/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
@@ -89,7 +89,8 @@ The `conditionExpression` can use any valid Cypher expression that evaluates to 
 +
 [NOTE]
 ====
-The functions, `date`, `datetime`, `localdatetime`, `localtime`, and `time` are only supported when you use an input argument to specify the instance. This is because auth rules get evaluated at the instant that the transaction begins.
+The functions `date`, `datetime`, `localdatetime`, `localtime`, and `time` are only supported when you use an input argument to specify the instant.
+This is because auth rules are evaluated at the moment the transaction begins.
 As far as auth rules are concerned, there is no concept of statement time or real time. To get the current temporal instant, use any of the `*.transaction()` functions.
 ====
 +

--- a/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
@@ -91,25 +91,19 @@ The `conditionExpression` can use any valid Cypher expression that evaluates to 
 ====
 The functions `date`, `datetime`, `localdatetime`, `localtime`, and `time` are only supported when you use an input argument to specify the instant.
 This is because auth rules are evaluated at the moment the transaction begins.
-As far as auth rules are concerned, there is no concept of statement time or real time. 
+As far as auth rules are concerned, there is no concept of statement time or real time.
 To get the current temporal instant type, use any of the `*.transaction()` functions.
-====
-+
-[NOTE]
-====
+
 Transaction time functions such as `datetime.transaction()` always reflect the server's clock time.
 In a cluster, it is important to keep the system clocks synchronized across all cluster members to ensure consistent auth rule evaluation.
 ====
 +
 [WARNING]
 ====
-Avoid using `localtime` and `localdatetime` without specifying a timezone, as these functions rely on the server's default timezone.
-====
-+
-[WARNING]
-====
-Avoid mixing time values from authentication token claims (via `abac.oidc.user_attribute()`) with server time functions such as `datetime.transaction()` or `time()`.
-Token timestamps are fixed at the time of issuance and may use different formats or time zones, which can lead to unexpected comparison results.
+* Avoid using `localtime` and `localdatetime` without specifying a timezone, as these functions rely on the server's default timezone.
+
+* Avoid mixing time values from authentication token claims (via `abac.oidc.user_attribute()`) with server time functions such as `datetime.transaction()` or `time()`.
+Token timestamps are fixed at the time of issuance and may use different formats or timezones, leading to unexpected comparison results.
 ====
 
 <4> (Optional) The `SET ENABLED` clause allows you to enable or disable the rule upon creation.

--- a/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
@@ -90,7 +90,7 @@ The `conditionExpression` can use any valid Cypher expression that evaluates to 
 [NOTE]
 ====
 The functions, `date`, `datetime`, `localdatetime`, `localtime`, and `time` are only supported when you use an input argument to specify the instance. This is because auth rules get evaluated at the instant that the transaction begins.
-As far as auth rules are concerned, there is no concept of statement time or real time. To get a temporal instance without specifying the temporal instance, use any of the `*.transaction()` functions.
+As far as auth rules are concerned, there is no concept of statement time or real time. To get the current temporal instant, use any of the `*.transaction()` functions.
 ====
 +
 [NOTE]

--- a/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
@@ -92,18 +92,18 @@ The `conditionExpression` can use any valid Cypher expression that evaluates to 
 The functions, `date`, `datetime`, `localdatetime`, `localtime`, and `time` are only supported when you use an input argument to specify the instance. This is because auth rules get evaluated at the instant that the transaction begins.
 As far as auth rules are concerned, there is no concept of statement time or real time. To get a temporal instance without specifying the temporal instance, use any of the `*.transaction()` functions.
 ====
-
++
 [NOTE]
 ====
 Transaction time functions such as `datetime.transaction()` always reflect the server's clock time.
 In a cluster, it is important to keep the system clocks synchronized across all cluster nodes to ensure consistent auth rule evaluation.
 ====
-
++
 [WARNING]
 ====
 Avoid using `localtime` and `localdatetime` without specifying a timezone, as these functions rely on the server's default timezone.
 ====
-
++
 [WARNING]
 ====
 Avoid mixing time values from authentication token claims (via `abac.oidc.user_attribute()`) with server time functions such as `datetime.transaction()` or `time()`.

--- a/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
@@ -98,7 +98,7 @@ To get the current temporal instant type, use any of the `*.transaction()` funct
 [NOTE]
 ====
 Transaction time functions such as `datetime.transaction()` always reflect the server's clock time.
-In a cluster, it is important to keep the system clocks synchronized across all cluster nodes to ensure consistent auth rule evaluation.
+In a cluster, it is important to keep the system clocks synchronized across all cluster members to ensure consistent auth rule evaluation.
 ====
 +
 [WARNING]

--- a/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
@@ -91,7 +91,8 @@ The `conditionExpression` can use any valid Cypher expression that evaluates to 
 ====
 The functions `date`, `datetime`, `localdatetime`, `localtime`, and `time` are only supported when you use an input argument to specify the instant.
 This is because auth rules are evaluated at the moment the transaction begins.
-As far as auth rules are concerned, there is no concept of statement time or real time. To get the current temporal instant, use any of the `*.transaction()` functions.
+As far as auth rules are concerned, there is no concept of statement time or real time. 
+To get the current temporal instant type, use any of the `*.transaction()` functions.
 ====
 +
 [NOTE]

--- a/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
@@ -89,13 +89,14 @@ The `conditionExpression` can use any valid Cypher expression that evaluates to 
 +
 [NOTE]
 ====
-The functions, `date`, `datetime`, `localdatetime`, `localtime`, and `time` are only supported when you use an input argument.
+The functions, `date`, `datetime`, `localdatetime`, `localtime`, and `time` are only supported when you use an input argument to specify the instance. This is because auth rules get evaluated at the instant that the transaction begins.
+As far as auth rules are concerned, there is no concept of statement time or real time. To get a temporal instance without specifying the temporal instance, use any of the `*.transaction()` functions.
 ====
 
 [NOTE]
 ====
 Transaction time functions such as `datetime.transaction()` always reflect the server's clock time.
-In a cluster, it is important to keep the system clocks synchronized across all nodes to ensure consistent auth rule evaluation.
+In a cluster, it is important to keep the system clocks synchronized across all cluster nodes to ensure consistent auth rule evaluation.
 ====
 
 [WARNING]
@@ -156,13 +157,13 @@ CREATE AUTH RULE temporary_reader
         AND datetime.transaction().hour >= 19 AND datetime.transaction().hour < 20;
 ----
 
-The following example uses zoned time anchored to UTC to avoid dependency on the server's default timezone, granting access to users in the `EMEA` region during European working hours (06:00–18:00 UTC):
+The following example uses `time.transaction()` anchored to UTC to avoid dependency on the server's default timezone, granting access to users in the `EMEA` region during European working hours (06:00–18:00 UTC):
 
 [source, cypher25, role="noheader"]
 ----
 CREATE AUTH RULE emea_working_hours
     SET CONDITION abac.oidc.user_attribute('region') = 'EMEA'
-        AND time({timezone: 'UTC'}).hour >= 6 AND time({timezone: 'UTC'}).hour < 18;
+        AND time.transaction('UTC').hour >= 6 AND time.transaction('UTC').hour < 18;
 ----
 
 [[assign-roles-auth-rules]]

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -132,7 +132,7 @@ If <database> is "*", `neo4j-admin` will attempt to back up all databases of the
 |--include-metadata=none\|all\|users[=user1,user2]\|roles
 |label:new[Changed in 2025.10] Include metadata in the file. This cannot be used for backing up the `system` database. Possible values are:
 
-- `roles` - include commands to create the roles and privileges (for both database and graph) that affect the use of the database.
+- `roles` - include commands to create the roles, auth rules and privileges (for both database and graph) that affect the use of the database.
 - `users` - include commands to create the users that can use the database and their role assignments. If a list of users is specified (e.g. `users=alice,bob,charlie`), only those users are included in the backup.
 - `all` - include both `roles` and `users`.
 - `none` - does not include any metadata.

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -132,7 +132,7 @@ If <database> is "*", `neo4j-admin` will attempt to back up all databases of the
 |--include-metadata=none\|all\|users[=user1,user2]\|roles
 |label:new[Changed in 2025.10] Include metadata in the file. This cannot be used for backing up the `system` database. Possible values are:
 
-- `roles` - include commands to create the roles, auth rules and privileges (for both database and graph) that affect the use of the database.
+- `roles` - include commands to create the roles, auth rules, and privileges (for both database and graph) that affect the use of the database.
 - `users` - include commands to create the users that can use the database and their role assignments. If a list of users is specified (e.g. `users=alice,bob,charlie`), only those users are included in the backup.
 - `all` - include both `roles` and `users`.
 - `none` - does not include any metadata.

--- a/modules/ROOT/pages/backup-restore/restore-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/restore-backup.adoc
@@ -298,7 +298,7 @@ For more information, see xref:clustering/databases.adoc#cluster-seed[Designated
 
 === Restore users and roles metadata
 
-If you have backed up a database with the option `--include-metadata`, you can manually restore the users and roles metadata.
+If you have backed up a database with the option `--include-metadata`, you can manually restore the users, roles, and auth rules metadata.
 
 From the _<NEO4J_HOME>_ directory, you run the Cypher script _/data/scripts/databasename/restore_metadata.cypher_, which the `neo4j-admin database restore` command outputs, using xref:cypher-shell.adoc[]:
 


### PR DESCRIPTION
A few updates to the documentation regarding ABAC:

* Mention auth rules in the backup documentation
* One more time example and warnings about things to keep in mind when creating ABAC rules based on temporal functions. 