### PR TITLE
Add a stable anchor to fix the xref

### DIFF
--- a/modules/ROOT/pages/kubernetes/configuration.adoc
+++ b/modules/ROOT/pages/kubernetes/configuration.adoc
@@ -147,7 +147,10 @@ When installing a cluster, you should set `neo4j.minimumClusterSize` to the numb
 If you later decide to add an extra cluster server in excess of `neo4j.minimumClusterSize`, you need to manually enable it using the Cypher command `ENABLE SERVER`.
 For more information on enabling new servers, see xref:clustering/servers.adoc#cluster-add-server[Add a server to the cluster].
 
+
+[[config]]
 === `config`
+
 The Neo4j Helm chart does not use a `neo4j.conf` file.
 Instead, the Neo4j configuration is set in the Helm deployment's _values.yaml_ file under the `config` object.
 

--- a/modules/ROOT/pages/kubernetes/plugins.adoc
+++ b/modules/ROOT/pages/kubernetes/plugins.adoc
@@ -134,7 +134,7 @@ Strict config validation can be disabled by setting `server.config.strict_valida
 An alternative method for adding Neo4j plugins to a Neo4j Helm deployment is to mount a shared plugins volume.
 With this method, the plugin jar files are stored on a Persistent Volume that is mounted at _/plugins_ in the Neo4j container.
 
-To configure Neo4j to load plugins from the mounted volume, add `server.directories.plugins: /plugins` to the link:https://neo4j.com/docs/operations-manual/current/kubernetes/configuration/#_config[`config:`] object of your _values.yaml_ file to ensure Neo4j recognizes the mounted volume.
+To configure Neo4j to load plugins from the mounted volume, add `server.directories.plugins: /plugins` to the xref:kubernetes/configuration.adoc#config[`config:`] object of your _values.yaml_ file to ensure Neo4j recognizes the mounted volume.
 Although the Helm chart mounts the shared volume at _/plugins_, explicit configuration is required to override the default plugin directory.
 
 To set up a persistent `plugins` volume, reuse the Persistent Volume that stores Neo4j data.


### PR DESCRIPTION
DOCCORE-374
This PR adds a stable anchor to the section `config` in the _kubernetes/configuration.adoc_ file. This makes page consistent with the `main` branch. See PR #3230 