### PR TITLE
Async raft sender - document in 5.26

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -150,6 +150,7 @@
 ** xref:clustering/servers.adoc[]
 ** xref:clustering/databases.adoc[]
 ** xref:clustering/unbind-system-database.adoc[]
+** xref:clustering/troubleshooting.adoc[]
 ** Monitoring
 *** xref:clustering/monitoring/show-servers-monitoring.adoc[]
 *** xref:clustering/monitoring/show-databases-monitoring.adoc[]

--- a/modules/ROOT/pages/clustering/index.adoc
+++ b/modules/ROOT/pages/clustering/index.adoc
@@ -19,6 +19,7 @@ This chapter describes the following:
 * xref:clustering/servers.adoc[Managing servers in a cluster] -- How to manage the servers in a cluster.
 * xref:clustering/databases.adoc[Managing databases in a cluster] -- How to manage the databases in a cluster.
 * xref:clustering/unbind-system-database.adoc[Unbind the `system` database] label:new[Introduced in 5.0] -- How to use the `neo4j-admin dbms unbind-system-db` command.
+* xref:clustering/troubleshooting.adoc[Troubleshooting] -- Diagnose and mitigate common cluster issues.
 
 * **Monitoring** -- Monitoring of a cluster.
 ** xref:clustering/monitoring/show-servers-monitoring.adoc[Monitor servers] -- The tools available for monitoring the servers in a cluster.

--- a/modules/ROOT/pages/clustering/index.adoc
+++ b/modules/ROOT/pages/clustering/index.adoc
@@ -19,7 +19,7 @@ This chapter describes the following:
 * xref:clustering/servers.adoc[Managing servers in a cluster] -- How to manage the servers in a cluster.
 * xref:clustering/databases.adoc[Managing databases in a cluster] -- How to manage the databases in a cluster.
 * xref:clustering/unbind-system-database.adoc[Unbind the `system` database] label:new[Introduced in 5.0] -- How to use the `neo4j-admin dbms unbind-system-db` command.
-* xref:clustering/troubleshooting.adoc[Troubleshooting] -- Diagnose and mitigate common cluster issues.
+* xref:clustering/troubleshooting.adoc[Troubleshooting write delays when one cluster member is unavailable] -- Diagnose and mitigate delayed or unavailable writes when one cluster member is unavailable.
 
 * **Monitoring** -- Monitoring of a cluster.
 ** xref:clustering/monitoring/show-servers-monitoring.adoc[Monitor servers] -- The tools available for monitoring the servers in a cluster.

--- a/modules/ROOT/pages/clustering/troubleshooting.adoc
+++ b/modules/ROOT/pages/clustering/troubleshooting.adoc
@@ -1,25 +1,25 @@
 :description: Troubleshooting information for common Neo4j cluster availability and replication issues.
-[role=enterprise-edition]
+:page-role: enterprise-edition
 [[clustering-troubleshooting]]
 = Troubleshooting
 
-This page describes known cluster issues and mitigations.
+This page describes known cluster issues and their mitigations.
 
 [[clustering-troubleshooting-raft-sender-channel-acquisition]]
 == Slow or unavailable writes when a cluster member is shut down
 
 In Neo4j 5.26 LTS, a cluster can experience delayed or unavailable writes if the leader waits for a Raft sender connection to a cluster member that has stopped but whose network endpoint still accepts connection attempts.
-This can happen when a server, virtual machine, or container is killed or shut down, but the network layer does not immediately refuse connections to that member.
+This can happen when a server, virtual machine, or container is stopped or shut down, but the network layer does not immediately refuse connections to that member.
 
-When this happens, the leader may wait until `dbms.cluster.network.connect_timeout` elapses before it attempts to replicate to another member.
-In a three-member cluster, this can delay writes because Raft requires a quorum to receive the replication message.
+When this happens, the leader may wait until xref:configuration/configuration-settings.adoc#config_dbms.cluster.network.connect_timeout[`dbms.cluster.network.connect_timeout`] elapses before attempting to replicate data to another cluster member.
+In a three-member cluster, this can delay writes because the Raft protocol requires a quorum (two of the three members) to replicate the transaction before it can be committed.
 
 [[clustering-troubleshooting-raft-sender-channel-acquisition-symptoms]]
 === Symptoms
 
 Common symptoms include:
 
