### PR TITLE
Clarify import memory controls (#2980)

### DIFF
--- a/modules/ROOT/pages/backup-restore/consistency-checker.adoc
+++ b/modules/ROOT/pages/backup-restore/consistency-checker.adoc
@@ -98,8 +98,7 @@ The `neo4j-admin database check` command has the following options:
 | .
 
 |--max-off-heap-memory=<size>
-| Maximum memory that the command can use for page cache and various caching data structures to improve performance.
-Value can be plain numbers, such as 10000000 or, for example, 20G for 20 gigabytes, or 70%, which will amount to 70% of currently free memory on the machine.
+| Maximum off-heap memory that the command can use for page cache and various caching data structures to improve performance. Use this option to tune the command memory usage; the command does not use the server.memory.pagecache.size configuration setting for this purpose. Values can be plain numbers, such as 10000000, or, for example, 20G for 20 gigabytes, or 70%, which will amount to 70% of currently free memory on the machine.
 |90%
 
 |--threads=<number of threads>

--- a/modules/ROOT/pages/backup-restore/copy-database.adoc
+++ b/modules/ROOT/pages/backup-restore/copy-database.adoc
@@ -133,8 +133,7 @@ The indexes will be built the first time the database is started.
 |
 
 |--from-pagecache, --max-off-heap-memory=<size>
-|label:new[Introduced in 2025.01] Maximum memory that the command can use for page cache and various caching data structures to improve performance.
-Values can be plain numbers, such as 10000000, or, for example, 20G for 20 gigabytes, or 70%, which will amount to 70% of currently free memory on the machine.
+|label:new[Introduced in 2025.01] Maximum off-heap memory that the command can use for page cache and various caching data structures to improve performance. Use this option to tune the command memory usage; the command does not use the server.memory.pagecache.size configuration setting for this purpose. Values can be plain numbers, such as 10000000, or, for example, 20G for 20 gigabytes, or 70%, which will amount to 70% of currently free memory on the machine.
 |90%
 
 |--from-path-data=<path>

--- a/modules/ROOT/pages/database-administration/standard-databases/migrate-database.adoc
+++ b/modules/ROOT/pages/database-administration/standard-databases/migrate-database.adoc
@@ -97,8 +97,7 @@ This option is only relevant when migrating from Neo4j 4.4.
 |
 
 |--max-off-heap-memory=<size> label:new[Introduced in Neo4j 2025.04]
-|Maximum memory that the command can use for page cache and various caching data structures to improve performance.
-Values can be plain numbers, such as 10000000, or, for example, 20G for 20 gigabytes, or 70%, which will amount to 70% of currently free memory on the machine.
+|Maximum off-heap memory that the command can use for page cache and various caching data structures to improve performance. Use this option to tune the command memory usage; the command does not use the server.memory.pagecache.size configuration setting for this purpose. Values can be plain numbers, such as 10000000, or, for example, 20G for 20 gigabytes, or 70%, which will amount to 70% of currently free memory on the machine.
 |90%
 
 |--pagecache=<size> label:deprecated[Deprecated in Neo4j 2025.04]

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -61,6 +61,21 @@ For information on `LOAD CSV`, see the link:{neo4j-docs-base-uri}/cypher-manual/
 For in-depth examples of using the command `neo4j-admin database import`, refer to the xref:tutorial/neo4j-admin-import.adoc[Tutorials -> Importing data].
 ====
 
+[[import-memory-controls]]
+=== Import memory controls
+
+`neo4j-admin database import` uses two main memory controls:
+
+* JVM heap, configured for the admin process through the usual configuration sources described in xref:neo4j-admin-neo4j-cli.adoc#_configuration[Neo4j Admin and Neo4j CLI -> Configuration].
+* Off-heap working memory, controlled by `--max-off-heap-memory`.
+If this option is not provided, the importer derives a budget from the available system resources.
+
+The importer does not use the `server.memory.pagecache.size` configuration setting to size import memory.
+The off-heap budget is shared across page cache and other off-heap data structures used during import.
+In dry-run and verbose output, `Configured max memory` shows the effective off-heap memory budget available to the import command.
+
+[[import-file-considerations]]
+=== Input file considerations
 These are some things you need to keep in mind when creating your input files:
 
 * Fields are comma-separated by default but a different delimiter can be specified.
@@ -303,8 +318,7 @@ Possible values are:
 | {check-mark}
 
 |--max-off-heap-memory=<size>
-|Maximum memory that the command can use for page cache and various caching data structures to improve performance.
-Values can be plain numbers, such as 10000000, or, for example, 20G for 20 gigabytes, or 70%, which will amount to 70% of currently free memory on the machine.
+|Maximum off-heap memory that the command can use for page cache and various caching data structures to improve performance. Use this option to tune the command memory usage; the command does not use the server.memory.pagecache.size configuration setting for this purpose. Values can be plain numbers, such as 10000000, or, for example, 20G for 20 gigabytes, or 70%, which will amount to 70% of currently free memory on the machine.
 |90%
 | {check-mark}
 | {check-mark}
@@ -1001,8 +1015,7 @@ Possible values are:
 | {check-mark}
 
 |--max-off-heap-memory=<size>
-|Maximum memory that the command can use for page cache and various caching data structures to improve performance.
-Values can be plain numbers, such as 10000000, or, for example, 20G for 20 gigabytes, or 70%, which will amount to 70% of currently free memory on the machine.
+|Maximum off-heap memory that the command can use for page cache and various caching data structures to improve performance. Use this option to tune the command memory usage; the command does not use the server.memory.pagecache.size configuration setting for this purpose. Values can be plain numbers, such as 10000000, or, for example, 20G for 20 gigabytes, or 70%, which will amount to 70% of currently free memory on the machine.
 |90%
 | {check-mark}
 | {check-mark}

--- a/modules/ROOT/pages/neo4j-admin-neo4j-cli.adoc
+++ b/modules/ROOT/pages/neo4j-admin-neo4j-cli.adoc
@@ -273,6 +273,9 @@ Administration operations use the configuration specified in the _neo4j.conf_ fi
 Sharing configuration between the DBMS and its administration tasks makes sense as most settings are the same.
 In some cases, however, it is better to override some settings specified in _neo4j.conf_ by configuring the tasks (instead of updating the config settings in the _neo4j.conf_ file) because administration tasks generally use fewer resources than the DBMS.
 For instance, if the page cache of your DBMS is configured to a very high value in _neo4j.conf_, and you want to override this because the admin tasks like backup do not need so much memory, you provide configuration for the admin tasks instead of updating the page cache setting in the _neo4j.conf_ file.
+`neo4j-admin database import` does not use `server.memory.pagecache.size` for import memory sizing.
+Instead, use `--max-off-heap-memory` to tune the command's off-heap working memory.
+See xref:import.adoc#import-memory-controls[Import -> Import memory controls] for details.
 
 There are several options for overriding settings specified in the _neo4j.conf_ file using administration tasks:
 


### PR DESCRIPTION
## Summary
- clarify on the generic admin configuration page that `neo4j-admin database import` uses `--max-off-heap-memory` rather than `server.memory.pagecache.size` for import memory sizing
- add an `Import memory controls` subsection to the import page
- explain that `Configured max memory` in import output is the effective off-heap memory budget
- update the full and incremental option tables to make `--max-off-heap-memory` the explicit tuning knob for import memory

## Validation
- `git diff --check`
- `npm run build:preview`

---------