### PR TITLE
Mention vector and array handling for parquet files

### DIFF
--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -914,6 +914,7 @@ If the database into which you import does not exist prior to importing, you mus
 |--array-delimiter=<char>
 |Delimiter character between array elements within a value in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 For CSV data, this value must be different from the one specified in the `--delimiter` option.
+For Parquet data, this is only needed if the array is encoded as a string.
 
 ====
 * ASCII character -- e.g. `--array-delimiter=";"`.

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -519,6 +519,7 @@ performance, this value should not be greater than the number of available proce
 |--vector-delimiter=<char>
 |label:new[Introduced in 2025.10] Delimiter character between vector coordinates within a value in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 For CSV data, this value must be different from the one specified in the `--delimiter` option.
+For Parquet data, this is only needed if the vector is encoded as a string.
 |;
 | {check-mark}
 | {check-mark}
@@ -1599,7 +1600,7 @@ Arrays are not affected by the `--normalize-types` flag.
 For example, if you want a byte array to be stored as a Cypher long array, you must explicitly declare the property as `long[]`.
 
 Array values can also be sourced directly from a `LIST` typed column with Parquet files, in which case the `--array-delimiter` option is not needed.
-Furthermore, values read from `LIST` typed columns are mapped to their corresponding Cypher types, e.g. `LIST<INT>` is mapped to `int[]`, `LIST<STRING>` is mapped to `string[]`, and so on and there is no need to specify the type in the header.
+Furthermore, values read from `LIST` typed columns are mapped to their corresponding Cypher types, e.g., `LIST<INT>` is mapped to `int[]`, `LIST<STRING>` is mapped to `string[]`, and so on, and there is no need to specify the type in the header.
 
 [NOTE]
 ====
@@ -1731,7 +1732,7 @@ Note that quotation marks are necessary, since the `,` inside the map would othe
 With CSV files and Parquet files where vector values are encoded as strings, by default, vector values are separated by `;`.
 A different delimiter can be specified with `--vector-delimiter`.
 
-Since 2026.06, vector values can also be sourced from a `LIST` typed column with Parquet files, in which case the `--vector-delimiter` option is not needed.
+Starting with Neo4j 2026.06, vector values can also be sourced from a `LIST` typed column with Parquet files, in which case the `--vector-delimiter` option is not needed.
 --
 
 [[import-tool-id-spaces]]

--- a/modules/ROOT/pages/import.adoc
+++ b/modules/ROOT/pages/import.adoc
@@ -191,6 +191,7 @@ The xref:import.adoc#import-tool-examples[examples] for CSV can also be used wit
 |--array-delimiter=<char>
 |Delimiter character between array elements within a value in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 For CSV data, this value must be different from the one specified in the `--delimiter` option.
+For Parquet data, this is only needed if the array is encoded as a string.
 
 ====
 * ASCII character -- e.g. `--array-delimiter=";"`.
@@ -1240,6 +1241,7 @@ If not specifically provided, the default temp path will be created inside the d
 |--vector-delimiter=<char>
 |label:new[Introduced in 2025.10] Delimiter character between vector coordinates within a value in CSV data. Also accepts `TAB` and e.g. `U+20AC` for specifying a character using Unicode.
 For CSV data, this value must be different from the one specified in the `--delimiter` option.
+For Parquet data, this is only needed if the vector is encoded as a string.
 |;
 | {check-mark}
 | {check-mark}
@@ -1596,6 +1598,9 @@ A different delimiter can be specified with `--array-delimiter`.
 Arrays are not affected by the `--normalize-types` flag.
 For example, if you want a byte array to be stored as a Cypher long array, you must explicitly declare the property as `long[]`.
 
+Array values can also be sourced directly from a `LIST` typed column with Parquet files, in which case the `--array-delimiter` option is not needed.
+Furthermore, values read from `LIST` typed columns are mapped to their corresponding Cypher types, e.g. `LIST<INT>` is mapped to `int[]`, `LIST<STRING>` is mapped to `string[]`, and so on and there is no need to specify the type in the header.
+
 [NOTE]
 ====
 CSV-based import does not import empty arrays, because they cannot be distinguished from arrays that are set to `null`.
@@ -1713,9 +1718,6 @@ The map must specify both the `coordinateType` and the `dimensions` of the vecto
 The `coordinateType` can be one of `byte`, `short`, `int`, `long`, `float`, or `double`.
 The `dimensions` must be between 1 and 4096, inclusive.
 
-By default, vector values are separated by `;`.
-A different delimiter can be specified with `--vector-delimiter`.
-
 The dimensions of each vector in the data must match what is specified in the header.
 
 A vector in a header could for example look like this:
@@ -1725,6 +1727,11 @@ A vector in a header could for example look like this:
 ----
 
 Note that quotation marks are necessary, since the `,` inside the map would otherwise be interpreted as a column delimiter.
+
+With CSV files and Parquet files where vector values are encoded as strings, by default, vector values are separated by `;`.
+A different delimiter can be specified with `--vector-delimiter`.
+
+Since 2026.06, vector values can also be sourced from a `LIST` typed column with Parquet files, in which case the `--vector-delimiter` option is not needed.
 --
 
 [[import-tool-id-spaces]]


### PR DESCRIPTION
This pull request updates the import documentation to clarify the handling of array and vector data when importing from CSV and Parquet files. The changes explain when delimiter options are needed, and how Parquet `LIST` typed columns are mapped to Cypher types, reducing the need for explicit configuration in many cases.