### PR TITLE
Update description for db.prepareForReplanning with 0s timeout.

### DIFF
--- a/modules/ROOT/pages/performance/statistics-execution-plans.adoc
+++ b/modules/ROOT/pages/performance/statistics-execution-plans.adoc
@@ -120,7 +120,7 @@ CALL db.clearQueryCaches()
 xref:procedures.adoc#procedure_db_prepareForReplanning[`db.prepareForReplanning()`]::
 Completely recalculates all database statistics to be used for any subsequent query planning.
 +
-The procedure triggers an index resampling, waits for it to complete, and clears all query caches.
+The procedure triggers an index resampling, waits for it to complete, unless the wait time is 0 then it skips waiting, and clears all query caches.
 Afterwards, queries are planned based on the latest database statistics.
 +
 [source, cypher]

--- a/modules/ROOT/pages/performance/statistics-execution-plans.adoc
+++ b/modules/ROOT/pages/performance/statistics-execution-plans.adoc
@@ -120,8 +120,8 @@ CALL db.clearQueryCaches()
 xref:procedures.adoc#procedure_db_prepareForReplanning[`db.prepareForReplanning()`]::
 Completely recalculates all database statistics to be used for any subsequent query planning.
 +
-The procedure triggers an index resampling, waits for it to complete, unless the wait time is 0 then it skips waiting, and clears all query caches.
-Afterwards, queries are planned based on the latest database statistics.
+The procedure triggers an index resample and waits for its completion. If the wait time is 0, it skips waiting. After that, the procedure clears query caches.
+Once the process is complete, queries are planned using the latest database statistics.
 +
 [source, cypher]
 ----

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -1744,7 +1744,7 @@ For more information, see xref:performance/statistics-execution-plans.adoc[]
 .Details
 |===
 | *Syntax* 3+m| db.prepareForReplanning([ timeOutSeconds ])
-| *Description* 3+a| Triggers an index resample and waits for it to complete, and after that clears query caches. After this procedure has finished queries will be planned using the latest database statistics.
+| *Description* 3+a| Triggers an index resample and waits for it to complete, unless the wait time is 0 then it skips waiting, and after that clears query caches. After this procedure has finished queries will be planned using the latest database statistics.
 .2+| *Input arguments* | *Name* | *Type* | *Description*
 | `timeOutSeconds` | `INTEGER` | The maximum time to wait in seconds.
 | *Mode* 3+| READ

--- a/modules/ROOT/pages/procedures.adoc
+++ b/modules/ROOT/pages/procedures.adoc
@@ -1744,7 +1744,7 @@ For more information, see xref:performance/statistics-execution-plans.adoc[]
 .Details
 |===
 | *Syntax* 3+m| db.prepareForReplanning([ timeOutSeconds ])
-| *Description* 3+a| Triggers an index resample and waits for it to complete, unless the wait time is 0 then it skips waiting, and after that clears query caches. After this procedure has finished queries will be planned using the latest database statistics.
+| *Description* 3+a| Triggers an index resample and waits for its completion. If the wait time is 0, it skips waiting. After that, the procedure clears query caches. Once the process is complete, queries are planned using the latest database statistics.
 .2+| *Input arguments* | *Name* | *Type* | *Description*
 | `timeOutSeconds` | `INTEGER` | The maximum time to wait in seconds.
 | *Mode* 3+| READ


### PR DESCRIPTION
Updates the description for db.prepareForReplanning to specify what happens when using 0 seconds as the timeout. 