### PR TITLE
Backport extended header support for Parquet docs

### DIFF
--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -1202,9 +1202,9 @@ For example, you can use `uuid:ID(Person){label:Person}`, where the relationship
 * For examples of creating property uniqueness constraints, see link:{neo4j-docs-base-uri}/cypher-manual/5/constraints/managing-constraints/#create-property-uniqueness-constraints[Cypher Manual -> Create property uniqueness constraints].
 ====
 
+[role=label--new-5.26]
 === Extended header support for Parquet
 
-label:new[Introduced in 5.26]
 In addition to the header format supported by the CSV import, the Parquet import supports name-mapping header files.
 Those files contain two rows of entries, where the first row represents the name (incl. optional type, id group, etc.), and the second row references the name of the original columns in the data files.
 

--- a/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
+++ b/modules/ROOT/pages/tools/neo4j-admin/neo4j-admin-import.adoc
@@ -1202,6 +1202,21 @@ For example, you can use `uuid:ID(Person){label:Person}`, where the relationship
 * For examples of creating property uniqueness constraints, see link:{neo4j-docs-base-uri}/cypher-manual/5/constraints/managing-constraints/#create-property-uniqueness-constraints[Cypher Manual -> Create property uniqueness constraints].
 ====
 
+=== Extended header support for Parquet
+
+label:new[Introduced in 5.26]
+In addition to the header format supported by the CSV import, the Parquet import supports name-mapping header files.
+Those files contain two rows of entries, where the first row represents the name (incl. optional type, id group, etc.), and the second row references the name of the original columns in the data files.
+
+.movie_header.csv
+[source, csv]
+----
+movieId:ID,title,year:int,:LABEL
+id,movie_title,year,label
+----
+
+If a header file is provided for a set of labels or a relationship type, the importer will ignore columns not mentioned in the headers.
+
 [[import-tool-header-format-nodes]]
 == Node files
 


### PR DESCRIPTION
## Feature

Extended header support for Parquet was backported to the 5.26.x branch. Copied over the extended header support section from the dev branch since it's now relevant.