### PR TITLE
Fix the Cypher command

### DIFF
--- a/modules/ROOT/pages/clustering/databases.adoc
+++ b/modules/ROOT/pages/clustering/databases.adoc
@@ -350,8 +350,11 @@ See <<create-database, `CREATE DATABASE`>> for more information.
 ----
 CREATE DATABASE foo
 TOPOLOGY [desired number of primaries] PRIMARIES [desired number of secondaries] SECONDARIES
-OPTIONS {existingData: 'use', existingDataSeedServer: '8512c9b9-d9e8-48e6-b037-b15b0004ca18'};
+OPTIONS {existingData: 'use', existingDataSeedInstance: '8512c9b9-d9e8-48e6-b037-b15b0004ca18'};
 ----
++
+In Neo4j 5.25, `existingDataSeedInstance` is deprecated.
+`existingDataSeedServer` is introduced to replace it.
 . Verify that the `foo` database is online on the desired number of servers, in the desired roles.
 If the `foo` database is of considerable size, the execution of the command can take some time.
 +


### PR DESCRIPTION
Updated documentation to reflect the deprecation of existingDataSeedInstance and the introduction of existingDataSeedServer in Neo4j 5.25.