-* Writes become slow, time out, or appear unavailable after one cluster member is stopped, killed, or restarted.
+* Writes become slow, time out, or appear unavailable after one cluster member is stopped, shut down, or restarted.
 * The problem lasts for approximately the configured `dbms.cluster.network.connect_timeout`, which is `30s` by default.
 * The problem is more likely in environments where a stopped member's network endpoint continues to accept connection attempts instead of refusing them immediately.
 This has been observed in Kubernetes environments, but it is not limited to Kubernetes.
@@ -51,6 +51,6 @@ This allows the leader to continue replicating to other members without blocking
 [NOTE]
 ====
 *Behavior from Neo4j 2025.02* +
-Starting in Neo4j 2025.02, the setting is available as link:https://neo4j-docs-operations-3174.surge.sh/operations-manual/2026.07/configuration/configuration-settings/#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] and defaults to `true`.
+Starting with Neo4j 2025.02, the setting is available as xref:configuration/configuration-settings.adoc#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] and defaults to `true`.
 No mitigation is required for this issue in Neo4j 2025.02 or later unless this setting has been explicitly changed to `false`.
 ====

--- a/modules/ROOT/pages/clustering/troubleshooting.adoc
+++ b/modules/ROOT/pages/clustering/troubleshooting.adoc
@@ -51,6 +51,6 @@ This allows the leader to continue replicating to other members without blocking
 [NOTE]
 ====
 *Behavior from Neo4j 2025.02* +
-Starting with Neo4j 2025.02, the setting is available as xref:configuration/configuration-settings.adoc#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] and defaults to `true`.
+Starting with Neo4j 2025.02, the setting is available as link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] and defaults to `true`.
 No mitigation is required for this issue in Neo4j 2025.02 or later unless this setting has been explicitly changed to `false`.
 ====

--- a/modules/ROOT/pages/clustering/troubleshooting.adoc
+++ b/modules/ROOT/pages/clustering/troubleshooting.adoc
@@ -34,7 +34,7 @@ That case is less likely to cause the write latency described here because the l
 [[clustering-troubleshooting-raft-sender-channel-acquisition-mitigation]]
 == Mitigation
 
-In Neo4j 5.26.29 and later, enable asynchronous acquisition of Raft sender channels by setting xref:configuration/configuration-settings.adoc#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] to `true` in _neo4j.conf_ on all cluster members:
+Starting with Neo4j 5.26.29, you can enable asynchronous acquisition of Raft sender channels by setting xref:configuration/configuration-settings.adoc#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] to `true` in _neo4j.conf_ on each cluster members:
 
 [source, properties]
 ----
@@ -42,7 +42,10 @@ dbms.cluster.raft.async_channel_acquisition_enabled=true
 ----
 
 Restart each member for the setting to take effect.
-This allows the leader to continue replicating to other members without blocking on a slow or hanging connection attempt to one member.
+This allows the database leader to continue replicating to other members without blocking on a slow or hanging connection attempt to one member.
 
-Note that in Neo4j 5.26.29, this new setting makes an existing internal async Raft sender behavior available as a public setting.
+[NOTE]
+====
+In Neo4j 5.26.29, this new setting makes an existing internal async Raft sender behavior available as a public setting.
 It does not introduce a new implementation or change the async Raft sender behavior itself.
+====

