### PR TITLE
Document independent full and differential backup scheduling  (#2998)

### DIFF
--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -39,6 +39,15 @@ On the other hand, differential backup artifacts are produced by the subsequent 
 
 A _backup chain_ consists of a full backup optionally followed by a sequence of n contiguous differential backups.
 
+[NOTE]
+====
+Starting with 2026.02, the first differential backup in a chain may _overlap_ with the previous full backup, meaning its lowest transaction ID may be less than or equal to the full backup's highest transaction ID.
+Subsequent differential backups must still be contiguous with their parent.
+
+This allows full and differential backups to be scheduled on independent cadences.
+See xref:backup-restore/online-backup.adoc#backup-scheduling-rpo-rto[Scheduling for RPO and RTO].
+====
+
 image::backup-chain.png[title="Backup chain",role="middle"]
 
 [[backup-command-usage]]
@@ -417,6 +426,48 @@ Starting from 2025.11, the `--parallel-download` option is available.
 When enabled, the backup process pulls data from multiple servers which have been either defined in the `--from` option or determined from `--remote-address-resolution`.
 
 Note that this will speed up the backup process if sufficient throughput is provisioned for both the backup process and the source servers from which data is being pulled.
+
+[role=label--new-2026.02]
+[[backup-scheduling-rpo-rto]]
+=== Scheduling for RPO and RTO
+
+Starting with 2026.02, the first differential backup in a xref:backup-restore/online-backup.adoc#backup-chain[backup chain] may overlap with its parent full backup.
+This allows you to schedule full and differential backups independently, tuning each cadence to a different recovery objective:
+
+Recovery Point Objective (RPO)::
+The maximum amount of data loss you can tolerate, measured in time.
+Drive RPO with the *differential* backup schedule -- a differential backup every 15 minutes yields an RPO of roughly 15 minutes.
+
+Recovery Time Objective (RTO)::
+The maximum time a restore is allowed to take.
+Drive RTO with the *full* backup schedule -- a more recent full backup shortens a differential chain that must be replayed at restore time, enabling faster recovery.
+
+Before 2026.02, a full backup taken between two scheduled differential backups would break the differential chain, because the next differential backup had to start exactly where the new full backup ended.
+In practice this forced the two schedules to be coupled, and a full backup would interrupt the differential cadence, degrading RPO.
+
+With overlap allowed, two independent processes can run safely:
+
+* A differential schedule set to the desired RPO (for example, every 15 minutes).
+* A full schedule set to the desired RTO (for example, daily or weekly).
+
+The first differential backup after each full backup naturally overlaps with it; the chain remains restorable.
+
+[NOTE]
+====
+A differential backup can only succeed if there is already a xref:backup-restore/online-backup.adoc#backup-chain[backup chain] to build upon -- that is, at least one full backup must be present in the target location.
+
+You have two options when setting up the schedules:
+
+* Seed the target location with an initial full backup (or ensure the full schedule has produced one) before the differential schedule starts running.
+* Run the differential schedule with `--type=AUTO` (the default) instead of `--type=DIFF`.
+With `AUTO`, the backup client falls back to a full backup when no chain is present.
+Therefore, the first run produces a full backup and subsequent runs produce differential backups.
+====
+
+[TIP]
+====
+Consider also running xref:backup-restore/aggregate.adoc[`neo4j-admin backup aggregate`] to collapse a chain into a single recovered full artifact when restore time matters most.
+====
 
 [[online-backup-example]]
 == Examples

--- a/modules/ROOT/pages/backup-restore/planning.adoc
+++ b/modules/ROOT/pages/backup-restore/planning.adoc
@@ -31,6 +31,13 @@ This factor might lead your decision towards performing these operations during 
 * Tolerance for data loss in case of failure.
 * Tolerance for downtime in case of failure.
 If you have zero tolerance for downtime and data loss, you might want to consider performing an online or even a scheduled backup.
++
+[TIP]
+====
+Starting with 2026.02, full and differential backups can be scheduled on independent cadences.
+Use the differential schedule to drive your recovery point objective (RPO), and the full schedule to drive your recovery time objective (RTO).
+See xref:backup-restore/online-backup.adoc#backup-scheduling-rpo-rto[Scheduling for RPO and RTO] for details.
+====
 * Frequency of updates to the database.
 * Type of backup and restore method (online or offline), which may depend on whether you want to:
 ** perform full backups (online or offline).


### PR DESCRIPTION
Document independent full and differential backup scheduling for RPO/RTO tuning

Starting in 2026.02, differential backups can overlap with full backups, enabling independent scheduling to optimize recovery point objective (RPO) via differential cadence and recovery time objective (RTO) via full backup cadence.