### PR TITLE
Clarify the use of the web directory (#2971)

### DIFF
--- a/modules/ROOT/pages/configuration/file-locations.adoc
+++ b/modules/ROOT/pages/configuration/file-locations.adoc
@@ -306,11 +306,14 @@ File permissions:: Read and write.
 |===
 
 
-[role=label--new-2026.02]
+[role=label--new-2026.02.3]
 [[neo4j-web]]
 === Web
 
-Neo4j 2026.02 introduces a new directory _web_, which contains Neo4j Browser as a .zip file.
+Starting from Neo4j 2026.02.3, a new directory _web_ is introduced in the Neo4j Community Edition.
+The _web_ directory contains Neo4j Browser bundled as a .zip file.
+
+The Neo4j Enterprise Edition does not include the _web_ directory; and Neo4j Browser continues to be distributed as a .jar file located in the _lib_ directory.
 
 File permissions:: Read only.
 


### PR DESCRIPTION
Clarify the introduction of the _web_ directory in Neo4j 2026.02 and its contents for Community Edition.

I'm not sure if we want to add these details to the docs, but it reflects the current situation with the Neo4j editions and packages.

This info should also be copied to the 5.x branch as those changes were introduced in 5.26.23 (TBC)