### PR TITLE
Configure `server.directories.plugins` when using plugins volumes on Kubernetes

### DIFF
--- a/modules/ROOT/pages/kubernetes/plugins.adoc
+++ b/modules/ROOT/pages/kubernetes/plugins.adoc
@@ -131,17 +131,14 @@ Strict config validation can be disabled by setting `server.config.strict_valida
 [[plugins-volume]]
 == Add plugins using a plugins volume
 
-An alternative method for adding Neo4j plugins to a Neo4j Helm deployment uses a `plugins` volume mount.
-With this method, the plugin jar files are stored on a Persistent Volume that is mounted to the `/plugins` directory of the Neo4j container.
+An alternative method for adding Neo4j plugins to a Neo4j Helm deployment is to mount a shared plugins volume.
+With this method, the plugin jar files are stored on a Persistent Volume that is mounted at _/plugins_ in the Neo4j container.
 
-[NOTE]
-====
-link:https://neo4j.com/deployment-center/?bloom[The Neo4j Bloom] plugin requires a license activation key, which needs to be placed in a directory accessible by the Neo4j Docker container, for example, mounted to _/licenses_ (default).
-To obtain a valid license, reach out to your Neo4j account representative or use the form https://neo4j.com/contact-us/[Contact Neo4j].
-====
+To configure Neo4j to load plugins from the mounted volume, add `server.directories.plugins: /plugins` to the xref:kubernetes/configuration.adoc#_config[`config:`] object of your _values.yaml_ file to ensure Neo4j recognizes the mounted volume.
+Although the Helm chart mounts the shared volume at _/plugins_, explicit configuration is required to override the default plugin directory.
 
-The simplest way to set up a persistent `plugins` volume is to share the Persistent Volume that is used for storing Neo4j data.
-This example shows how to configure that in the Neo4j Helm deployment _values.yaml_ file:
+To set up a persistent `plugins` volume, reuse the Persistent Volume that stores Neo4j data.
+The following example shows how to configure that in the Neo4j Helm deployment _values.yaml_ file:
 
 [source, yaml]
 ----
@@ -163,11 +160,8 @@ The Neo4j container now has an empty _/plugins_ directory backed by a persistent
 Plugin jar files can be copied onto the volume using `kubectl cp`.
 Because it is backed by a persistent volume, plugin files will persist even if the Neo4j pod is restarted or moved.
 
-[NOTE]
-====
 Neo4j loads plugins only on startup.
 Therefore, you must restart the Neo4j pod to load them once all plugins are in place.
-====
 
 For example:
 
@@ -182,6 +176,12 @@ kubectl rollout restart statefulset/<neo4j-statefulset-name>
 # Verify plugins are still present after restart
 kubectl exec <neo4j-pod-name> -- ls /plugins
 ----
+
+[NOTE]
+====
+link:https://neo4j.com/deployment-center/?bloom[The Neo4j Bloom] plugin requires a license activation key, which needs to be placed in a directory accessible by the Neo4j Docker container, for example, mounted to _/licenses_ (default).
+To obtain a valid license, reach out to your Neo4j account representative or use the form https://neo4j.com/contact-us/[Contact Neo4j].
+====
 
 [[operations-using-apoc-core]]
 == Configure and install APOC core only

--- a/modules/ROOT/pages/kubernetes/plugins.adoc
+++ b/modules/ROOT/pages/kubernetes/plugins.adoc
@@ -134,7 +134,7 @@ Strict config validation can be disabled by setting `server.config.strict_valida
 An alternative method for adding Neo4j plugins to a Neo4j Helm deployment is to mount a shared plugins volume.
 With this method, the plugin jar files are stored on a Persistent Volume that is mounted at _/plugins_ in the Neo4j container.
 
-To configure Neo4j to load plugins from the mounted volume, add `server.directories.plugins: /plugins` to the xref:kubernetes/configuration.adoc#_config[`config:`] object of your _values.yaml_ file to ensure Neo4j recognizes the mounted volume.
+To configure Neo4j to load plugins from the mounted volume, add `server.directories.plugins: /plugins` to the link:https://neo4j.com/docs/operations-manual/current/kubernetes/configuration/#_config[`config:`] object of your _values.yaml_ file to ensure Neo4j recognizes the mounted volume.
 Although the Helm chart mounts the shared volume at _/plugins_, explicit configuration is required to override the default plugin directory.
 
 To set up a persistent `plugins` volume, reuse the Persistent Volume that stores Neo4j data.


### PR DESCRIPTION
DOCCORE-374