### PR TITLE
CCDR: Note remote address resolution is possible

### DIFF
--- a/modules/ROOT/pages/clustering/replicating-databases-across-clusters.adoc
+++ b/modules/ROOT/pages/clustering/replicating-databases-across-clusters.adoc
@@ -86,7 +86,7 @@ Use the following procedure to create a replica database.
 | `numPrimaries` | `INTEGER` | The number of replica primaries. These primaries will align with the mode constraints set on the server, but will not be writable because they are still replicas.
 | `numSecondaries` | `INTEGER` | The number of replica secondaries.
 | `upstreamDatabaseName` | `STRING` | The name of the upstream database in the remote cluster.
-| `remoteAddresses` | `LIST<STRING>` | A list of the link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_dbms.cluster.endpoints[cluster endpoints] of the servers in the remote cluster.
+| `remoteAddresses` | `LIST<STRING>` | A list of the link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_dbms.cluster.endpoints[cluster endpoints] of the servers in the remote cluster. There is no requirement that every remote server hosts the upstream database.
 | *Mode* 3+| WRITE
 |===
 


### PR DESCRIPTION
Document that cross-cluster database replication is possible even with disjoint allocation, where not every upstream server hosts the upstream database. 

We consider this to be the expected default behaviour from customers, so don't want to have too much detail on how or why there is no restriction about upstream allocations, so as not to expose implementation details.

For some more context: we've just implemented remote-address-resolution for replica databases, which (similarly to backups) lets the replica select which upstream servers to pull from. Previously, the replica would fail to create/fail to pull if some upstream server didn't host the upstream database.


Part of [CLUSTER-1367](https://linear.app/neo4j/issue/CLUSTER-1367/remote-address-resolution-for-replicas)