--- a/modules/ROOT/pages/clustering/troubleshooting.adoc
+++ b/modules/ROOT/pages/clustering/troubleshooting.adoc
@@ -1,0 +1,56 @@
+:description: Troubleshooting information for common Neo4j cluster availability and replication issues.
+[role=enterprise-edition]
+[[clustering-troubleshooting]]
+= Troubleshooting
+
+This page describes known cluster issues and mitigations.
+
+[[clustering-troubleshooting-raft-sender-channel-acquisition]]
+== Slow or unavailable writes when a cluster member is shut down
+
+In Neo4j 5.26 LTS, a cluster can experience delayed or unavailable writes if the leader waits for a Raft sender connection to a cluster member that has stopped but whose network endpoint still accepts connection attempts.
+This can happen when a server, virtual machine, or container is killed or shut down, but the network layer does not immediately refuse connections to that member.
+
+When this happens, the leader may wait until `dbms.cluster.network.connect_timeout` elapses before it attempts to replicate to another member.
+In a three-member cluster, this can delay writes because Raft requires a quorum to receive the replication message.
+
+[[clustering-troubleshooting-raft-sender-channel-acquisition-symptoms]]
+=== Symptoms
+
+Common symptoms include:
+
+* Writes become slow, time out, or appear unavailable after one cluster member is stopped, killed, or restarted.
+* The problem lasts for approximately the configured `dbms.cluster.network.connect_timeout`, which is `30s` by default.
+* The problem is more likely in environments where a stopped member's network endpoint continues to accept connection attempts instead of refusing them immediately.
+This has been observed in Kubernetes environments, but it is not limited to Kubernetes.
+* The Neo4j debug log can contain Raft sender connection timeout messages similar to:
++
+[source, text]
+----
+Raft sender failed exceptionally [Address: <host>:7000]
+...
+io.netty.channel.ConnectTimeoutException: connection timed out after 30000 ms
+----
+
+If the network endpoint refuses connections immediately, the log can instead contain `Connection refused`.
+That case is less likely to cause the write latency described here because the leader can move on to another member without waiting for the connection timeout.
+
+[[clustering-troubleshooting-raft-sender-channel-acquisition-mitigation]]
+=== Mitigation in Neo4j 5.26 LTS
+
+In Neo4j 5.26 LTS, enable asynchronous acquisition of Raft sender channels by setting the following internal setting to `true` in _neo4j.conf_ on all cluster members:
+
+[source, properties]
+----
+internal.dbms.cluster.raft.async_acquisition_of_raft_sender_channels=true
+----
+
+Restart each member for the setting to take effect.
+This allows the leader to continue replicating to other members without blocking on a slow or hanging connection attempt to one member.
+
+[NOTE]
+====
+*Behavior from Neo4j 2025.02* +
+Starting in Neo4j 2025.02, the setting is available as link:https://neo4j-docs-operations-3174.surge.sh/operations-manual/2026.07/configuration/configuration-settings/#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] and defaults to `true`.
+No mitigation is required for this issue in Neo4j 2025.02 or later unless this setting has been explicitly changed to `false`.
+====

--- a/modules/ROOT/pages/clustering/troubleshooting.adoc
+++ b/modules/ROOT/pages/clustering/troubleshooting.adoc
@@ -38,19 +38,13 @@ That case is less likely to cause the write latency described here because the l
 [[clustering-troubleshooting-raft-sender-channel-acquisition-mitigation]]
 === Mitigation
 
-In Neo4j 5.26 LTS, enable asynchronous acquisition of Raft sender channels by setting the following internal setting to `true` in _neo4j.conf_ on all cluster members:
+In Neo4j 5.26.29 and later, enable asynchronous acquisition of Raft sender channels by setting xref:configuration/configuration-settings.adoc#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] to `true` in _neo4j.conf_ on all cluster members:
 
 [source, properties]
 ----
-internal.dbms.cluster.raft.async_acquisition_of_raft_sender_channels=true
+dbms.cluster.raft.async_channel_acquisition_enabled=true
 ----
 
 Restart each member for the setting to take effect.
 This allows the leader to continue replicating to other members without blocking on a slow or hanging connection attempt to one member.
 
-[NOTE]
-====
-*Behavior from Neo4j 2025.02* +
-Starting with Neo4j 2025.02, the setting is available as link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings/#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] and defaults to `true`.
-No mitigation is required for this issue in Neo4j 2025.02 or later unless this setting has been explicitly changed to `false`.
-====

--- a/modules/ROOT/pages/clustering/troubleshooting.adoc
+++ b/modules/ROOT/pages/clustering/troubleshooting.adoc
@@ -8,7 +8,7 @@ This page describes known cluster issues and their mitigations.
 [[clustering-troubleshooting-raft-sender-channel-acquisition]]
 == Slow or unavailable writes when a cluster member is shut down
 
