### PR TITLE
Update GitHub link for Neo4j CloudFormation template

### DIFF
--- a/modules/ROOT/pages/cloud-deployments/neo4j-aws.adoc
+++ b/modules/ROOT/pages/cloud-deployments/neo4j-aws.adoc
@@ -24,7 +24,7 @@ The  CloudFormation template always installs the latest available version.
 
 AWS CloudFormation is a declarative Infrastructure as Code (IaC) language that is based on YAML and instructs AWS to deploy a set of cloud resources.
 
-The Neo4j CloudFormation template's code is available on link:https://github.com/neo4j-partners/amazon-cloud-formation-neo4j/blob/main/neo4j-ee/neo4j.template.yaml[GitHub].
+The Neo4j CloudFormation template's code is available on link:https://github.com/neo4j-partners/neo4j-aws-cloudformation[GitHub].
 It takes several parameters as inputs, deploys a set of cloud resources, and provides outputs that can be used to connect to a Neo4j DBMS.
 
 === Important considerations


### PR DESCRIPTION
I'm suggesting to update the link this way because they change the repo structure every other month