### PR TITLE
Add backup option `--skip-producing-empty-diff`

### DIFF
--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -78,8 +78,8 @@ neo4j-admin database backup [-h] [--expand-commands] [--prefer-diff-as-parent] [
                             [--parallel-download[=true|false]] [--parallel-recovery[=true|false]]
                             [--remote-address-resolution[=true|false]] [--skip-producing-empty-diff
                             [=true|false]] [--skip-recovery[=true|false]]
-                            [--additional-config=<file>] [--include-metadata=none|all|users[=user1,
-                            user2]|roles] [--inspect-path=<path>] [--pagecache=<size>]
+                            [--additional-config=<file>] [--include-metadata=none|all|users
+                            [=user1,user2]|roles] [--inspect-path=<path>] [--pagecache=<size>]
                             [--temp-path=<path>] [--to-path=<path>] [--type=<type>] [--from=<host:
                             port>[,<host:port>...]]... [<database>...]
 ----

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -76,11 +76,12 @@ For more information, see xref:backup-restore/online-backup.adoc#online-backup-c
 neo4j-admin database backup [-h] [--expand-commands] [--prefer-diff-as-parent] [--verbose]
                             [--compress[=true|false]] [--keep-failed[=true|false]]
                             [--parallel-download[=true|false]] [--parallel-recovery[=true|false]]
-                            [--remote-address-resolution[=true|false]] [--skip-producing-empty-diff[=true|false]]
-                            [--skip-recovery[=true|false]] [--additional-config=<file>]
-                            [--include-metadata=none|all|users[=user1,user2]|roles]
-                            [--inspect-path=<path>] [--pagecache=<size>] [--temp-path=<path>]
-                            [--to-path=<path>] [--type=<type>] [--from=<host:port>[,<host:port>...]]... [<database>...]
+                            [--remote-address-resolution[=true|false]] [--skip-producing-empty-diff
+                            [=true|false]] [--skip-recovery[=true|false]]
+                            [--additional-config=<file>] [--include-metadata=none|all|users[=user1,
+                            user2]|roles] [--inspect-path=<path>] [--pagecache=<size>]
+                            [--temp-path=<path>] [--to-path=<path>] [--type=<type>] [--from=<host:
+                            port>[,<host:port>...]]... [<database>...]
 ----
 
 === Description

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -76,8 +76,8 @@ For more information, see xref:backup-restore/online-backup.adoc#online-backup-c
 neo4j-admin database backup [-h] [--expand-commands] [--prefer-diff-as-parent] [--verbose]
                             [--compress[=true|false]] [--keep-failed[=true|false]]
                             [--parallel-download[=true|false]] [--parallel-recovery[=true|false]]
-                            [--remote-address-resolution[=true|false]] [--skip-recovery
-                            [=true|false]] [--skip-producing-empty-diff[=true|false]] [--additional-config=<file>]
+                            [--remote-address-resolution[=true|false]] [--skip-producing-empty-diff[=true|false]]
+                            [--skip-recovery[=true|false]] [--additional-config=<file>]
                             [--include-metadata=none|all|users[=user1,user2]|roles]
                             [--inspect-path=<path>] [--pagecache=<size>] [--temp-path=<path>]
                             [--to-path=<path>] [--type=<type>] [--from=<host:port>[,<host:port>...]]... [<database>...]

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -185,7 +185,7 @@ Note: this is an EXPERIMENTAL option. Consult Neo4j support before use.
 
 |--skip-producing-empty-diff[=true\|false]
 |label:new[Introduced in 2026.07] When performing a differential backup and there are no new transactions to back-up, do not produce any backup file.
-This option can only be used if metadata is explicitly omitted (--include-metadata=none).
+This option can only be used if metadata is explicitly omitted (`--include-metadata=none`).
 |false
 
 |--skip-recovery[=true\|false]

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -77,7 +77,7 @@ neo4j-admin database backup [-h] [--expand-commands] [--prefer-diff-as-parent] [
                             [--compress[=true|false]] [--keep-failed[=true|false]]
                             [--parallel-download[=true|false]] [--parallel-recovery[=true|false]]
                             [--remote-address-resolution[=true|false]] [--skip-recovery
-                            [=true|false]] [--additional-config=<file>]
+                            [=true|false]] [--skip-producing-empty-diff[=true|false]] [--additional-config=<file>]
                             [--include-metadata=none|all|users[=user1,user2]|roles]
                             [--inspect-path=<path>] [--pagecache=<size>] [--temp-path=<path>]
                             [--to-path=<path>] [--type=<type>] [--from=<host:port>[,<host:port>...]]... [<database>...]
@@ -181,6 +181,11 @@ Note: this is an EXPERIMENTAL option. Consult Neo4j support before use.
 
 |--remote-address-resolution[=true\|false]
 |label:new[Introduced in 2025.09] Allow the DBMS to automatically determine which servers are eligible to serve as backup sources, instead of requiring manual selection.
+|false
+
+|--skip-producing-empty-diff[=true\|false]
+|label:new[Introduced in 2026.07] When performing a differential backup and there are no new transactions to back-up, do not produce any backup file.
+This option can only be used if metadata is explicitly omitted (--include-metadata=none).
 |false
 
 |--skip-recovery[=true\|false]


### PR DESCRIPTION
Document a new public option for `backup` that disables the creation of empty diff backups (containing zero transactions).

This option is incompatible with `--include-metadata` so we require `--include-metadata=none when it is specified.

The option is added in
- https://github.com/neo-technology/neo4j/pull/38434

CLUSTER-1675