### PR TITLE
fix tutorial composite using deprecated or invalid syntax (#3125)

### DIFF
--- a/modules/ROOT/pages/tutorial/tutorial-composite-database.adoc
+++ b/modules/ROOT/pages/tutorial/tutorial-composite-database.adoc
@@ -594,7 +594,7 @@ Or, using a more common Composite database idiom:
 [source, cypher, role=noplay]
 ----
 UNWIND ['compositenw.customerAME', 'compositenw.customerEU'] AS g
-CALL {
+CALL(g) {
   USE graph.byName(g)
   MATCH (c:Customer)
   WHERE c.customerID STARTS WITH 'A'
@@ -630,7 +630,7 @@ Here is a more complex query that uses all 3 databases to find all customers who
 
 [source, cypher, role=noplay]
 ----
-CALL {
+CALL() {
   USE compositenw.product
   MATCH (p:Product)-[:PART_OF]->(c:Category)
   WHERE p.discontinued = true
@@ -639,9 +639,8 @@ CALL {
 }
 WITH *
 UNWIND [g IN graph.names() WHERE g STARTS WITH 'compositenw.customer'] AS g
-CALL {
+CALL(g, pids) {
   USE graph.byName(g)
-  WITH pids
   UNWIND pids as pid
   MATCH (p:Product{productID:pid})<-[:ORDERS]-(:Order)<-[:PURCHASED]-(c:Customer)
   RETURN DISTINCT c.customerID AS customer, c.country AS country


### PR DESCRIPTION
On the following page
https://neo4j.com/docs/operations-manual/2026.05/tutorial/tutorial-composite-database/ , some cypher queries use deprecated syntax or invalid syntax.

<img width="1591" height="579" alt="Screenshot 2026-06-10 at 21 32 05" src="https://github.com/user-attachments/assets/cc3176ca-d7cf-4a24-bfda-1c4b2bfe983e" />
<img width="2141" height="580" alt="Screenshot 2026-06-10 at 21 32 24" src="https://github.com/user-attachments/assets/17983956-9eea-4f43-bacc-608a3ccd008b" />

This PR fixes them.