### PR TITLE
Update deprecations for Neo4j 2026.07

### DIFF
--- a/modules/ROOT/pages/deprecations.adoc
+++ b/modules/ROOT/pages/deprecations.adoc
@@ -137,10 +137,10 @@ For details, refer to xref:monitoring/logging.adoc#_json_format_log_entries[Logg
 | Comment
 
 |`<prefix>.cluster.raft.in_flight_cache.max_bytes` label:deprecated[Deprecated in 2026.07]
-|
+|The metric will be removed after the next LTS.
 
 |`<prefix>.cluster.raft.in_flight_cache.max_elements` label:deprecated[Deprecated in 2026.07]
-|
+|The metric will be removed after the next LTS.
 
 |xref:monitoring/metrics/reference.adoc#raft-metrics[`<prefix>.cluster.raft.tx_retries`] label:deprecated[Deprecated in 2025.02]
 |The metric will be removed in a future release.

--- a/modules/ROOT/pages/deprecations.adoc
+++ b/modules/ROOT/pages/deprecations.adoc
@@ -102,6 +102,7 @@ Neo4j 5.26::
 
 The server-side Notification API and the `getNotifications()` method of the Result Core API are deprecated.
 
+
 == Neo4j Helm charts
 
 Neo4j 5.26::
@@ -134,6 +135,12 @@ For details, refer to xref:monitoring/logging.adoc#_json_format_log_entries[Logg
 |===
 | Name
 | Comment
+
+|`<prefix>.cluster.raft.in_flight_cache.max_bytes` label:deprecated[Deprecated in 2026.07]
+|
+
+|`<prefix>.cluster.raft.in_flight_cache.max_elements` label:deprecated[Deprecated in 2026.07]
+|
 
 |xref:monitoring/metrics/reference.adoc#raft-metrics[`<prefix>.cluster.raft.tx_retries`] label:deprecated[Deprecated in 2025.02]
 |The metric will be removed in a future release.


### PR DESCRIPTION
Following the PR #3135 