### PR TITLE
Clarify port information in installation docs

### DIFF
--- a/modules/ROOT/partials/access-neo4j.adoc
+++ b/modules/ROOT/partials/access-neo4j.adoc
@@ -6,7 +6,12 @@ No subscription is required.
 . On the *Instances* page, click the *Self-managed* tab and then *+ Add deployment* button.
 . Select *URL Connection*.
 . Provide a *Name* and *Connection URL*.
-If you have installed Neo4j locally on your system, you can connect to _bolt://localhost:7687_.
+If you have installed Neo4j locally on your system, you can connect either via _bolt://localhost:7687_, _neo4j://localhost:7687_, or using the secure _\https://localhost:7473_.
++
+[TIP]
+====
+For more information about the Neo4j ports, see xref:configuration/ports.adoc[Ports].
+====
 . Click the *Connect* dropdown to launch various graph tools such as *Query*, *Explore*, and *Dashboards*.
 . Type the username `neo4j` and your password or the default password `neo4j`.
 You will be prompted to change the latter upon first login.


### PR DESCRIPTION
Add more information about the ports. `http://localhost:7474` is described a bit further down on the page when we mention Browser as a way to access Neo4j.