### PR TITLE
Remove the broken link and refine wording (#3027)

### DIFF
--- a/modules/ROOT/pages/clustering/setup/routing.adoc
+++ b/modules/ROOT/pages/clustering/setup/routing.adoc
@@ -38,20 +38,23 @@ Additionally, Neo4j automatically transfers database leaderships away from insta
 [[clustering-client-side-routing]]
 == Client-side routing
 
-Client-side routing is when the database client takes control over which cluster member to send specific requests to.
-Typically this would be to make sure that write operations are sent to the server that can write for the target database, and that read operations are sent to other servers.
+Client-side routing means that the application decides which cluster server to send specific requests to.
+Typically, this ensures that write operations are sent to the server currently acting as the `writer` for the target database, while read operations are sent to other servers.
 
-Client-side routing is based on getting a routing table from a cluster member, and then using that information to make the routing decisions.
-A routing table contains information about the writers, readers, and routers for a specific database.
-There is usually one _writer_, though there may be none if the database is read only or unhealthy.
-With the default configuration, all other servers that host the database are considered _readers_, i.e. the writer is not in the list of readers.
+Client-side routing is based on getting a routing table from a cluster server, and then using that information to make the routing decisions.
+Use the xref:procedures.adoc#procedure_dbms_routing_getRoutingTable[`dbms.routing.getRoutingTable()`] procedure to obtain a routing table.
+
+A routing table contains information about the servers and their roles as `writers`, `readers`, and `routers` for a specific database.
+There is usually one `writer`, though there may be none if the database is read-only or unhealthy.
+With the default configuration, all other servers are considered `readers`, i.e. the `writer` is not in the list of `readers`.
 This is to let it focus on the write load and not have to manage two kinds of interactions.
-Typically, all servers that host the database are listed as _routers_, which are servers that can be contacted to get a new routing table for that database.
+Typically, all servers that host the database are listed as `routers`, which are servers that can be contacted to get a new routing table for that database.
 
 link:{neo4j-docs-base-uri}/create-applications/[Neo4j Drivers] retrieve a routing table the first time they attempt to connect to a database, and fetch a fresh one after the configured time-to-live, or if it seems the routing table has got out of date.
-For example, if the routing table lists `server-3` as the writer for the database, but write requests get rejected with a _not able to write_ error, the driver may decide to get a new routing table, because the writer could be a different server.
 
-For lower level details about getting routing tables, see link:https://neo4j.com/docs/bolt/current/driver-api/#client-side-routing[Bolt protocol > Neo4j Driver API > Client-side routing].
+For example, if the routing table lists `server-3` as the `writer` for the database, but write requests are rejected with a _not able to write_ error, the driver may request a new routing table, since the writer role may have moved to a different server.
+
+
 
 [[clustering-client-side-routing-policies]]
 === Routing policies


### PR DESCRIPTION
The link
https://neo4j.com/docs/bolt/current/driver-api/#client-side-routing doesn't work as the target page was removed. That's why the paragraph is updated.