### PR TITLE
update docs around non-obfuscated literals

### DIFF
--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -2926,7 +2926,7 @@ m|+++false+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|If true, obfuscates all literals in a query before writing the query to the query log. Note that node labels, relationship types, skip/limit values, field terminators in load csv, and map property keys, while being literals, remain visible. Changing the setting will not affect queries that are cached. To apply the change immediately, you must also call `CALL db.clearQueryCaches()`. It is recommended to set this setting to `true` in production.
+a|If true, obfuscates all literals in a query before writing the query to the query log. Note that node labels, relationship types, skip/limit values, field terminators in `LOAD CSV`, and map property keys, while being literals, remain visible. Changing the setting will not affect cached queries. To apply the change immediately, you must also run `CALL db.clearQueryCaches()`. It is recommended to set this setting to `true` in production.
 |Valid values
 a|A boolean.
 |Default value

--- a/modules/ROOT/pages/configuration/configuration-settings.adoc
+++ b/modules/ROOT/pages/configuration/configuration-settings.adoc
@@ -2926,7 +2926,7 @@ m|+++false+++
 [frame="topbot", stripes=odd, grid="cols", cols="<1s,<4"]
 |===
 |Description
-a|If true, obfuscates all literals in a query before writing the query to the query log. Note that node labels, relationship types, and map property keys remain visible. Changing the setting will not affect queries that are cached. To apply the change immediately, you must also call `CALL db.clearQueryCaches()`. It is recommended to set this setting to `true` in production.
+a|If true, obfuscates all literals in a query before writing the query to the query log. Note that node labels, relationship types, skip/limit values, field terminators in load csv, and map property keys, while being literals, remain visible. Changing the setting will not affect queries that are cached. To apply the change immediately, you must also call `CALL db.clearQueryCaches()`. It is recommended to set this setting to `true` in production.
 |Valid values
 a|A boolean.
 |Default value

--- a/modules/ROOT/pages/monitoring/logging.adoc
+++ b/modules/ROOT/pages/monitoring/logging.adoc
@@ -881,7 +881,10 @@ It is recommended to set this setting to `true` in production.
 
 [NOTE]
 ====
-Node labels, relationship types, and map property keys are still shown.
+Literals that describe the shape of the query rather than the data it operates on are still shown.
+These are node labels, relationship types, and map property keys. +
+label:changed[Changed in 2026.08] For the same reason, `SKIP` and `LIMIT` values and the `FIELDTERMINATOR` of `LOAD CSV` are also still shown.
+Sensitive values, such as passwords, remain obfuscated wherever they appear, including inside a `SKIP` or `LIMIT` expression.
 Changing the setting does not affect cached queries.
 Therefore, if you want the switch to have an immediate effect, you must also clear the query cache; `CALL db.clearQueryCaches()`. +
 Also, keep in mind that if Neo4j receives a malformed query that cannot be parsed, it cannot obfuscate its literals (because it does not know which parts are literals) and, therefore, the query text will not be included in any logging.


### PR DESCRIPTION
with the change of no longer obfuscating some literals (SKIP/LIMIT & FIELDTERMINATOR), the docs should reflect that as well.