### PR TITLE
COPS-705: Part 2: Warn about fail-open DENY semantics in comparison operator example

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/property-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/property-based-access-control.adoc
@@ -135,6 +135,13 @@ DENY MATCH {*} ON GRAPH * FOR (n) WHERE n.classification <> 'UNCLASSIFIED' TO re
 DENY MATCH {*} ON GRAPH * FOR ()-[r]-() WHERE r.classification <> 'UNCLASSIFIED' TO regularUsers
 ----
 
+[CAUTION]
+====
+These `DENY` rules fail open for nodes and relationships without a `classification` property.
+When the property is missing, the `<>` comparison cannot be evaluated, so the restriction is not applied and access is granted by default if a broader `GRANT` exists.
+For details, see xref:authentication-authorization/limitations.adoc#fail-open-deny-behavior[Limitations -> Fail-open `DENY` behavior].
+====
+
 === Grant a property-based privilege on all properties using a property value
 
 The following example shows how to grant permission to `READ` all properties on nodes and relationships where the property `securityLevel` is higher than `3` to role `regularUsers`:

--- a/modules/ROOT/pages/authentication-authorization/property-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/property-based-access-control.adoc
@@ -157,14 +157,14 @@ GRANT READ {*} ON GRAPH * FOR ()-[r]-() WHERE r.securityLevel > 3 TO regularUser
 The role `regularUsers` does not need to have `READ` privilege for the property `securityLevel` used by the property-based privilege.
 ====
 
-=== Deny a property-based privilege using a list of values
+=== Grant a property-based privilege using a list of values
 
-The following example shows how to deny permission to `READ` all properties on nodes and relationships where the property `classification` is not included in the list of `[UNCLASSIFIED, PUBLIC]`:
+The following example shows how to grant permission to `READ` all properties on nodes and relationships where the property `classification` is included in the list `[UNCLASSIFIED, PUBLIC]`:
 
 [source, syntax, role="noheader"]
 ----
-DENY READ {*} ON GRAPH * FOR (n) WHERE NOT n.classification IN ['UNCLASSIFIED', 'PUBLIC'] TO regularUsers
-DENY READ {*} ON GRAPH * FOR ()-[r]-() WHERE NOT r.classification IN ['UNCLASSIFIED', 'PUBLIC'] TO regularUsers
+GRANT READ {*} ON GRAPH * FOR (n) WHERE n.classification IN ['UNCLASSIFIED', 'PUBLIC'] TO regularUsers
+GRANT READ {*} ON GRAPH * FOR ()-[r]-() WHERE r.classification IN ['UNCLASSIFIED', 'PUBLIC'] TO regularUsers
 ----
 
 // The last two examples were added in 5.26.


### PR DESCRIPTION
BUilds on https://github.com/neo4j/docs-operations/pull/3178 to add the warning to the relevant example too.