### PR TITLE
Add backup option `--skip-empty-diffs`

### DIFF
--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -76,11 +76,12 @@ For more information, see xref:backup-restore/online-backup.adoc#online-backup-c
 neo4j-admin database backup [-h] [--expand-commands] [--prefer-diff-as-parent] [--verbose]
                             [--compress[=true|false]] [--keep-failed[=true|false]]
                             [--parallel-download[=true|false]] [--parallel-recovery[=true|false]]
-                            [--remote-address-resolution[=true|false]] [--skip-recovery
-                            [=true|false]] [--additional-config=<file>]
-                            [--include-metadata=none|all|users[=user1,user2]|roles]
-                            [--inspect-path=<path>] [--pagecache=<size>] [--temp-path=<path>]
-                            [--to-path=<path>] [--type=<type>] [--from=<host:port>[,<host:port>...]]... [<database>...]
+                            [--remote-address-resolution[=true|false]] [--skip-empty-diffs
+                            [=true|false]] [--skip-recovery[=true|false]]
+                            [--additional-config=<file>] [--include-metadata=none|all|users[=user1,
+                            user2]|roles] [--inspect-path=<path>] [--pagecache=<size>]
+                            [--temp-path=<path>] [--to-path=<path>] [--type=<type>] [--from=<host:
+                            port>[,<host:port>...]]... [<database>...]
 ----
 
 === Description
@@ -181,6 +182,10 @@ Note: this is an EXPERIMENTAL option. Consult Neo4j support before use.
 
 |--remote-address-resolution[=true\|false]
 |label:new[Introduced in 2025.09] Allow the DBMS to automatically determine which servers are eligible to serve as backup sources, instead of requiring manual selection.
+|false
+
+|--skip-empty-diffs[=true\|false]
+|label:new[Introduced in 2026.08] When performing a differential backup and there are no new transactions to back-up, do not produce any backup file. This option can only be used if metadata is explicitly omitted (`--include-metadata=none`).
 |false
 
 |--skip-recovery[=true\|false]

--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -78,8 +78,8 @@ neo4j-admin database backup [-h] [--expand-commands] [--prefer-diff-as-parent] [
                             [--parallel-download[=true|false]] [--parallel-recovery[=true|false]]
                             [--remote-address-resolution[=true|false]] [--skip-empty-diffs
                             [=true|false]] [--skip-recovery[=true|false]]
-                            [--additional-config=<file>] [--include-metadata=none|all|users[=user1,
-                            user2]|roles] [--inspect-path=<path>] [--pagecache=<size>]
+                            [--additional-config=<file>] [--include-metadata=none|all|users
+                            [=user1,user2]|roles] [--inspect-path=<path>] [--pagecache=<size>]
                             [--temp-path=<path>] [--to-path=<path>] [--type=<type>] [--from=<host:
                             port>[,<host:port>...]]... [<database>...]
 ----


### PR DESCRIPTION
Documents the `neo4j-admin database backup --skip-empty-diffs` option, which is being made public in https://github.com/neo-technology/neo4j/pull/39121 (part of CLUSTER-1675).

This option was previously documented as `--skip-producing-empty-diff` in #3162, but that was reverted in #3177 when the flag was hidden again in the product. It is now public under the shorter name `--skip-empty-diffs`, so this re-adds it with the new name.

Changes:
- Add the `--skip-empty-diffs[=true|false]` row to the options table, labelled `Introduced in 2026.08`.
- Refresh the command synopsis to match the current CLI output.

Both the synopsis and the option description are taken verbatim from the updated `OnlineBackupCommandTest.printUsageHelp` expectation in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of CLUSTER-1675