### PR TITLE
Revert "Add backup option `--skip-producing-empty-diff`"

### DIFF
--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -76,12 +76,11 @@ For more information, see xref:backup-restore/online-backup.adoc#online-backup-c
 neo4j-admin database backup [-h] [--expand-commands] [--prefer-diff-as-parent] [--verbose]
                             [--compress[=true|false]] [--keep-failed[=true|false]]
                             [--parallel-download[=true|false]] [--parallel-recovery[=true|false]]
-                            [--remote-address-resolution[=true|false]] [--skip-producing-empty-diff
-                            [=true|false]] [--skip-recovery[=true|false]]
-                            [--additional-config=<file>] [--include-metadata=none|all|users
-                            [=user1,user2]|roles] [--inspect-path=<path>] [--pagecache=<size>]
-                            [--temp-path=<path>] [--to-path=<path>] [--type=<type>] [--from=<host:
-                            port>[,<host:port>...]]... [<database>...]
+                            [--remote-address-resolution[=true|false]] [--skip-recovery
+                            [=true|false]] [--additional-config=<file>]
+                            [--include-metadata=none|all|users[=user1,user2]|roles]
+                            [--inspect-path=<path>] [--pagecache=<size>] [--temp-path=<path>]
+                            [--to-path=<path>] [--type=<type>] [--from=<host:port>[,<host:port>...]]... [<database>...]
 ----
 
 === Description
@@ -182,11 +181,6 @@ Note: this is an EXPERIMENTAL option. Consult Neo4j support before use.
 
 |--remote-address-resolution[=true\|false]
 |label:new[Introduced in 2025.09] Allow the DBMS to automatically determine which servers are eligible to serve as backup sources, instead of requiring manual selection.
-|false
-
-|--skip-producing-empty-diff[=true\|false]
-|label:new[Introduced in 2026.07] When performing a differential backup and there are no new transactions to back-up, do not produce any backup file.
-This option can only be used if metadata is explicitly omitted (`--include-metadata=none`).
 |false
 
 |--skip-recovery[=true\|false]


### PR DESCRIPTION
Reverts neo4j/docs-operations#3162

See:
- https://github.com/neo-technology/neo4j/pull/38844
- https://github.com/neo4j/docs-operations/pull/3177 <- I think tests will fail until this gets merged to remove the option in dev