-In Neo4j 5.26 LTS, a cluster can experience delayed or unavailable writes if the leader waits for a Raft sender connection to a cluster member that has stopped but whose network endpoint still accepts connection attempts.
+A cluster can experience delayed or unavailable writes if the leader waits for a Raft sender connection to a cluster member that has stopped but whose network endpoint still accepts connection attempts.
 This can happen when a server, virtual machine, or container is stopped or shut down, but the network layer does not immediately refuse connections to that member.
 
 When this happens, the leader may wait until xref:configuration/configuration-settings.adoc#config_dbms.cluster.network.connect_timeout[`dbms.cluster.network.connect_timeout`] elapses before attempting to replicate data to another cluster member.
@@ -36,7 +36,7 @@ If the network endpoint refuses connections immediately, the log can instead con
 That case is less likely to cause the write latency described here because the leader can move on to another member without waiting for the connection timeout.
 
 [[clustering-troubleshooting-raft-sender-channel-acquisition-mitigation]]
-=== Mitigation in Neo4j 5.26 LTS
+=== Mitigation
 
 In Neo4j 5.26 LTS, enable asynchronous acquisition of Raft sender channels by setting the following internal setting to `true` in _neo4j.conf_ on all cluster members:
 

--- a/modules/ROOT/pages/clustering/troubleshooting.adoc
+++ b/modules/ROOT/pages/clustering/troubleshooting.adoc
@@ -1,12 +1,8 @@
-:description: Troubleshooting information for common Neo4j cluster availability and replication issues.
+:description: Troubleshooting information for write delays when one cluster member is unavailable.
 :page-role: enterprise-edition
 [[clustering-troubleshooting]]
-= Troubleshooting
-
-This page describes known cluster issues and their mitigations.
-
 [[clustering-troubleshooting-raft-sender-channel-acquisition]]
-== Slow or unavailable writes when a cluster member is shut down
+= Troubleshooting write delays when one cluster member is unavailable
 
 A cluster can experience delayed or unavailable writes if the leader waits for a Raft sender connection to a cluster member that has stopped but whose network endpoint still accepts connection attempts.
 This can happen when a server, virtual machine, or container is stopped or shut down, but the network layer does not immediately refuse connections to that member.
@@ -15,7 +11,7 @@ When this happens, the leader may wait until xref:configuration/configuration-se
 In a three-member cluster, this can delay writes because the Raft protocol requires a quorum (two of the three members) to replicate the transaction before it can be committed.
 
 [[clustering-troubleshooting-raft-sender-channel-acquisition-symptoms]]
-=== Symptoms
+== Symptoms
 
 Common symptoms include:
 
@@ -36,7 +32,7 @@ If the network endpoint refuses connections immediately, the log can instead con
 That case is less likely to cause the write latency described here because the leader can move on to another member without waiting for the connection timeout.
 
 [[clustering-troubleshooting-raft-sender-channel-acquisition-mitigation]]
-=== Mitigation
+== Mitigation
 
 In Neo4j 5.26.29 and later, enable asynchronous acquisition of Raft sender channels by setting xref:configuration/configuration-settings.adoc#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] to `true` in _neo4j.conf_ on all cluster members:
 
@@ -50,4 +46,3 @@ This allows the leader to continue replicating to other members without blocking
 
 Note that in Neo4j 5.26.29, this new setting makes an existing internal async Raft sender behavior available as a public setting.
 It does not introduce a new implementation or change the async Raft sender behavior itself.
-

--- a/modules/ROOT/pages/clustering/troubleshooting.adoc
+++ b/modules/ROOT/pages/clustering/troubleshooting.adoc
@@ -48,3 +48,6 @@ dbms.cluster.raft.async_channel_acquisition_enabled=true
 Restart each member for the setting to take effect.
 This allows the leader to continue replicating to other members without blocking on a slow or hanging connection attempt to one member.
 
+Note that in Neo4j 5.26.29, this new setting makes an existing internal async Raft sender behavior available as a public setting.
+It does not introduce a new implementation or change the async Raft sender behavior itself.
+

--- a/modules/ROOT/pages/clustering/troubleshooting.adoc
+++ b/modules/ROOT/pages/clustering/troubleshooting.adoc
@@ -3,7 +3,7 @@
 [[clustering-troubleshooting-raft-sender-channel-acquisition]]
 = Troubleshooting write delays when one cluster member is unavailable
 
