### PR TITLE
Correct the sentence (#3222)

### DIFF
--- a/modules/ROOT/pages/backup-restore/online-backup.adoc
+++ b/modules/ROOT/pages/backup-restore/online-backup.adoc
@@ -214,7 +214,8 @@ For more information, see <<online-backup-cloud-storage>>.
 Even when `--to-path` points to a cloud storage bucket, the backup process requires a temporary local directory to store the database store files and transaction logs before creating and streaming the backup artifact to the cloud destination.
 The temporary directory must therefore have enough free space to hold the entire backup.
 
-If `--to-path` is not specified or points to a cloud storage bucket, Neo4j creates the temporary directory in its current working directory.
+The temporary path can be specified by the `--temp-path` option.
+If `--temp-path` is unspecified, Neo4j creates the temporary directory in its current working directory.
 If that location does not have sufficient free disk space, the backup can fail.
 
 To avoid this issue, it is strongly recommended to specify `--temp-path` and point it to a local directory with sufficient free disk space, especially when backing up to cloud storage.


### PR DESCRIPTION
Correct information about specifying a temporary path for backups.