### PR TITLE
removed deprecated docker image bases from documentation (#3115)

### DIFF
--- a/modules/ROOT/pages/deprecations.adoc
+++ b/modules/ROOT/pages/deprecations.adoc
@@ -76,6 +76,13 @@ See xref:clustering/multi-region-deployment/multi-data-center-routing.adoc#mdc-l
 |===
 ====
 
+== Docker base images
+
+Neo4j 2026.05::
+
+The following base images are not supported: `debian:bullseye-slim`, `redhat/ubi9-minimal:latest`.
+For details, see xref:docker/introduction.adoc[].
+
 == HTTP API
 
 Neo4j 5.26::

--- a/modules/ROOT/pages/docker/introduction.adoc
+++ b/modules/ROOT/pages/docker/introduction.adoc
@@ -33,7 +33,10 @@ ____
 
 === Base operating system
 
-The Neo4j image is available with either `debian:trixie-slim`, `debian:bullseye-slim`, `redhat/ubi10-minimal:latest`, or `redhat/ubi9-minimal:latest` as the base image.
+The Neo4j image is available with either `debian:trixie-slim` or `redhat/ubi10-minimal:latest` as the base image.
+
+`debian:bullseye-slim` and `redhat/ubi9-minimal:latest` are not supported starting with Neo4j 2026.05.
+
 Starting with 2026.01, the default is `debian:trixie-slim` (updated from `debian:bullseye-slim`).
 
 [TIP]
@@ -42,15 +45,13 @@ If you are unsure which base image to use or have no preference, just use the de
 ====
 
 
-To specify which base image to use, the image tags optionally have a `-trixie` `-bullseye`, `-ubi10`, or `-ubi9` suffix.
+To specify which base image to use, the image tags optionally have a `-trixie` or `-ubi10` suffix.
 
 For example:
 
 [source, subs="attributes"]
 ----
 neo4j:{neo4j-version-exact}-trixie              # debian 13 community
-neo4j:{neo4j-version-exact}-enterprise-bullseye # debian 11 enterprise
-neo4j:{neo4j-version-exact}-ubi9               # redhat UBI9 community
 neo4j:{neo4j-version-exact}-enterprise-ubi10   # redhat UBI10 enterprise
 neo4j:{neo4j-version-exact}                    # debian 13 community
 neo4j:{neo4j-version-exact}-enterprise         # debian 13 enterprise
@@ -66,14 +67,8 @@ neo4j:{neo4j-version-exact}-enterprise         # debian 13 enterprise
 | `-trixie`
 | `debian:trixie-slim`
 
-| `-bullseye`
-| `debian:bullseye-slim`
-
 | `-ubi10`
 | `redhat/ubi10-minimal:latest`
-
-| `-ubi9`
-| `redhat/ubi9-minimal:latest`
 
 | _unspecified_
 | `debian:trixie-slim`
@@ -82,10 +77,8 @@ neo4j:{neo4j-version-exact}-enterprise         # debian 13 enterprise
 
 [NOTE]
 ====
-The Red Hat UBI9 variant images are only available from 5.17.0 and onwards.
 The Red Hat UBI10 variant images are only available from 2026.01.0 and onwards.
 The Debian 13 variant images are only available from 2026.01.0 and onwards.
-For earlier Neo4j versions, do not specify a base image.
 ====
 
 [[docker-image]]


### PR DESCRIPTION
Debian bullseye and Redhat ubi9 images are deprecated now, so this PR removes them from the documentation.