-A cluster can experience delayed or unavailable writes if the leader waits for a Raft sender connection to a cluster member that has stopped but whose network endpoint still accepts connection attempts.
+In Neo4j 5.26, a cluster can experience delayed or unavailable writes if the leader waits for a Raft sender connection to a cluster member that has stopped but whose network endpoint still accepts connection attempts.
 This can happen when a server, virtual machine, or container is stopped or shut down, but the network layer does not immediately refuse connections to that member.
 
 When this happens, the leader may wait until xref:configuration/configuration-settings.adoc#config_dbms.cluster.network.connect_timeout[`dbms.cluster.network.connect_timeout`] elapses before attempting to replicate data to another cluster member.

--- a/modules/ROOT/pages/clustering/troubleshooting.adoc
+++ b/modules/ROOT/pages/clustering/troubleshooting.adoc
@@ -1,6 +1,5 @@
 :description: Troubleshooting information for write delays when one cluster member is unavailable.
 :page-role: enterprise-edition
-[[clustering-troubleshooting]]
 [[clustering-troubleshooting-raft-sender-channel-acquisition]]
 = Troubleshooting write delays when one cluster member is unavailable
 
@@ -34,7 +33,7 @@ That case is less likely to cause the write latency described here because the l
 [[clustering-troubleshooting-raft-sender-channel-acquisition-mitigation]]
 == Mitigation
 
-Starting with Neo4j 5.26.29, you can enable asynchronous acquisition of Raft sender channels by setting xref:configuration/configuration-settings.adoc#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] to `true` in _neo4j.conf_ on each cluster members:
+Starting with Neo4j 5.26.29, you can enable asynchronous acquisition of Raft sender channels by setting xref:configuration/configuration-settings.adoc#config_dbms.cluster.raft.async_channel_acquisition_enabled[`dbms.cluster.raft.async_channel_acquisition_enabled`] to `true` in _neo4j.conf_ on each cluster member:
 
 [source, properties]
 ----

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -649,6 +649,22 @@ m|++++++
 |===
 
 
+[role=label--enterprise-edition label--new-5.26.29]
+[[config_dbms.cluster.raft.async_channel_acquisition_enabled]]
+=== `dbms.cluster.raft.async_channel_acquisition_enabled`
+
+.dbms.cluster.raft.async_channel_acquisition_enabled
+[frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
+|===
+|Description
+a|Enable async acquisition of Raft sender channels. If set to `false`, the leader waits for a connection to a follower before shipping entries to it. This may cause latencies in replication if one or more members are slow at establishing connections.
+|Valid values
+a|A boolean.
+|Default value
+m|+++false+++
+|===
+
+
 [role=label--enterprise-edition]
 [[config_dbms.cluster.raft.binding_timeout]]
 === `dbms.cluster.raft.binding_timeout`

--- a/modules/ROOT/pages/docker/ref-settings.adoc
+++ b/modules/ROOT/pages/docker/ref-settings.adoc
@@ -307,6 +307,9 @@ For more information on the configuration descriptions, valid values, and defaul
 | `dbms.cluster.network.supported_compression_algos`
 | `+NEO4J_dbms_cluster_network_supported__compression__algos+`
 
+| `dbms.cluster.raft.async_channel_acquisition_enabled` label:new[Introduced in 5.26.29]
+| `+NEO4J_dbms_cluster_raft_async__channel__acquisition__enabled+`
+
 | `dbms.cluster.raft.binding_timeout`
 | `+NEO4J_dbms_cluster_raft_binding__timeout+`
 
@@ -1037,4 +1040,3 @@ For more information on the configuration descriptions, valid values, and defaul
 | `+NEO4J_server_windows__service__name+`
 
 |===
-


### PR DESCRIPTION
Part of CLUSTER-1827

In this PR, we add troubleshooting for raft sender problems. This cause of this can be found in this [internal document](https://wiki.internal.neo4j.com/wiki/spaces/Cluster/pages/900661269/RaftSender+connection+timed+out+documentation). However, customers in 5.26LTS are now asking for a more detailed write up of cause and mitigation, which is presented here.

I will also ask someone in clustering to review this.