### PR TITLE
COPS-773: adding a warning about missing native user in conjunction with `abac.native.user_tags()` (#3211)

### DIFF
--- a/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
+++ b/modules/ROOT/pages/authentication-authorization/attribute-based-access-control.adoc
@@ -142,10 +142,17 @@ In a cluster, it is important to keep the system clocks synchronized across all 
 When using native user tags in auth rules, avoid writing rules whose condition is solely based on the _absence_ of a tag from a user, for example `NOT ('restricted' IN abac.native.user_tags())`.
 See <<example-avoid-absence-of-tags>> for an illustration.
 
-Someone who holds the xref:authentication-authorization/dbms-administration/dbms-user-management-privileges.adoc[`USER MANAGEMENT`] privilege, but not the xref:authentication-authorization/dbms-administration/dbms-user-metadata-management-privileges.adoc[`USER METADATA MANAGEMENT`] privilege can create a user with no tags.
-Such a user satisfies the "absence of tag" condition and is therefore granted the roles associated with the rule, potentially leading to an unintended escalation of privileges.
+There are two potential risks with such a rule design, which can lead to unintended escalation of privileges:
 
+* Someone who holds the xref:authentication-authorization/dbms-administration/dbms-user-management-privileges.adoc[`USER MANAGEMENT`] privilege, but not the xref:authentication-authorization/dbms-administration/dbms-user-metadata-management-privileges.adoc[`USER METADATA MANAGEMENT`] privilege can create a user with no tags.
+Such a user satisfies the "absence of tag" condition and is therefore granted the roles associated with the rule, potentially leading to an unintended escalation of privileges. +
 Prefer conditions based on the _presence_ of a required tag instead.
+
+* A user authenticates with an external provider (OIDC or LDAP) and is not linked to a native user.
+In this case, the `abac.native.user_tags()` function returns an empty list, and the "absence of tag" condition is satisfied, again potentially leading to an unintended escalation of privileges. +
+This risk can be mitigated by using xref:authentication-authorization/auth-providers.adoc[user auth providers], which link each externally authenticated identity to a native user whose tags can then be resolved.
+Setting xref:configuration/configuration-settings.adoc#config_dbms.security.require_local_user[`dbms.security.require_local_user`] to `true` additionally means that only users with a matching auth provider in the database can authenticate at all, so an external user cannot bypass the tag lookup.
+For details and examples, see xref:authentication-authorization/auth-providers.adoc[User auth providers] and <<linking-external-users-to-native,linking external users to native users>>, and xref:authentication-authorization/sso-integration.adoc#auth-sso-auth-providers[Configure SSO at the user level using auth providers].
 ====
 +
 [WARNING]
@@ -291,7 +298,12 @@ CREATE AUTH RULE unrestrictedRule
 Because the condition is satisfied solely by the _absence_ of the `restricted` tag, any user with no tags meets it.
 Subsequently, someone who holds the xref:authentication-authorization/dbms-administration/dbms-user-management-privileges.adoc[`USER MANAGEMENT`] privilege but not the xref:authentication-authorization/dbms-administration/dbms-user-metadata-management-privileges.adoc[`USER METADATA MANAGEMENT`] privilege can create such a user (they can create users, but cannot set or remove tags), and yet that new user would be granted the roles associated with `unrestrictedRule`.
 
-Instead, base the condition on the _presence_ of a required tag (as in <<example-tag-presence>>), so that the roles are only granted when a tag has been deliberately attached by someone holding the `SET USER METADATA` privilege.
+To avoid this potential risk, base the condition on the _presence_ of a required tag (as in <<example-tag-presence>>), so that the roles are only granted when a tag has been deliberately attached by someone holding the `SET USER METADATA` privilege.
+
+Another potential risk with the auth rule in this example is that a user who authenticates with an external provider (OIDC or LDAP) but is not linked to a native user also meets the condition, because `abac.native.user_tags()` returns an empty list for them, and so `unrestrictedRule` grants them its roles.
+
+Explicitly linking such users to a native user with xref:authentication-authorization/auth-providers.adoc[user auth providers] means their tags can be resolved.
+See <<linking-external-users-to-native, linking external users>> for details.
 
 [[linking-external-users-to-native]]
 [NOTE]


### PR DESCRIPTION
…