### PR TITLE
Add information and example of combining SHOW DATABASES with regular Cypher

### DIFF
--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -28,6 +28,10 @@ YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
 
 |===
 
+From 2026.XX, it is possible to combine the `SHOW DATABASES` command with regular Cypher syntax.
+However, since `SHOW DATABASES` still need to be run against the system database, all parts of the query must be allowed on the system database.
+This means that clauses like `MATCH` or `SHOW INDEXES` are not allowed, as those are not allowed on the system database, but procedure calls of system-allowed procedures are allowed.
+If the `SHOW DATABASES` is combined with other clauses the automatic re-routing of the command to the system database is disabled and explicit connection or routing is required.
 
 == `SHOW DATABASES` output
 
@@ -147,7 +151,7 @@ Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`.
 | Number of primaries for this database reported as running currently.
 It is the same as the number of rows where `role=primary` and `name=this database`.
 
-Not applicable to composite databasesfootnote:compositeDb[The change for composite databases applies to versions 2025.04 and later and 5.26.5 and later.], virtual sharded databases, and property shards. (the value is `NULL`).
+Not applicable to composite databasesfootnote:compositeDb[The change for composite databases applies to versions 2025.04 and later and 5.26.5 and later.], virtual sharded databases, and property shards (the value is `NULL`).
 | INTEGER
 |
 
@@ -211,7 +215,7 @@ The value is a string formatted as `{storage engine}-{store format}-{major versi
 Only available for `online` or `deallocating` databases.
 For other database states the value will be `NULL`.
 
-Not applicable to composite databasesfootnote:compositeDb[] and virtual sharded databases. (the value is `NULL`).
+Not applicable to composite databasesfootnote:compositeDb[] and virtual sharded databases (the value is `NULL`).
 | STRING
 |
 
@@ -393,6 +397,9 @@ SHOW DATABASE movies YIELD *
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ----
 
+From 2026.XX, if the given database is a parameter that evaluates to null the command will no longer fail on wrong type but instead return nothing.
+This is consistent with how nothing is returned when the given database name doesn't exist.
+
 == Show the number of databases
 
 The number of distinct databases can be seen using `YIELD` and a `count()` function in the `RETURN` clause.
@@ -506,3 +513,21 @@ include::partial$/view-cypher-version.adoc[]
 
 2+d|Rows: 3
 |===
+
+[role=label--new-2026.XX]
+== Show databases with quarantined status and unquarantine them
+
+The `SHOW DATABASES` command can be combined with procedure calls.
+Since it is not the only clause in the query it will not be automatically routed to the system database so we add the `USE` clause to ensure we're executing on there.
+
+.Query
+[source, cypher]
+----
+USE system
+SHOW DATABASES
+YIELD name, serverID, currentStatus
+WHERE currentStatus='quarantined'
+CALL dbms.unquarantineDatabase(serverID, name)
+----
+
+Nothing is returned from the query as it ends with a procedure call of a procedure that doesn't return anything.

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -28,7 +28,7 @@ YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
 
 |===
 
-From 2026.XX, it is possible to combine the `SHOW DATABASES` command with regular Cypher syntax.
+From 2026.05, it is possible to combine the `SHOW DATABASES` command with regular Cypher syntax.
 However, since `SHOW DATABASES` still need to be run against the system database, all parts of the query must be allowed on the system database.
 This means that clauses like `MATCH` or `SHOW INDEXES` are not allowed, as those are not allowed on the system database, but procedure calls of system-allowed procedures are allowed.
 If the `SHOW DATABASES` is combined with other clauses the automatic re-routing of the command to the system database is disabled and explicit connection or routing is required.
@@ -514,7 +514,7 @@ include::partial$/view-cypher-version.adoc[]
 2+d|Rows: 3
 |===
 
-[role=label--new-2026.XX]
+[role=label--new-2026.05]
 == Show databases with quarantined status and unquarantine them
 
 The `SHOW DATABASES` command can be combined with procedure calls.

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -397,7 +397,7 @@ SHOW DATABASE movies YIELD *
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ----
 
-From 2026.XX, if the given database is a parameter that evaluates to null the command will no longer fail on wrong type but instead return nothing.
+From 2026.05, if the given database is a parameter that evaluates to null the command will no longer fail on wrong type but instead return nothing.
 This is consistent with how nothing is returned when the given database name doesn't exist.
 
 == Show the number of databases

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -30,7 +30,7 @@ YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
 
 In Cypher 25 from 2026.05, it is possible to combine the `SHOW DATABASES` command with regular Cypher syntax.
 However, since `SHOW DATABASES` is run against the `system` database, all parts of the query must be allowed on the `system` database.
-For example, clauses like `MATCH` and `SHOW INDEXES` are not allowed on the `system` database, therefore, they cannot be used with `SHOW DATABASES`.
+For example, clauses like `MATCH` and `SHOW INDEXES` are not allowed on the `system` database; therefore, they cannot be used with `SHOW DATABASES`.
 However, procedure calls of system-allowed procedures are allowed.
 If the `SHOW DATABASES` is combined with other clauses, the automatic re-routing of the command to the `system` database is disabled, and explicit connection or routing is required.
 

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -28,10 +28,11 @@ YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
 
 |===
 
-From 2026.05, it is possible to combine the `SHOW DATABASES` command with regular Cypher syntax.
-However, since `SHOW DATABASES` still need to be run against the system database, all parts of the query must be allowed on the system database.
-This means that clauses like `MATCH` or `SHOW INDEXES` are not allowed, as those are not allowed on the system database, but procedure calls of system-allowed procedures are allowed.
-If the `SHOW DATABASES` is combined with other clauses the automatic re-routing of the command to the system database is disabled and explicit connection or routing is required.
+In Cypher 25 from 2026.05, it is possible to combine the `SHOW DATABASES` command with regular Cypher syntax.
+However, since `SHOW DATABASES` is run against the `system` database, all parts of the query must be allowed on the `system` database.
+For example, clauses like `MATCH` and `SHOW INDEXES` are not allowed on the `system` database, therefore, they cannot be used with `SHOW DATABASES`.
+However, procedure calls of system-allowed procedures are allowed.
+If the `SHOW DATABASES` is combined with other clauses, the automatic re-routing of the command to the `system` database is disabled, and explicit connection or routing is required.
 
 == `SHOW DATABASES` output
 
@@ -397,8 +398,8 @@ SHOW DATABASE movies YIELD *
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ----
 
-From 2026.05, if the given database is a parameter that evaluates to null the command will no longer fail on wrong type but instead return nothing.
-This is consistent with how nothing is returned when the given database name doesn't exist.
+In Cypher 25 from 2026.05, if the given database is a parameter that evaluates to null, the command no longer fails on the wrong type but instead returns nothing.
+This behavior aligns with not returning anything when the given database name does not exist.
 
 == Show the number of databases
 
@@ -514,11 +515,12 @@ include::partial$/view-cypher-version.adoc[]
 2+d|Rows: 3
 |===
 
-[role=label--new-2026.05]
+[role=label--cypher-25 label--new-2026.05]
 == Show databases with quarantined status and unquarantine them
 
 The `SHOW DATABASES` command can be combined with procedure calls.
-Since it is not the only clause in the query it will not be automatically routed to the system database so we add the `USE` clause to ensure we're executing on there.
+To ensure the command is run against the `system` database, prepend it with the `USE` clause.
+Combining `SHOW DATABASES` with other Cypher clauses disables the automatic re-routing.
 
 .Query
 [source, cypher]
@@ -530,4 +532,4 @@ WHERE currentStatus='quarantined'
 CALL dbms.unquarantineDatabase(serverID, name)
 ----
 
-Nothing is returned from the query as it ends with a procedure call of a procedure that doesn't return anything.
+Nothing is returned from the query, as it ends with a procedure call of a procedure that does not return anything.

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -527,9 +527,14 @@ Combining `SHOW DATABASES` with other Cypher clauses disables the automatic re-r
 ----
 USE system
 SHOW DATABASES
-YIELD name, serverID, currentStatus
+YIELD name AS database, serverID AS server, currentStatus
 WHERE currentStatus='quarantined'
-CALL dbms.unquarantineDatabase(serverID, name)
+CALL dbms.unquarantineDatabase(server, database)
 ----
 
-Nothing is returned from the query, as it ends with a procedure call of a procedure that does not return anything.
+Nothing is returned from the query, as it ends with a procedure call of a void procedure.
+To return the affected databases, add `RETURN database, server` at the end of the query.
+It is possible to specify the `operation` argument to the `dbms.unquarantineDatabase()` procedure.
+
+For more information on the `dbms.unquarantineDatabase()` procedure, see xref:database-administration/standard-databases/errors.adoc#quarantine[Standard databases -> Error handling].
+For more information on void procedures, see xref:procedures/call-procedures.adoc#void-procedures[Call procedures -> Note on VOID procedures].

--- a/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/listing-databases.adoc
@@ -516,7 +516,7 @@ include::partial$/view-cypher-version.adoc[]
 |===
 
 [role=label--cypher-25 label--new-2026.05]
-== Show databases with quarantined status and unquarantine them
+== Show quarantined databases and lift their quarantine
 
 The `SHOW DATABASES` command can be combined with procedure calls.
 To ensure the command is run against the `system` database, prepend it with the `USE` clause.


### PR DESCRIPTION
Also add a comment about if the input to `SHOW DATABASES $db` is null.

TODO:
- [x] Does it need any markers for being Cypher 25 only?
- [x] Update 2026.XX to relevant version once released
- [x] Do I need to add anything to https://neo4j.com/docs/operations-manual/current/changes-2025-2026/? Or do we still add the administration command updates to the https://neo4j.com/docs/cypher-manual/current/deprecations-additions-removals-compatibility/ page?